### PR TITLE
chore: add ci job timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout twilio-oai-generator
         uses: actions/checkout@v2
@@ -31,16 +32,20 @@ jobs:
       - name: Run tests
         run: make test-docker
 
-      - name: Slack notify on failure
-        if: ${{ failure() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_ICON_EMOJI: ':github:'
-          SLACK_MESSAGE: ${{ format('Build {2} in {1} failed{3} {0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id, ':') }}
-          SLACK_TITLE: Build Failure
-          SLACK_USERNAME: GitHub Actions
-          SLACK_MSG_AUTHOR: twilio-dx
-          SLACK_FOOTER: Posted automatically using GitHub Actions
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          MSG_MINIMAL: true
+  notify-on-failure:
+      name: Slack notify on failure
+      if: ${{ failure() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+      needs: [test]
+      runs-on: ubuntu-latest
+      steps:
+        - uses: rtCamp/action-slack-notify@v2
+          env:
+            SLACK_COLOR: ${{ job.status }}
+            SLACK_ICON_EMOJI: ':github:'
+            SLACK_MESSAGE: ${{ format('Build {2} in {1} failed{3} {0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id, ':') }}
+            SLACK_TITLE: Build Failure
+            SLACK_USERNAME: GitHub Actions
+            SLACK_MSG_AUTHOR: twilio-dx
+            SLACK_FOOTER: Posted automatically using GitHub Actions
+            SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+            MSG_MINIMAL: true


### PR DESCRIPTION
Adds 20 minute timeout to GitHub Actions test job. Moves Slack notification to it's own job so it is unaffected by the timeout.