### PR TITLE
fix: Update "SchemaComputed" to "SchemaOptional"

### DIFF
--- a/src/main/java/com/twilio/oai/TwilioTerraformGenerator.java
+++ b/src/main/java/com/twilio/oai/TwilioTerraformGenerator.java
@@ -206,7 +206,7 @@ public class TwilioTerraformGenerator extends AbstractTwilioGoGenerator {
                 String key = pair.getKey();
                 Schema value = pair.getValue();
                 CodegenProperty codegenProperty = fromProperty(key, value);
-                String schemaType = BuildSchemaType(value, codegenProperty.openApiType, "SchemaComputed", codegenProperty, null);
+                String schemaType = BuildSchemaType(value, codegenProperty.openApiType, "SchemaOptional", codegenProperty, null);
 
                 codegenProperty.vendorExtensions.put("x-terraform-schema-type", schemaType);
                 codegenProperty.vendorExtensions.put("x-name-in-snake-case", this.toSnakeCase(codegenProperty.baseName));


### PR DESCRIPTION
In certain cases such as chat service, the [create](https://www.twilio.com/docs/chat/rest/service-resource#create-a-service-resource) takes in only one parameter but we cannot assume all the response parameters are "computed" since they can be updated. 

Related PR: https://github.com/twilio/terraform-provider-twilio/pull/35