### PR TITLE
chore: upgrade openapi-generator to version 5.3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install test-docker
 
-OPENAPI_GENERATOR_VERSION=5.2.0
+OPENAPI_GENERATOR_VERSION=5.3.1
 
 install:
 	wget -N https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/$(OPENAPI_GENERATOR_VERSION)/openapi-generator-cli-$(OPENAPI_GENERATOR_VERSION).jar

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <openapi-generator-version>5.2.0</openapi-generator-version>
+        <openapi-generator-version>5.3.1</openapi-generator-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.13.1</junit-version>
     </properties>

--- a/src/main/java/com/twilio/oai/AbstractTwilioGoGenerator.java
+++ b/src/main/java/com/twilio/oai/AbstractTwilioGoGenerator.java
@@ -2,6 +2,7 @@ package com.twilio.oai;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -9,8 +10,11 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.CodegenOperation;
 import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.languages.GoClientCodegen;
+
+import static org.openapitools.codegen.utils.StringUtils.camelize;
 
 public abstract class AbstractTwilioGoGenerator extends GoClientCodegen {
 
@@ -83,5 +87,23 @@ public abstract class AbstractTwilioGoGenerator extends GoClientCodegen {
         name = name.replace(">", "After");
         name = super.toVarName(name);
         return name;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Map<String, Object> postProcessOperationsWithModels(final Map<String, Object> objs, List<Object> allModels) {
+        final Map<String, Object> objectMap = (Map<String, Object>) objs.get("operations");
+        final List<CodegenOperation> operations = (List<CodegenOperation>) objectMap.get("operation");
+        final List<Map<String, String>> imports = (List<Map<String, String>>) objs.get("imports");
+
+        // HTTP method verb conversion (e.g. PUT => Put).
+        operations.forEach(operation -> operation.httpMethod = camelize(operation.httpMethod.toLowerCase()));
+
+        if (imports != null) {
+            // Remove model imports to avoid error.
+            imports.removeIf(item -> item.get("import").startsWith(apiPackage()));
+        }
+
+        return objs;
     }
 }

--- a/src/main/resources/twilio-go/partial_serialization.mustache
+++ b/src/main/resources/twilio-go/partial_serialization.mustache
@@ -20,9 +20,9 @@ headers := make(map[string]interface{})
 {{^isHeaderParam}}
 {{^vendorExtensions.x-custom}}
 if params != nil && params.{{paramName}} != nil {
-{{#isFreeFormObject}}
 {{#isArray}}
     for _, item  := range *params.{{paramName}} {
+{{#items.isFreeFormObject}}
         v, err := json.Marshal(item)
 
         if err != nil {
@@ -30,9 +30,14 @@ if params != nil && params.{{paramName}} != nil {
         }
 
         data.Add("{{{baseName}}}", string(v))
+{{/items.isFreeFormObject}}
+{{^items.isFreeFormObject}}
+        data.Add("{{{baseName}}}", item)
+{{/items.isFreeFormObject}}
     }
 {{/isArray}}
 {{^isArray}}
+{{#isFreeFormObject}}
     v, err := json.Marshal(params.{{paramName}})
 
     if err != nil {
@@ -40,18 +45,11 @@ if params != nil && params.{{paramName}} != nil {
     }
 
     data.Set("{{{baseName}}}", string(v))
-{{/isArray}}
 {{/isFreeFormObject}}
 {{^isFreeFormObject}}
-{{#isArray}}
-    for _, item  := range *params.{{paramName}} {
-        data.Add("{{{baseName}}}", item)
-    }
-{{/isArray}}
-{{^isArray}}
     data.Set("{{{baseName}}}", {{^isString}}fmt.Sprint({{/isString}}{{#isDateTime}}({{/isDateTime}}*params.{{paramName}}{{^isString}}{{#isDateTime}}).Format(time.RFC3339){{/isDateTime}}){{/isString}})
-{{/isArray}}
 {{/isFreeFormObject}}
+{{/isArray}}
 }
 {{/vendorExtensions.x-custom}}
 {{/isHeaderParam}}


### PR DESCRIPTION
Extracts minimal code needed from upstream `postProcessOperationsWithModels` to avoid NPE when generating sample values. Also fixes serialization template for arrays to depend on type of the inner items.

Relates to https://github.com/OpenAPITools/openapi-generator/issues/11470