### PR TITLE
chore: upgrade openapi-generator to version 5.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install test-docker
 
-OPENAPI_GENERATOR_VERSION=5.1.1
+OPENAPI_GENERATOR_VERSION=5.2.0
 
 install:
 	wget -N https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/$(OPENAPI_GENERATOR_VERSION)/openapi-generator-cli-$(OPENAPI_GENERATOR_VERSION).jar

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <openapi-generator-version>5.1.1</openapi-generator-version>
+        <openapi-generator-version>5.2.0</openapi-generator-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.13.1</junit-version>
     </properties>


### PR DESCRIPTION
Use the [latest openapi-generator](https://github.com/OpenAPITools/openapi-generator/releases/tag/v5.2.0) 