### PR TITLE
fix resource property names in terraform provider

### DIFF
--- a/src/main/java/com/twilio/oai/TwilioTerraformGenerator.java
+++ b/src/main/java/com/twilio/oai/TwilioTerraformGenerator.java
@@ -137,7 +137,7 @@ public class TwilioTerraformGenerator extends AbstractTwilioGoGenerator {
     }
 
     private void addParamVendorExtensions(final List<CodegenParameter> params) {
-        params.forEach(p -> p.vendorExtensions.put("x-name-in-snake-case", this.toSnakeCase(p.baseName)));
+        params.forEach(p -> p.vendorExtensions.put("x-name-in-snake-case", this.toSnakeCase(p.paramName)));
         params.forEach(p -> p.vendorExtensions.put("x-util-name", p.isFreeFormObject ? "Object" : "String"));
     }
 


### PR DESCRIPTION
# Fixes #

Fixes names such as `integration.channel`, `integration.url` in the terraform provider resources


Related PR: https://github.com/twilio/terraform-provider-twilio/pull/31