### PR TITLE
chore: bump version to 5.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install test-docker
 
-OPENAPI_GENERATOR_VERSION=5.0.1
+OPENAPI_GENERATOR_VERSION=5.1.1
 
 install:
 	-wget --no-clobber https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/$(OPENAPI_GENERATOR_VERSION)/openapi-generator-cli-$(OPENAPI_GENERATOR_VERSION).jar -O openapi-generator-cli.jar

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <openapi-generator-version>5.0.1</openapi-generator-version>
+        <openapi-generator-version>5.1.1</openapi-generator-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.13.1</junit-version>
     </properties>


### PR DESCRIPTION
We would be incorporating changes from [5.1.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v5.1.0) and [5.1.1](https://github.com/OpenAPITools/openapi-generator/releases/tag/v5.1.1).

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license