### PR TITLE
feat: split model.mustache into separate components

### DIFF
--- a/src/main/resources/twilio-go/model.mustache
+++ b/src/main/resources/twilio-go/model.mustache
@@ -12,32 +12,10 @@ import (
 {{/imports}}
 {{#model}}
 {{#isEnum}}
-// {{{classname}}} {{#description}}{{{.}}}{{/description}}{{^description}}the model '{{{classname}}}'{{/description}}
-type {{{classname}}} {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{/format}}
-
-// List of {{{name}}}
-const (
-	{{#allowableValues}}
-	{{#enumVars}}
-	{{^-first}}
-	{{/-first}}
-	{{#enumClassPrefix}}{{{classname.toUpperCase}}}_{{/enumClassPrefix}}{{name}} {{{classname}}} = {{{value}}}
-	{{/enumVars}}
-	{{/allowableValues}}
-)
+{{>model_enum}}
 {{/isEnum}}
 {{^isEnum}}
-// {{classname}}{{#description}} {{{description}}}{{/description}}{{^description}} struct for {{{classname}}}{{/description}}
-type {{classname}} struct {
-{{#allVars}}
-{{^-first}}
-{{/-first}}
-{{#description}}
-	// {{{description}}}
-{{/description}}
-	{{name}} {{#isNullable}}*{{/isNullable}}{{{dataType}}} `json:"{{name}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
-{{/allVars}}
-}
+{{>model_simple}}
 {{/isEnum}}
 {{/model}}
 {{/models}}

--- a/src/main/resources/twilio-go/model_enum.mustache
+++ b/src/main/resources/twilio-go/model_enum.mustache
@@ -1,0 +1,13 @@
+// {{{classname}}} {{#description}}{{{.}}}{{/description}}{{^description}}the model '{{{classname}}}'{{/description}}
+type {{{classname}}} {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{/format}}
+
+// List of {{{name}}}
+const (
+{{#allowableValues}}
+    {{#enumVars}}
+        {{^-first}}
+        {{/-first}}
+        {{#enumClassPrefix}}{{{classname.toUpperCase}}}_{{/enumClassPrefix}}{{name}} {{{classname}}} = {{{value}}}
+    {{/enumVars}}
+{{/allowableValues}}
+)

--- a/src/main/resources/twilio-go/model_simple.mustache
+++ b/src/main/resources/twilio-go/model_simple.mustache
@@ -1,0 +1,11 @@
+// {{classname}}{{#description}} {{{description}}}{{/description}}{{^description}} struct for {{{classname}}}{{/description}}
+type {{classname}} struct {
+{{#allVars}}
+    {{^-first}}
+    {{/-first}}
+    {{#description}}
+        // {{{description}}}
+    {{/description}}
+    {{name}} {{#isNullable}}*{{/isNullable}}{{{dataType}}} `json:"{{name}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+{{/allVars}}
+}


### PR DESCRIPTION
# Fixes #
Split model.mustache into separate components to stay up in-sync with Open API generator 5.X.X changes. This PR does not change any of the functionality in the Go library.

https://issues.corp.twilio.com/browse/DI-1234

Related PRs:
https://github.com/twilio/twilio-go/pull/55