### PR TITLE
fix: add computed terraform resource properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target/
 
 examples/go/rest/
 examples/terraform/resources/
+
+*.iml

--- a/examples/terraform/unit/accounts_calls_recordings_test.go
+++ b/examples/terraform/unit/accounts_calls_recordings_test.go
@@ -83,15 +83,20 @@ func TestImportInvalidCallRecording(t *testing.T) {
 }
 
 func TestSchemaCallRecording(t *testing.T) {
+	testCases := map[string]ExpectedParamSchema {
+		"call_sid": {true, false, false, false},
+		"sid": {false, false, true, false},
+		"path_account_sid": {false, false, true, true},
+		"pause_behavior": {false, false, true, true},
+		"price": {false, false, true, false},
+	}
+
 	assert.Contains(t, resource.Schema, "path_account_sid")
-
 	for paramName, paramSchema := range resource.Schema {
-		required := paramName == "call_sid"
-		computed := paramName != "call_sid"
-		optional := paramName != "sid" && paramName != "call_sid"
-
-		assert.Equal(t, required, paramSchema.Required, fmt.Sprintf("schema.Required iff call_sid: %s", paramName))
-		assert.Equal(t, computed, paramSchema.Computed, fmt.Sprintf("schema.Computed iff not call_sid: %s", paramName))
-		assert.Equal(t, optional, paramSchema.Optional, fmt.Sprintf("schema.Optional iff not sid or call_sid: %s", paramName))
+		if expectedSchema, ok := testCases[paramName]; ok {
+			assert.Equal(t, expectedSchema.Required, paramSchema.Required, fmt.Sprintf("schema.Required iff call_sid: %s", paramName))
+			assert.Equal(t, expectedSchema.Computed, paramSchema.Computed, fmt.Sprintf("schema.Computed iff not call_sid: %s", paramName))
+			assert.Equal(t, expectedSchema.Optional, paramSchema.Optional, fmt.Sprintf("schema.Optional iff param and not sid or call_sid: %s", paramName))
+		}
 	}
 }

--- a/examples/terraform/unit/credentials_aws_test.go
+++ b/examples/terraform/unit/credentials_aws_test.go
@@ -123,13 +123,21 @@ func TestImportInvalidCredentialAws(t *testing.T) {
 }
 
 func TestSchemaCredentialAws(t *testing.T) {
-	for paramName, paramSchema := range resource.Schema {
-		required := paramName == "credentials"
-		computed := paramName != "credentials"
-		optional := paramName != "sid" && paramName != "credentials"
+	testCases := map[string]ExpectedParamSchema {
+		"credential": {true, false, false, false},
+		"sid": {false, false, true, false},
+		"account_sid": {false, false, true, true},
+		"friendly_name": {false, false, true, true},
+		"test_number": {false, false, true, true},
+		"url": {false, false, true, false},
+	}
 
-		assert.Equal(t, required, paramSchema.Required, fmt.Sprintf("schema.Required iff credentials: %s", paramName))
-		assert.Equal(t, computed, paramSchema.Computed, fmt.Sprintf("schema.Computed iff not credentials: %s", paramName))
-		assert.Equal(t, optional, paramSchema.Optional, fmt.Sprintf("schema.Optional iff not sid or credentials: %s", paramName))
+	for paramName, paramSchema := range resource.Schema {
+		if expectedSchema, ok := testCases[paramName]; ok {
+			assert.Equal(t, expectedSchema.Required, paramSchema.Required, fmt.Sprintf("schema.Required iff credentials: %s", paramName))
+			assert.Equal(t, expectedSchema.Computed, paramSchema.Computed, fmt.Sprintf("schema.Computed iff not credentials: %s", paramName))
+			assert.Equal(t, expectedSchema.Optional, paramSchema.Optional, fmt.Sprintf("schema.Optional iff param and not sid or credentials: %s", paramName))
+
+		}
 	}
 }

--- a/examples/terraform/unit/serverless_services_environments_test.go
+++ b/examples/terraform/unit/serverless_services_environments_test.go
@@ -90,21 +90,16 @@ func TestSchemaServiceEnvironment(t *testing.T) {
 		"sid": {false, false, true, false},
 		"domain_suffix": {false, true, true, true},
 		"date_created": {false, false, true, false},
-		"date_updated": {false, false, true, false},
-		"url": {false, false, true, false},
-		"links": {false, false, true, false},
-		"build_sid": {false, false, true, false},
-		"domain_name": {false, false, true, false},
-		"account_sid": {false, false, true, false},
 	}
 
-	assert.Equal(t, len(testCases), len(resource.Schema), "Resource schema should include all resource properties")
+	assert.Contains(t, resource.Schema, "date_created")
 	for paramName, paramSchema := range resource.Schema {
-		expectedParams := testCases[paramName]
+		if expectedParams, ok := testCases[paramName]; ok {
+			assert.Equal(t, expectedParams.Required, paramSchema.Required, fmt.Sprintf("schema.Required iff service_sid or unique_name: %s", paramName))
+			assert.Equal(t, expectedParams.ForceNew, paramSchema.ForceNew, fmt.Sprintf("schema.ForceNew iff service_sid or unique_name or domain_suffix: %s", paramName))
+			assert.Equal(t, expectedParams.Computed, paramSchema.Computed, fmt.Sprintf("schema.Computed iff not service_sid or unique_name: %s", paramName))
+			assert.Equal(t, expectedParams.Optional, paramSchema.Optional, fmt.Sprintf("schema.Optional iff param and not sid or service_sid or unique_name: %s", paramName))
+		}
 
-		assert.Equal(t, expectedParams.Required, paramSchema.Required, fmt.Sprintf("schema.Required iff service_sid or unique_name: %s", paramName))
-		assert.Equal(t, expectedParams.ForceNew, paramSchema.ForceNew, fmt.Sprintf("schema.ForceNew iff service_sid or unique_name or domain_suffix: %s", paramName))
-		assert.Equal(t, expectedParams.Computed, paramSchema.Computed, fmt.Sprintf("schema.Computed iff not service_sid or unique_name: %s", paramName))
-		assert.Equal(t, expectedParams.Optional, paramSchema.Optional, fmt.Sprintf("schema.Optional iff param and not sid or service_sid or unique_name: %s", paramName))
 	}
 }

--- a/examples/twilio_api_v2010.yaml
+++ b/examples/twilio_api_v2010.yaml
@@ -55,11 +55,6 @@ components:
           format: date-time-rfc-2822
           nullable: true
           type: string
-        date_created_test:
-          description: The RFC 2822 date and time in GMT that the resource was created
-          format: date-time-rfc-2822
-          nullable: true
-          type: string
         price:
           description: The one-time cost of creating the recording.
           nullable: true

--- a/src/main/java/com/twilio/oai/TwilioTerraformGenerator.java
+++ b/src/main/java/com/twilio/oai/TwilioTerraformGenerator.java
@@ -8,14 +8,13 @@ import java.util.stream.Stream;
 import io.swagger.v3.oas.models.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Value;
-import org.openapitools.codegen.CodegenOperation;
-import org.openapitools.codegen.CodegenParameter;
-import org.openapitools.codegen.CodegenProperty;
-import org.openapitools.codegen.SupportingFile;
+import org.openapitools.codegen.*;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.openapitools.codegen.utils.StringUtils;
 
 public class TwilioTerraformGenerator extends AbstractTwilioGoGenerator {
+
+    private final Map<String, CodegenModel> allModels = new HashMap<String, CodegenModel>();
 
     @Value
     private static class TerraformSchema {
@@ -82,7 +81,19 @@ public class TwilioTerraformGenerator extends AbstractTwilioGoGenerator {
 
     @Override
     public Map<String, Object> postProcessAllModels(final Map<String, Object> allModels) {
-        super.postProcessAllModels(allModels);
+        final Map<String, Object> results = super.postProcessAllModels(allModels);
+
+        for (final Object obj : results.values()) {
+            final Map<String, Object> mods = (Map<String, Object>) obj;
+            final ArrayList<Map<String, Object>> modList = (ArrayList<Map<String, Object>>) mods.get("models");
+
+            // Add all the models to the local models list.
+            modList
+                    .stream()
+                    .map(model -> model.get("model"))
+                    .map(CodegenModel.class::cast)
+                    .forEach(model -> this.allModels.put(model.getClassname(), model));
+        }
 
         // Return an empty collection so no model files get generated.
         return new HashMap<>();
@@ -248,9 +259,9 @@ public class TwilioTerraformGenerator extends AbstractTwilioGoGenerator {
         return (CodegenOperation) resource.get(resourceOperation.name());
     }
 
-    private List<CodegenParameter> getResourceSchema(final CodegenOperation createOperation,
-                                                     final CodegenOperation updateOperation,
-                                                     final CodegenOperation fetchOperation) {
+    private List<Object> getResourceSchema(final CodegenOperation createOperation,
+                                           final CodegenOperation updateOperation,
+                                           final CodegenOperation fetchOperation) {
         var createParams = getCreateParams(createOperation, updateOperation != null);
 
         List<CodegenParameter> params = updateOperation != null ? updateOperation.allParams : fetchOperation.pathParams;
@@ -260,8 +271,15 @@ public class TwilioTerraformGenerator extends AbstractTwilioGoGenerator {
         final Stream<CodegenParameter> updateStream = updateParams
                 .stream()
                 .filter(param -> !createParamName.contains(param.paramName));
+        final List<CodegenParameter> operationParams = Stream.concat(createParams.stream(), updateStream).collect(Collectors.toList());
 
-        return Stream.concat(createParams.stream(), updateStream).collect(Collectors.toList());
+        final Set<String> operationParamName = getParamNames(operationParams);
+        final Stream<CodegenProperty> filteredProperties = getResourceProperties(
+                this.allModels.get(createOperation.returnType))
+                .stream()
+                .filter(prop -> !operationParamName.contains(prop.name));
+
+        return Stream.concat(operationParams.stream(), filteredProperties).collect(Collectors.toList());
     }
 
     private List<CodegenParameter> getCreateParams(CodegenOperation createOperation, boolean hasUpdate) {
@@ -288,12 +306,25 @@ public class TwilioTerraformGenerator extends AbstractTwilioGoGenerator {
         return params;
     }
 
+    private List<CodegenProperty> getResourceProperties(CodegenModel resourceModel) {
+        resourceModel.allVars.forEach(prop -> addSchemaVendorExtensions(prop, TerraformSchemaOptions.COMPUTED));
+        return resourceModel.allVars;
+    }
+
     private void addSchemaVendorExtensions(final CodegenParameter codegenParameter,
                                            final TerraformSchemaOptions schemaOptions) {
         final TerraformSchema terraformSchema = buildTerraformSchema(codegenParameter, schemaOptions);
 
         codegenParameter.vendorExtensions.put("x-terraform-schema", terraformSchema);
         codegenParameter.vendorExtensions.put("x-name-in-snake-case", this.toSnakeCase(codegenParameter.baseName));
+    }
+
+    private void addSchemaVendorExtensions(final CodegenProperty codegenProperty,
+                                           final TerraformSchemaOptions schemaOptions) {
+        final TerraformSchema terraformSchema = buildTerraformSchema(codegenProperty, schemaOptions);
+
+        codegenProperty.vendorExtensions.put("x-terraform-schema", terraformSchema);
+        codegenProperty.vendorExtensions.put("x-name-in-snake-case", this.toSnakeCase(codegenProperty.baseName));
     }
 
     private Set<String> getParamNames(final List<CodegenParameter> parameters) {

--- a/src/test/java/com/twilio/oai/TwilioTerraformGeneratorTest.java
+++ b/src/test/java/com/twilio/oai/TwilioTerraformGeneratorTest.java
@@ -9,14 +9,14 @@ import org.openapitools.codegen.config.CodegenConfigurator;
  * This test allows you to easily launch your code generation software under a debugger. Then run this test under debug
  * mode.  You will be able to step through your java code and then see the results in the out directory.
  */
-public class TwilioGoGeneratorTest {
+public class TwilioTerraformGeneratorTest {
 
     @Test
     public void launchCodeGenerator() {
         final CodegenConfigurator configurator = new CodegenConfigurator()
-            .setGeneratorName("twilio-go")
+            .setGeneratorName("terraform-provider-twilio")
             .setInputSpec("examples/twilio_api_v2010.yaml")
-            .setOutputDir("examples/go/rest");
+            .setOutputDir("examples/terraform/resources");
 
         final ClientOptInput clientOptInput = configurator.toClientOptInput();
         DefaultGenerator generator = new DefaultGenerator();


### PR DESCRIPTION
Adds API response fields that cannot be used as operation parameters as "Computed" Terraform Resource schema fields.

Related PR:
https://github.com/twilio/terraform-provider-twilio/pull/71