### PR TITLE
fix: nullable property fields are not optional

### DIFF
--- a/src/main/resources/twilio-go/model_doc.mustache
+++ b/src/main/resources/twilio-go/model_doc.mustache
@@ -3,7 +3,7 @@
 {{^isEnum}}## Properties
 Name | Type | Notes
 ------------ | ------------- | -------------
-{{#allVars}}**{{name}}** | {{#isNullable}}Pointer to {{/isNullable}}{{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#allVars}}**{{name}}** | {{#isNullable}}Pointer to {{/isNullable}}{{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{^required}}{{^isNullable}}[optional] {{/isNullable}}{{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/allVars}}
 {{/isEnum}}
 {{#isEnum}}## Enum


### PR DESCRIPTION
Fixes auto-generated documentation such that resource property docs do not render the `[optional]` note for fields marked `nullable`
https://github.com/twilio/twilio-go/pull/50