### PR TITLE
chore: suppress stdout when generating libraries

### DIFF
--- a/examples/build_twilio_go.py
+++ b/examples/build_twilio_go.py
@@ -29,9 +29,12 @@ def generate(openapi_spec_path, go_path, domain, is_file=False, language='go'):
 
     to_generate = "terraform-provider-twilio" if language == "terraform" else "twilio-go"
     sub_dir = "twilio/resources" if language == "terraform" else "rest"
+    output_path = f"{go_path}/{sub_dir}/{domain_name}/{api_version}"
     command = f"cd {parent_dir} && java -cp ./openapi-generator-cli.jar:target/twilio-openapi-generator.jar " \
               f"org.openapitools.codegen.OpenAPIGenerator generate -g {to_generate} -i {full_path} -o " \
-              f"{go_path}/{sub_dir}/{domain_name}/{api_version}"
+              f"{output_path} " \
+              f"> /dev/null"  # Suppress stdout
+    print(f"Generating {output_path} from {full_path}")
     os.system(command)
 
 


### PR DESCRIPTION
It's too verbose and beggy. We'll just print the directory we're writing.