### PR TITLE
fix: refactor limit enforcement and fetching next page

### DIFF
--- a/examples/go-client/Dockerfile
+++ b/examples/go-client/Dockerfile
@@ -6,7 +6,7 @@ RUN go install golang.org/x/tools/cmd/goimports@latest
 WORKDIR /go/src/twilio-go
 COPY . .
 
-RUN go get -u github.com/twilio/twilio-go@main
+RUN go get -u github.com/twilio/twilio-go@empty-list-and-limit # Temp change to pass tests, will revert before merging
 RUN go get -u github.com/twilio/terraform-provider-twilio@main
 RUN goimports -w .
 

--- a/examples/go-client/Dockerfile
+++ b/examples/go-client/Dockerfile
@@ -6,7 +6,7 @@ RUN go install golang.org/x/tools/cmd/goimports@latest
 WORKDIR /go/src/twilio-go
 COPY . .
 
-RUN go get -u github.com/twilio/twilio-go@empty-list-and-limit # Temp change to pass tests, will revert before merging
+RUN go get -u github.com/twilio/twilio-go@main
 RUN go get -u github.com/twilio/terraform-provider-twilio@main
 RUN goimports -w .
 

--- a/examples/go-client/helper/rest/api/v2010/accounts_calls.go
+++ b/examples/go-client/helper/rest/api/v2010/accounts_calls.go
@@ -239,28 +239,15 @@ if params != nil && params.PageSize != nil {
 
 // Lists Call records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCall(params *ListCallParams) ([]TestResponseObject, error) {
-    if params == nil {
-        params = &ListCallParams{}
-    }
-    params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-    response, err := c.PageCall(params, "", "")
+    response, err := c.StreamCall(params)
     if err != nil {
         return nil, err
     }
 
-    curRecord := 0
-    var records []TestResponseObject
+    records := make([]TestResponseObject, 0)
 
-    for response != nil {
-        records = append(records, response.Calls...)
-
-        var record interface{}
-        if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCallResponse); record == nil || err != nil {
-            return records, err
-        }
-
-        response = record.(*ListCallResponse)
+    for record := range response {
+        records = append(records, record)
     }
 
     return records, err
@@ -278,19 +265,24 @@ func (c *ApiService) StreamCall(params *ListCallParams) (chan TestResponseObject
         return nil, err
     }
 
-    curRecord := 0
+    curRecord := 1
     //set buffer size of the channel to 1
     channel := make(chan TestResponseObject, 1)
 
     go func() {
         for response != nil {
-            for item := range response.Calls {
-                channel <- response.Calls[item]
+            responseRecords := response.Calls
+            for item := range responseRecords {
+                channel <- responseRecords[item]
+                curRecord += 1
+                if params.Limit != nil && *params.Limit < curRecord {
+                    close(channel)
+                    return
+                }
             }
 
-
             var record interface{}
-            if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCallResponse); record == nil || err != nil {
+            if record, err = client.GetNext(c.baseURL, response, c.getNextListCallResponse); record == nil || err != nil {
                 close(channel)
                 return
             }

--- a/examples/go-client/helper/rest/api/v2010/accounts_calls_recordings.go
+++ b/examples/go-client/helper/rest/api/v2010/accounts_calls_recordings.go
@@ -270,28 +270,15 @@ if params != nil && params.PageSize != nil {
 
 // Lists CallRecording records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCallRecording(CallSid string, params *ListCallRecordingParams) ([]TestResponseObject, error) {
-    if params == nil {
-        params = &ListCallRecordingParams{}
-    }
-    params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-    response, err := c.PageCallRecording(CallSid, params, "", "")
+    response, err := c.StreamCallRecording(CallSid, params)
     if err != nil {
         return nil, err
     }
 
-    curRecord := 0
-    var records []TestResponseObject
+    records := make([]TestResponseObject, 0)
 
-    for response != nil {
-        records = append(records, response.Recordings...)
-
-        var record interface{}
-        if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCallRecordingResponse); record == nil || err != nil {
-            return records, err
-        }
-
-        response = record.(*ListCallRecordingResponse)
+    for record := range response {
+        records = append(records, record)
     }
 
     return records, err
@@ -309,19 +296,24 @@ func (c *ApiService) StreamCallRecording(CallSid string, params *ListCallRecordi
         return nil, err
     }
 
-    curRecord := 0
+    curRecord := 1
     //set buffer size of the channel to 1
     channel := make(chan TestResponseObject, 1)
 
     go func() {
         for response != nil {
-            for item := range response.Recordings {
-                channel <- response.Recordings[item]
+            responseRecords := response.Recordings
+            for item := range responseRecords {
+                channel <- responseRecords[item]
+                curRecord += 1
+                if params.Limit != nil && *params.Limit < curRecord {
+                    close(channel)
+                    return
+                }
             }
 
-
             var record interface{}
-            if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCallRecordingResponse); record == nil || err != nil {
+            if record, err = client.GetNext(c.baseURL, response, c.getNextListCallRecordingResponse); record == nil || err != nil {
                 close(channel)
                 return
             }

--- a/examples/go-client/helper/rest/api/v2010/credentials_aws.go
+++ b/examples/go-client/helper/rest/api/v2010/credentials_aws.go
@@ -278,28 +278,15 @@ if params != nil && params.PageSize != nil {
 
 // Lists CredentialAws records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCredentialAws(params *ListCredentialAwsParams) ([]TestResponseObject, error) {
-    if params == nil {
-        params = &ListCredentialAwsParams{}
-    }
-    params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-    response, err := c.PageCredentialAws(params, "", "")
+    response, err := c.StreamCredentialAws(params)
     if err != nil {
         return nil, err
     }
 
-    curRecord := 0
-    var records []TestResponseObject
+    records := make([]TestResponseObject, 0)
 
-    for response != nil {
-        records = append(records, response.Credentials...)
-
-        var record interface{}
-        if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCredentialAwsResponse); record == nil || err != nil {
-            return records, err
-        }
-
-        response = record.(*ListCredentialAwsResponse)
+    for record := range response {
+        records = append(records, record)
     }
 
     return records, err
@@ -317,19 +304,24 @@ func (c *ApiService) StreamCredentialAws(params *ListCredentialAwsParams) (chan 
         return nil, err
     }
 
-    curRecord := 0
+    curRecord := 1
     //set buffer size of the channel to 1
     channel := make(chan TestResponseObject, 1)
 
     go func() {
         for response != nil {
-            for item := range response.Credentials {
-                channel <- response.Credentials[item]
+            responseRecords := response.Credentials
+            for item := range responseRecords {
+                channel <- responseRecords[item]
+                curRecord += 1
+                if params.Limit != nil && *params.Limit < curRecord {
+                    close(channel)
+                    return
+                }
             }
 
-
             var record interface{}
-            if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNextListCredentialAwsResponse); record == nil || err != nil {
+            if record, err = client.GetNext(c.baseURL, response, c.getNextListCredentialAwsResponse); record == nil || err != nil {
                 close(channel)
                 return
             }

--- a/examples/go-client/helper/rest/api/v2010/unit_test.go
+++ b/examples/go-client/helper/rest/api/v2010/unit_test.go
@@ -460,3 +460,33 @@ func TestListNoNextPage(t *testing.T) {
 	assert.Equal(t, 3, len(resp))
 	assert.Nil(t, err)
 }
+
+func TestPageToken(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	testClient := NewMockBaseClient(mockCtrl)
+
+	testClient.EXPECT().AccountSid().DoAndReturn(func() string {
+		return "AC222222222222222222222222222222"
+	}).AnyTimes()
+
+	pageToken := "token"
+	pageNumber := "5"
+
+	expectedData := url.Values{}
+	expectedData.Set("PageToken", pageToken)
+	expectedData.Set("Page", pageNumber)
+
+	testClient.EXPECT().SendRequest(
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any()).
+		DoAndReturn(func(method string, rawURL string, data url.Values, headers map[string]interface{}) (*http.Response, error) {
+			assert.Equal(t, expectedData, data)
+			return &http.Response{Body: ioutil.NopCloser(bytes.NewReader(nil))}, nil
+		}).AnyTimes()
+
+	twilio := NewApiServiceWithClient(testClient)
+
+	_, _ = twilio.PageCredentialAws(nil, pageToken, pageNumber)
+}

--- a/examples/go-client/helper/rest/api/v2010/unit_test.go
+++ b/examples/go-client/helper/rest/api/v2010/unit_test.go
@@ -296,9 +296,7 @@ func TestListPaging(t *testing.T) {
 		DoAndReturn(func(method string, rawURL string, data url.Values,
 			headers map[string]interface{}) (*http.Response, error) {
 			response := map[string]interface{}{
-				"end":            4,
-				"first_page_uri": "/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=0",
-				"calls": []map[string]interface{}{
+				"recordings": []map[string]interface{}{
 					{
 						"test_string": "first",
 					},
@@ -306,11 +304,7 @@ func TestListPaging(t *testing.T) {
 						"test_string": "second",
 					},
 				},
-				"uri":           "“/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=0&PageToken=",
-				"page_size":     5,
-				"start":         0,
 				"next_page_uri": "/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=1&PageToken=PASMc49f620580b24424bcfa885b1f741130",
-				"page":          0,
 			}
 
 			resp, _ := json.Marshal(response)
@@ -329,18 +323,12 @@ func TestListPaging(t *testing.T) {
 		DoAndReturn(func(method string, rawURL string, data url.Values,
 			headers map[string]interface{}) (*http.Response, error) {
 			response := map[string]interface{}{
-				"end":            3,
-				"first_page_uri": "/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=0",
-				"calls": []map[string]interface{}{
+				"recordings": []map[string]interface{}{
 					{
 						"test_string": "third",
 					},
 				},
-				"uri":           "“/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=1&PageToken=",
-				"page_size":     1,
-				"start":         0,
 				"next_page_uri": "/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=2&PageToken=PASMc49f620580b24424bcfa885b1f741130",
-				"page":          1,
 			}
 
 			resp, _ := json.Marshal(response)
@@ -372,13 +360,11 @@ func TestListPaging(t *testing.T) {
 
 	twilio := NewApiServiceWithClient(testClient)
 
-	params := &ListCallParams{}
-	params.SetFrom("from")
-	params.SetTo("to")
+	params := &ListCallRecordingParams{}
 	params.SetPageSize(5)
 	params.SetLimit(10)
 
-	resp, _ := twilio.ListCall(params)
+	resp, _ := twilio.ListCallRecording("CA123", params)
 	assert.Equal(t, "first", *resp[0].TestString)
 	assert.Equal(t, "second", *resp[1].TestString)
 	assert.Equal(t, "third", *resp[2].TestString)
@@ -401,9 +387,7 @@ func TestListError(t *testing.T) {
 		DoAndReturn(func(method string, rawURL string, data url.Values,
 			headers map[string]interface{}) (*http.Response, error) {
 			response := map[string]interface{}{
-				"end":            4,
-				"first_page_uri": "/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=0",
-				"calls": []map[string]interface{}{
+				"credentials": []map[string]interface{}{
 					{
 						"direction": "outbound-api",
 						"from":      "4444444444",
@@ -412,11 +396,7 @@ func TestListError(t *testing.T) {
 						"status":    "delivered",
 					},
 				},
-				"uri":           "“/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=0&PageToken=",
-				"page_size":     5,
-				"start":         0,
 				"next_page_uri": "/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=1&PageToken=PASMc49f620580b24424bcfa885b1f741130",
-				"page":          0,
 			}
 
 			resp, _ := json.Marshal(response)
@@ -429,13 +409,11 @@ func TestListError(t *testing.T) {
 
 	twilio := NewApiServiceWithClient(testClient)
 
-	params := &ListCallParams{}
-	params.SetFrom("from")
-	params.SetTo("to")
+	params := &ListCredentialAwsParams{}
 	params.SetPageSize(5)
 	params.SetLimit(5)
 
-	resp, err := twilio.ListCall(params)
+	resp, err := twilio.ListCredentialAws(params)
 	assert.Len(t, resp, 0)
 	assert.NotNil(t, err)
 	assert.Equal(t, "Listing error", err.Error())

--- a/examples/go-client/helper/rest/api/v2010/unit_test.go
+++ b/examples/go-client/helper/rest/api/v2010/unit_test.go
@@ -225,8 +225,6 @@ func TestList(t *testing.T) {
 		DoAndReturn(func(method string, rawURL string, data url.Values,
 			headers map[string]interface{}) (*http.Response, error) {
 			response := map[string]interface{}{
-				"end":            4,
-				"first_page_uri": "/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=0",
 				"calls": []map[string]interface{}{
 					{
 						"test_string": "hi",
@@ -244,11 +242,7 @@ func TestList(t *testing.T) {
 						"test_string": "others",
 					},
 				},
-				"uri":           "“/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=0&PageToken=",
-				"page_size":     5,
-				"start":         0,
 				"next_page_uri": "/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=1&PageToken=PASMc49f620580b24424bcfa885b1f741130",
-				"page":          0,
 			}
 
 			resp, _ := json.Marshal(response)
@@ -279,11 +273,16 @@ func TestList(t *testing.T) {
 	params.SetLimit(10)
 	resp, _ = twilio.ListCall(params)
 	assert.Equal(t, 10, len(resp))
+
+	params.SetLimit(3)
+	resp, _ = twilio.ListCall(params)
+	assert.Equal(t, 3, len(resp))
 }
 
 func TestListPaging(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	testClient := NewMockBaseClient(mockCtrl)
+
 	testClient.EXPECT().AccountSid().DoAndReturn(func() string {
 		return "AC222222222222222222222222222222"
 	}).AnyTimes()
@@ -419,189 +418,7 @@ func TestListError(t *testing.T) {
 	assert.Equal(t, "Listing error", err.Error())
 }
 
-func TestStream(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	testClient := NewMockBaseClient(mockCtrl)
-	testClient.EXPECT().AccountSid().DoAndReturn(func() string {
-		return "AC222222222222222222222222222222"
-	}).AnyTimes()
-
-	testClient.EXPECT().SendRequest(
-		gomock.Any(),
-		gomock.Any(),
-		gomock.Any(),
-		gomock.Any()).
-		DoAndReturn(func(method string, rawURL string, data url.Values,
-			headers map[string]interface{}) (*http.Response, error) {
-			response := map[string]interface{}{
-				"end":            4,
-				"first_page_uri": "/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=0",
-				"calls": []map[string]interface{}{
-					{
-						"direction": "outbound-api",
-						"from":      "4444444444",
-						"to":        "9999999999",
-						"body":      "Hi",
-						"status":    "delivered",
-					},
-					{
-						"direction": "outbound-call",
-						"from":      "4444444444",
-						"to":        "9999999999",
-						"body":      "Hi",
-						"status":    "queued",
-					},
-					{
-						"direction": "outbound-api",
-						"from":      "4444444444",
-						"to":        "9999999999",
-						"body":      "Hi",
-						"status":    "delivered",
-					},
-					{
-						"direction": "outbound-api",
-						"from":      "4444444444",
-						"to":        "9999999999",
-						"body":      "Hi",
-						"status":    "delivered",
-					},
-					{
-						"direction": "outbound-api",
-						"from":      "4444444444",
-						"to":        "9999999999",
-						"body":      "Hello",
-						"status":    "sent",
-					},
-				},
-				"uri":           "“/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=0&PageToken=",
-				"page_size":     5,
-				"start":         0,
-				"next_page_uri": "/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=1&PageToken=PASMc49f620580b24424bcfa885b1f741130",
-				"page":          0,
-			}
-
-			resp, _ := json.Marshal(response)
-
-			return &http.Response{
-				Body: ioutil.NopCloser(bytes.NewReader(resp)),
-			}, nil
-		},
-		).AnyTimes()
-
-	twilio := NewApiServiceWithClient(testClient)
-
-	params := &ListCallParams{}
-	params.SetPageSize(5)
-	params.SetLimit(10)
-
-	callCount := getStreamCount(twilio, params)
-	assert.Equal(t, 10, callCount)
-
-	params.SetLimit(15)
-	callCount = getStreamCount(twilio, params)
-	assert.Equal(t, 15, callCount)
-
-	params.SetLimit(40)
-	callCount = getStreamCount(twilio, params)
-	assert.Equal(t, 40, callCount)
-}
-
-func TestStreamPaging(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	testClient := NewMockBaseClient(mockCtrl)
-	testClient.EXPECT().AccountSid().DoAndReturn(func() string {
-		return "AC222222222222222222222222222222"
-	}).AnyTimes()
-
-	page0 := testClient.EXPECT().SendRequest(
-		gomock.Any(),
-		gomock.Any(),
-		gomock.Any(),
-		gomock.Any()).
-		DoAndReturn(func(method string, rawURL string, data url.Values,
-			headers map[string]interface{}) (*http.Response, error) {
-			response := map[string]interface{}{
-				"end":            2,
-				"first_page_uri": "/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=0",
-				"calls": []map[string]interface{}{
-					{
-						"test_string": "Call 0",
-					},
-					{
-						"test_string": "Call 1",
-					},
-				},
-				"uri":           "/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=0&PageToken=dummy",
-				"page_size":     5,
-				"start":         0,
-				"next_page_uri": "/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=1&PageToken=PASMc49f620580b24424bcfa885b1f741130",
-				"page":          0,
-			}
-
-			resp, _ := json.Marshal(response)
-
-			return &http.Response{
-				Body: ioutil.NopCloser(bytes.NewReader(resp)),
-			}, nil
-		},
-		)
-
-	page1 := testClient.EXPECT().SendRequest(
-		gomock.Any(),
-		gomock.Any(),
-		gomock.Any(),
-		gomock.Any()).
-		DoAndReturn(func(method string, rawURL string, data url.Values,
-			headers map[string]interface{}) (*http.Response, error) {
-			response := map[string]interface{}{
-				"end":            1,
-				"first_page_uri": "/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=0",
-				"calls": []map[string]interface{}{
-					{
-						"test_string": "Call 2",
-					},
-				},
-				"uri":           "“/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=1&PageToken=",
-				"page_size":     5,
-				"start":         0,
-				"next_page_uri": "/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=2&PageToken=PASMc49f620580b24424bcfa885b1f741130",
-				"page":          1,
-			}
-
-			resp, _ := json.Marshal(response)
-
-			return &http.Response{
-				Body: ioutil.NopCloser(bytes.NewReader(resp)),
-			}, nil
-		},
-		)
-
-	gomock.InOrder(
-		page0,
-		page1,
-	)
-
-	twilio := NewApiServiceWithClient(testClient)
-
-	params := &ListCallParams{}
-	params.SetFrom("4444444444")
-	params.SetTo("9999999999")
-	params.SetPageSize(5)
-	params.SetLimit(3)
-
-	callCount := 0
-
-	channel, _ := twilio.StreamCall(params)
-	for record := range channel {
-		text := fmt.Sprintf("Call %d", callCount)
-		assert.Equal(t, text, *record.TestString)
-		callCount += 1
-	}
-
-	assert.Equal(t, 3, callCount)
-}
-
-func TestStreamError(t *testing.T) {
+func TestListNoNextPage(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	testClient := NewMockBaseClient(mockCtrl)
 
@@ -617,40 +434,29 @@ func TestStreamError(t *testing.T) {
 		DoAndReturn(func(method string, rawURL string, data url.Values,
 			headers map[string]interface{}) (*http.Response, error) {
 			response := map[string]interface{}{
-				"end":            4,
-				"first_page_uri": "/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=0",
-				"calls": []map[string]interface{}{
+				"credentials": []map[string]interface{}{
 					{
-						"direction": "outbound-api",
-						"from":      "4444444444",
-						"to":        "9999999999",
-						"body":      "Hi",
-						"status":    "delivered",
+						"test_string": "me",
+					},
+					{
+						"test_string": "and",
+					},
+					{
+						"test_string": "you",
 					},
 				},
-				"uri":           "“/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=0&PageToken=",
-				"page_size":     5,
-				"start":         0,
-				"next_page_uri": "/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=1&PageToken=PASMc49f620580b24424bcfa885b1f741130",
-				"page":          0,
 			}
 
 			resp, _ := json.Marshal(response)
 
 			return &http.Response{
 				Body: ioutil.NopCloser(bytes.NewReader(resp)),
-			}, errors.New("streaming error")
-		},
-		).AnyTimes()
+			}, nil
+		}).AnyTimes()
 
 	twilio := NewApiServiceWithClient(testClient)
 
-	params := &ListCallParams{}
-	params.SetPageSize(5)
-	params.SetLimit(5)
-
-	resp, err := twilio.StreamCall(params)
-	assert.Len(t, resp, 0)
-	assert.NotNil(t, err)
-	assert.Equal(t, "streaming error", err.Error())
+	resp, err := twilio.ListCredentialAws(nil)
+	assert.Equal(t, 3, len(resp))
+	assert.Nil(t, err)
 }

--- a/src/main/resources/twilio-go/api.mustache
+++ b/src/main/resources/twilio-go/api.mustache
@@ -104,28 +104,15 @@ func (c *ApiService) Page{{{vendorExtensions.x-domain-name}}}({{#allParams}}{{#r
 
 // Lists {{{vendorExtensions.x-domain-name}}} records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) List{{{vendorExtensions.x-domain-name}}}({{#allParams}}{{#required}}{{paramName}} {{{dataType}}}{{^last}}, {{/last}}{{/required}}{{/allParams}}params *{{{nickname}}}Params) ({{{returnType}}}, error) {
-    if params == nil {
-        params = &{{{nickname}}}Params{}
-    }
-    params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
-
-    response, err := c.Page{{{vendorExtensions.x-domain-name}}}({{#allParams}}{{#required}}{{paramName}}{{^last}}, {{/last}}{{/required}}{{/allParams}}params, "", "")
+    response, err := c.Stream{{{vendorExtensions.x-domain-name}}}({{#allParams}}{{#required}}{{paramName}}{{^last}}, {{/last}}{{/required}}{{/allParams}}params)
     if err != nil {
         return nil, err
     }
 
-    curRecord := 0
-    var records {{{returnType}}}
+    records := make({{{returnType}}}, 0)
 
-    for response != nil {
-        records = append(records, response.{{{vendorExtensions.x-payload-field-name}}}...)
-
-        var record interface{}
-        if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNext{{{returnContainer}}}); record == nil || err != nil {
-            return records, err
-        }
-
-        response = record.(*{{{returnContainer}}})
+    for record := range response {
+        records = append(records, record)
     }
 
     return records, err
@@ -143,19 +130,24 @@ func (c *ApiService) Stream{{{vendorExtensions.x-domain-name}}}({{#allParams}}{{
         return nil, err
     }
 
-    curRecord := 0
+    curRecord := 1
     //set buffer size of the channel to 1
     channel := make(chan {{{returnBaseType}}}, 1)
 
     go func() {
         for response != nil {
-            for item := range response.{{{vendorExtensions.x-payload-field-name}}} {
-                channel <- response.{{{vendorExtensions.x-payload-field-name}}}[item]
+            responseRecords := response.{{{vendorExtensions.x-payload-field-name}}}
+            for item := range responseRecords {
+                channel <- responseRecords[item]
+                curRecord += 1
+                if params.Limit != nil && *params.Limit < curRecord {
+                    close(channel)
+                    return
+                }
             }
 
-
             var record interface{}
-            if record, err = client.GetNext(c.baseURL, response, &curRecord, params.Limit, c.getNext{{{returnContainer}}}); record == nil || err != nil {
+            if record, err = client.GetNext(c.baseURL, response, c.getNext{{{returnContainer}}}); record == nil || err != nil {
                 close(channel)
                 return
             }


### PR DESCRIPTION
Fixes bugs where limit param was not always enforced and empty results caused an error when attempting to fetch next page.

Relates to https://github.com/twilio/twilio-go/pull/148