### PR TITLE
fix: updated docs rendering templates

### DIFF
--- a/src/main/resources/twilio-go/api_doc.mustache
+++ b/src/main/resources/twilio-go/api_doc.mustache
@@ -27,16 +27,16 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.{{/-last}}{{/allParams}}{{#allParams}}{{#required}}
 **{{paramName}}** | {{#isFile}}**{{dataType}}**{{/isFile}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{/isPrimitiveType}}| {{description}} | {{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}{{/required}}{{/allParams}}{{#hasOptionalParams}}
- **optional** | ***{{{nickname}}}Opts** | optional parameters | nil if no parameters
+ **optional** | ***{{{nickname}}}Request** | optional parameters | nil if no parameters
 
 ### Optional Parameters
 
-Optional parameters are passed through a pointer to a {{{nickname}}}Opts struct
+Optional parameters are passed through a pointer to a {{{nickname}}}Request struct
  {{#allParams}}{{#-last}}
 
 Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------{{/-last}}{{/allParams}}{{#allParams}}
-{{^required}} **{{paramName}}** | {{#isFile}}**optional.Interface of {{dataType}}**{{/isFile}}{{#isPrimitiveType}}**optional.{{vendorExtensions.x-optional-data-type}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**optional.Interface of {{dataType}}**]({{baseType}}.md){{/isFile}}{{/isPrimitiveType}}| {{description}} | {{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}{{/required}}{{/allParams}}{{/hasOptionalParams}}
+------------- | ------------- | ------------- | -------------{{/-last}}{{/allParams}}{{#allParams}}{{^required}}
+**{{paramName}}** | {{#isFile}}**{{dataType}}**{{/isFile}}{{#isPrimitiveType}}**{{vendorExtensions.x-optional-data-type}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{/isPrimitiveType}}| {{description}} | {{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}{{/required}}{{/allParams}}{{/hasOptionalParams}}
 
 ### Return type
 

--- a/src/main/resources/twilio-go/model_doc.mustache
+++ b/src/main/resources/twilio-go/model_doc.mustache
@@ -1,11 +1,17 @@
 {{#models}}{{#model}}# {{classname}}
 
-## Properties
-
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-{{#allVars}}**{{name}}** | {{#isNullable}}Pointer to {{/isNullable}}{{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{^isEnum}}## Properties
+Name | Type | Notes
+------------ | ------------- | -------------
+{{#allVars}}**{{name}}** | {{#isNullable}}Pointer to {{/isNullable}}{{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/allVars}}
+{{/isEnum}}
+{{#isEnum}}## Enum
+Name | Type | Notes
+------------ | ------------- | -------------
+{{#allowableValues}}{{#enumVars}}**{{name}}** | {{dataType}} | (value: `{{{value}}}`)
+{{/enumVars}}{{/allowableValues}}
+{{/isEnum}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 


### PR DESCRIPTION
# Fixes #

This change fixes [missing docs](https://github.com/twilio/twilio-go/blob/main/twilio/rest/api/v2010/docs/AddressRequirement.md) for enum. Also, getting rid of `description` field in the model docs

Related PR: https://github.com/twilio/twilio-go/pull/48