### PR TITLE
fix: replace response properties with update properties

### DIFF
--- a/src/main/resources/terraform-provider-twilio/api.mustache
+++ b/src/main/resources/terraform-provider-twilio/api.mustache
@@ -21,9 +21,6 @@ func Resource{{name}}() *schema.Resource {
             {{#schema}}
             "{{{vendorExtensions.x-name-in-snake-case}}}": {{{vendorExtensions.x-terraform-schema-type}}},
             {{/schema}}
-            {{#responseSchema}}
-            "{{{vendorExtensions.x-name-in-snake-case}}}": {{{vendorExtensions.x-terraform-schema-type}}},
-            {{/responseSchema}}
         },
     }
 }


### PR DESCRIPTION
Response properties cannot be changed unless they are part of the create/update properties, so we'll only include create/update properties.

https://github.com/twilio/terraform-provider-twilio/pull/40