### PR TITLE
fix: filter out duplicate enum values

### DIFF
--- a/src/main/java/com/twilio/oai/AbstractTwilioGoGenerator.java
+++ b/src/main/java/com/twilio/oai/AbstractTwilioGoGenerator.java
@@ -8,9 +8,7 @@ import org.openapitools.codegen.CodegenParameter;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import io.swagger.v3.oas.models.media.Schema;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public abstract class AbstractTwilioGoGenerator extends GoClientCodegen {
 
@@ -25,6 +23,7 @@ public abstract class AbstractTwilioGoGenerator extends GoClientCodegen {
 		super.processOpts();
 
 		additionalProperties.put(CodegenConstants.IS_GO_SUBMODULE, true);
+		additionalProperties.put(CodegenConstants.ENUM_CLASS_PREFIX, true);
 
 		supportingFiles.clear();
 	}
@@ -60,5 +59,23 @@ public abstract class AbstractTwilioGoGenerator extends GoClientCodegen {
 		name = name.replace(">","After");
 		name = super.toVarName(name);
 		return name;
+	}
+
+	@Override
+	protected List<Map<String, Object>> buildEnumVars(List<Object> values, String dataType) {
+		List<Map<String, Object>> siftedEnumVars = new ArrayList<>();
+		Set<Object> uniqueNames = new HashSet<>();
+		List<Map<String, Object>> rawEnumVars = super.buildEnumVars(values, dataType);
+
+		// Filter out duplicate enum values. Example: HTTPMETHOD_HEAD = "head"/HTTPMETHOD_HEAD = "HEAD"
+		for (Map<String, Object> enumVar : rawEnumVars) {
+			Object enumName = enumVar.get("name");
+			if (!uniqueNames.contains(enumName)) {
+				uniqueNames.add(enumName);
+				siftedEnumVars.add(enumVar);
+			}
+		}
+
+		return siftedEnumVars;
 	}
 }


### PR DESCRIPTION
Removes duplicates in the case where enums are defined with same values in different casings. For example, the HttpMethod enum is defined in the OAI document with both "GET"/"get", "POST"/"post", etc. values. This fix ensures golang enums render once.

https://github.com/twilio/twilio-go/pull/40/commits/bb65aae16284bd6c24770bbba574415f6cfbb8c5
