### PR TITLE
chore: use primitive int for integer types

### DIFF
--- a/examples/go/test/api_test.go
+++ b/examples/go/test/api_test.go
@@ -84,7 +84,7 @@ func TestDateTimeQueryParams(t *testing.T) {
 	dateCreatedAfter := time.Now().Add(2)
 	dateTest := "2021-03-31"
 
-	pageSize := int32(4)
+	pageSize := 4
 
 	params := openapi.ListCallRecordingParams{
 		DateCreated:       &dateCreated,

--- a/examples/go/test/unit_test.go
+++ b/examples/go/test/unit_test.go
@@ -96,7 +96,7 @@ func TestQueryParams(t *testing.T) {
 	dateCreatedBefore := time.Date(2000, 1, 2, 1, 0, 0, 0, time.UTC)
 	dateCreatedAfter := time.Date(2000, 1, 4, 1, 0, 0, 0, time.UTC)
 	dateTest := "2021-03-31"
-	pageSize := int32(4)
+	pageSize := 4
 	params := openapi.ListCallRecordingParams{
 		DateCreated:       &dateCreated,
 		DateCreatedBefore: &dateCreatedBefore,

--- a/src/main/java/com/twilio/oai/AbstractTwilioGoGenerator.java
+++ b/src/main/java/com/twilio/oai/AbstractTwilioGoGenerator.java
@@ -18,6 +18,7 @@ public abstract class AbstractTwilioGoGenerator extends GoClientCodegen {
         super();
 
         embeddedTemplateDir = templateDir = getName();
+        typeMapping.put("integer", "int");
     }
 
     @Override

--- a/src/main/java/com/twilio/oai/TwilioTerraformGenerator.java
+++ b/src/main/java/com/twilio/oai/TwilioTerraformGenerator.java
@@ -130,8 +130,8 @@ public class TwilioTerraformGenerator extends AbstractTwilioGoGenerator {
                     createOperation.vendorExtensions.put("x-resource-id", idParameter.paramName);
                     createOperation.vendorExtensions.put("x-resource-id-in-snake-case", idParameterSnakeCase);
 
-                    if ("int32".equals(idParameter.dataType)) {
-                        createOperation.vendorExtensions.put("x-resource-id-conversion-func", "Int32ToString");
+                    if ("int".equals(idParameter.dataType)) {
+                        createOperation.vendorExtensions.put("x-resource-id-conversion-func", "IntToString");
                     }
                 });
         }
@@ -229,7 +229,7 @@ public class TwilioTerraformGenerator extends AbstractTwilioGoGenerator {
         switch (dataType) {
             case "float32":
                 return String.format("AsFloat(%s)", schemaType);
-            case "int32":
+            case "int":
                 return String.format("AsInt(%s)", schemaType);
             case "bool":
                 return String.format("AsBool(%s)", schemaType);


### PR DESCRIPTION
Use `int` instead of `int32` for integer types


Related PRs:
https://github.com/twilio/twilio-go/pull/86
https://github.com/twilio/terraform-provider-twilio/pull/44