### PR TITLE
fix: update api mustache template to set baseName instead of the paramName for the url Values key

### DIFF
--- a/src/main/resources/twilio-go/api.mustache
+++ b/src/main/resources/twilio-go/api.mustache
@@ -78,10 +78,10 @@ func (c *{{{classname}}}Service) {{{nickname}}}({{#allParams}}{{#required}}{{par
 	    return nil, err
 	}
 
-	data.Set("{{paramName}}", string(v))
+	data.Set("{{baseName}}", string(v))
 {{/isFreeFormObject}}
 {{^isFreeFormObject}}
-    data.Set("{{paramName}}", {{^isArray}}{{^isString}}fmt.Sprint({{/isString}}{{#isDateTime}}({{/isDateTime}}*params.{{paramName}}{{^isString}}{{#isDateTime}}).Format(time.RFC3339){{/isDateTime}}){{/isString}}){{/isArray}} {{#isArray}}strings.Join(*params.{{paramName}}, ",")){{/isArray}}
+    data.Set("{{baseName}}", {{^isArray}}{{^isString}}fmt.Sprint({{/isString}}{{#isDateTime}}({{/isDateTime}}*params.{{paramName}}{{^isString}}{{#isDateTime}}).Format(time.RFC3339){{/isDateTime}}){{/isString}}){{/isArray}} {{#isArray}}strings.Join(*params.{{paramName}}, ",")){{/isArray}}
 {{/isFreeFormObject}}
 }
 {{/isHeaderParam}}

--- a/src/main/resources/twilio-go/api.mustache
+++ b/src/main/resources/twilio-go/api.mustache
@@ -78,7 +78,7 @@ func (c *{{{classname}}}Service) {{{nickname}}}({{#allParams}}{{#required}}{{par
 	    return nil, err
 	}
 
-	data.Set("{{baseName}}", string(v))
+	data.Set("{{baseName}}", string(v)) {{!--  the `baseName` is the value specified in the OpenAPI template and not the mutated `paramName` --}}
 {{/isFreeFormObject}}
 {{^isFreeFormObject}}
     data.Set("{{baseName}}", {{^isArray}}{{^isString}}fmt.Sprint({{/isString}}{{#isDateTime}}({{/isDateTime}}*params.{{paramName}}{{^isString}}{{#isDateTime}}).Format(time.RFC3339){{/isDateTime}}){{/isString}}){{/isArray}} {{#isArray}}strings.Join(*params.{{paramName}}, ",")){{/isArray}}


### PR DESCRIPTION
# Fixes #27 

The parameter name is modified in the `AbstractTwilioGoGenerator` class to remove certain characters to allow the parameter name to be used as the prefix for the Params struct name.

The parameter name set as the key url Values needs to be the original name, specified in the OpenAPI template and not the modified value name.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-oai-generator/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please create a GitHub Issue in this repository.
