### PR TITLE
fix: over-reverted

### DIFF
--- a/src/main/java/com/twilio/oai/AbstractTwilioGoGenerator.java
+++ b/src/main/java/com/twilio/oai/AbstractTwilioGoGenerator.java
@@ -25,6 +25,7 @@ public abstract class AbstractTwilioGoGenerator extends GoClientCodegen {
 		super.processOpts();
 
 		additionalProperties.put(CodegenConstants.IS_GO_SUBMODULE, true);
+		additionalProperties.put(CodegenConstants.ENUM_CLASS_PREFIX, true);
 
 		supportingFiles.clear();
 	}


### PR DESCRIPTION
#13 accidentally over-reverted a flag that ass a class prefix to enum values that prevents naming conflicts. This PR adds that flag back to our base generator.

Related PRs:
https://github.com/twilio/twilio-go/pull/49