### PR TITLE
fix: Go tests wait for Prism to be responsive

### DIFF
--- a/examples/go-client/Dockerfile
+++ b/examples/go-client/Dockerfile
@@ -9,4 +9,4 @@ RUN go get -u github.com/twilio/twilio-go@main
 RUN go get -u github.com/twilio/terraform-provider-twilio@main
 
 # pipefail prevents errors in a pipeline from being masked.
-CMD ["/bin/bash", "-c", "set -o pipefail && go test ./... -coverprofile /local/coverage.out -json | tee /local/test-report.out"]
+CMD ["/local/wait-for-prism.sh", "/bin/bash", "-c", "set -o pipefail && go test ./... -coverprofile /local/coverage.out -json | tee /local/test-report.out"]

--- a/examples/go-client/wait-for-prism.sh
+++ b/examples/go-client/wait-for-prism.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+while true
+do
+  echo "Checking if Prism mock server is up... "
+  wget -O/dev/null --header="Authorization: Basic `echo -n abc:123 | base64`" http://prism_twilio:4010/v1/Credentials/AWS > /dev/null 2>&1
+  status=$?
+  echo "Prism Status: $status"
+  if [ $status -eq 0 ]; then
+    echo "Prism mock server is up now."
+    break
+  fi
+  sleep 0.1
+done
+
+
+>&2 echo "Prism is responding to API calls - executing command"
+exec "$@"
+


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

Fixes #127

This PR introduces a bash script that will repeatedly try to access the Prism container on a sample API.
Once a working response is received, the script stops looping and begins executing the passed in command (in this case, go tests).



### Checklist

Most of these items do not seem to apply to this change AFAICT.

- [x] I acknowledge that all my contributions will be made under the project's license
- [x] Run `make test-docker`
- [ ] Verify affected language:
    - [ ] Generate [twilio-go](https://github.com/twilio/twilio-go) from our [OpenAPI specification](https://github.com/twilio/twilio-oai) using the [build_twilio_go.py](./examples/build_twilio_go.py) using `python examples/build_twilio_go.py path/to/twilio-oai/spec/yaml path/to/twilio-go` and inspect the diff
    - [ ] Run `make test` in `twilio-go`
    - [ ] Create a pull request in `twilio-go`
    - [ ] Provide a link below to the pull request
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-oai-generator/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

