### PR TITLE
feat: add property descriptions to documentation

### DIFF
--- a/src/main/resources/twilio-go/model_doc.mustache
+++ b/src/main/resources/twilio-go/model_doc.mustache
@@ -3,7 +3,7 @@
 {{^isEnum}}## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#allVars}}**{{name}}** | {{#isNullable}}Pointer to {{/isNullable}}{{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} |{{#isNullable}} {{{description}}} {{/isNullable}}  |{{^required}}{{^isNullable}}[optional] {{/isNullable}}{{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#allVars}}**{{name}}** | {{#isNullable}}Pointer to {{/isNullable}}{{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{{description}}} |{{^required}}{{^isNullable}}[optional] {{/isNullable}}{{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/allVars}}
 {{/isEnum}}
 {{#isEnum}}## Enum


### PR DESCRIPTION
# Fixes #
[DI-1214](https://issues.corp.twilio.com/browse/DI-1214)

Add property descriptions to documentation and add description column back to template.
