### PR TITLE
feat: twilio-go stream functions also return error channel

### DIFF
--- a/examples/go-client/helper/rest/api/v2010/accounts_calls_recordings.go
+++ b/examples/go-client/helper/rest/api/v2010/accounts_calls_recordings.go
@@ -264,60 +264,70 @@ func (c *ApiService) PageCallRecording(CallSid string, params *ListCallRecording
 
 // Lists CallRecording records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCallRecording(CallSid string, params *ListCallRecordingParams) ([]TestResponseObject, error) {
-	response, err := c.StreamCallRecording(CallSid, params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamCallRecording(CallSid, params)
 
 	records := make([]TestResponseObject, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams CallRecording records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamCallRecording(CallSid string, params *ListCallRecordingParams) (chan TestResponseObject, error) {
+func (c *ApiService) StreamCallRecording(CallSid string, params *ListCallRecordingParams) (chan TestResponseObject, chan error) {
 	if params == nil {
 		params = &ListCallRecordingParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TestResponseObject, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageCallRecording(CallSid, params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamCallRecording(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamCallRecording(response *ListCallRecordingResponse, params *ListCallRecordingParams, recordChannel chan TestResponseObject, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TestResponseObject, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Recordings
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListCallRecordingResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Recordings
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListCallRecordingResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListCallRecordingResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListCallRecordingResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListCallRecordingResponse(nextPageUrl string) (interface{}, error) {

--- a/examples/go-client/helper/rest/api/v2010/credentials_aws.go
+++ b/examples/go-client/helper/rest/api/v2010/credentials_aws.go
@@ -285,60 +285,70 @@ func (c *ApiService) PageCredentialAws(params *ListCredentialAwsParams, pageToke
 
 // Lists CredentialAws records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) ListCredentialAws(params *ListCredentialAwsParams) ([]TestResponseObject, error) {
-	response, err := c.StreamCredentialAws(params)
-	if err != nil {
-		return nil, err
-	}
+	response, errors := c.StreamCredentialAws(params)
 
 	records := make([]TestResponseObject, 0)
-
 	for record := range response {
 		records = append(records, record)
 	}
 
-	return records, err
+	if err := <-errors; err != nil {
+		return nil, err
+	}
+
+	return records, nil
 }
 
 // Streams CredentialAws records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) StreamCredentialAws(params *ListCredentialAwsParams) (chan TestResponseObject, error) {
+func (c *ApiService) StreamCredentialAws(params *ListCredentialAwsParams) (chan TestResponseObject, chan error) {
 	if params == nil {
 		params = &ListCredentialAwsParams{}
 	}
 	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
+	recordChannel := make(chan TestResponseObject, 1)
+	errorChannel := make(chan error, 1)
+
 	response, err := c.PageCredentialAws(params, "", "")
 	if err != nil {
-		return nil, err
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.streamCredentialAws(response, params, recordChannel, errorChannel)
 	}
 
+	return recordChannel, errorChannel
+}
+
+func (c *ApiService) streamCredentialAws(response *ListCredentialAwsResponse, params *ListCredentialAwsParams, recordChannel chan TestResponseObject, errorChannel chan error) {
 	curRecord := 1
-	//set buffer size of the channel to 1
-	channel := make(chan TestResponseObject, 1)
 
-	go func() {
-		for response != nil {
-			responseRecords := response.Credentials
-			for item := range responseRecords {
-				channel <- responseRecords[item]
-				curRecord += 1
-				if params.Limit != nil && *params.Limit < curRecord {
-					close(channel)
-					return
-				}
-			}
-
-			var record interface{}
-			if record, err = client.GetNext(c.baseURL, response, c.getNextListCredentialAwsResponse); record == nil || err != nil {
-				close(channel)
+	for response != nil {
+		responseRecords := response.Credentials
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
 				return
 			}
-
-			response = record.(*ListCredentialAwsResponse)
 		}
-		close(channel)
-	}()
 
-	return channel, err
+		record, err := client.GetNext(c.baseURL, response, c.getNextListCredentialAwsResponse)
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*ListCredentialAwsResponse)
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNextListCredentialAwsResponse(nextPageUrl string) (interface{}, error) {

--- a/examples/go-client/helper/rest/api/v2010/unit_test.go
+++ b/examples/go-client/helper/rest/api/v2010/unit_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -31,7 +32,7 @@ func TestPathIsCorrect(t *testing.T) {
 		DoAndReturn(func(method string, rawURL string, data url.Values,
 			headers map[string]interface{}) (*http.Response, error) {
 			assert.Equal(t, "https://api.twilio.com/2010-04-01/Accounts/AC222222222222222222222222222222/Calls/CAXXXXY.json", rawURL)
-			return &http.Response{Body: ioutil.NopCloser(bytes.NewReader(nil))}, nil
+			return &http.Response{Body: getEmptyBody()}, nil
 		},
 		)
 
@@ -53,7 +54,7 @@ func TestAccountSidAsOptionalParam(t *testing.T) {
 		DoAndReturn(func(method string, rawURL string, data url.Values,
 			headers map[string]interface{}) (*http.Response, error) {
 			assert.Equal(t, "https://api.twilio.com/2010-04-01/Accounts/AC444444444444444444444444444444/Calls/CAXXXXY.json", rawURL)
-			return &http.Response{Body: ioutil.NopCloser(bytes.NewReader(nil))}, nil
+			return &http.Response{Body: getEmptyBody()}, nil
 		},
 		)
 
@@ -86,7 +87,7 @@ func TestAddingHeader(t *testing.T) {
 		DoAndReturn(func(method string, rawURL string, data url.Values,
 			headers map[string]interface{}) (*http.Response, error) {
 			assert.Equal(t, expectedHeader, headers)
-			return &http.Response{Body: ioutil.NopCloser(bytes.NewReader(nil))}, nil
+			return &http.Response{Body: getEmptyBody()}, nil
 		},
 		)
 	twilio := NewApiServiceWithClient(testClient)
@@ -126,7 +127,7 @@ func TestQueryParams(t *testing.T) {
 		DoAndReturn(func(method string, rawURL string, data url.Values,
 			headers map[string]interface{}) (*http.Response, error) {
 			assert.Equal(t, expectedData, data)
-			return &http.Response{Body: ioutil.NopCloser(bytes.NewReader(nil))}, nil
+			return &http.Response{Body: getEmptyBody()}, nil
 		},
 		)
 	twilio := NewApiServiceWithClient(testClient)
@@ -156,7 +157,7 @@ func TestArrayTypeParam(t *testing.T) {
 		DoAndReturn(func(method string, rawURL string, data url.Values,
 			headers map[string]interface{}) (*http.Response, error) {
 			assert.Equal(t, expectedData, data)
-			return &http.Response{Body: ioutil.NopCloser(bytes.NewReader(nil))}, nil
+			return &http.Response{Body: getEmptyBody()}, nil
 		},
 		)
 	twilio := NewApiServiceWithClient(testClient)
@@ -192,7 +193,7 @@ func TestObjectArrayTypeParam(t *testing.T) {
 		DoAndReturn(func(method string, rawURL string, data url.Values,
 			headers map[string]interface{}) (*http.Response, error) {
 			assert.Equal(t, expectedData, data)
-			return &http.Response{Body: ioutil.NopCloser(bytes.NewReader(nil))}, nil
+			return &http.Response{Body: getEmptyBody()}, nil
 		},
 		)
 	twilio := NewApiServiceWithClient(testClient)
@@ -237,9 +238,7 @@ func TestList(t *testing.T) {
 
 			resp, _ := json.Marshal(response)
 
-			return &http.Response{
-				Body: ioutil.NopCloser(bytes.NewReader(resp)),
-			}, nil
+			return &http.Response{Body: ioutil.NopCloser(bytes.NewReader(resp))}, nil
 		},
 		).AnyTimes()
 
@@ -296,9 +295,7 @@ func TestListPaging(t *testing.T) {
 
 			resp, _ := json.Marshal(response)
 
-			return &http.Response{
-				Body: ioutil.NopCloser(bytes.NewReader(resp)),
-			}, nil
+			return &http.Response{Body: ioutil.NopCloser(bytes.NewReader(resp))}, nil
 		},
 		)
 
@@ -320,9 +317,7 @@ func TestListPaging(t *testing.T) {
 
 			resp, _ := json.Marshal(response)
 
-			return &http.Response{
-				Body: ioutil.NopCloser(bytes.NewReader(resp)),
-			}, nil
+			return &http.Response{Body: ioutil.NopCloser(bytes.NewReader(resp))}, nil
 		},
 		)
 
@@ -333,9 +328,7 @@ func TestListPaging(t *testing.T) {
 		gomock.Any()).
 		DoAndReturn(func(method string, rawURL string, data url.Values,
 			headers map[string]interface{}) (*http.Response, error) {
-			return &http.Response{
-				Body: ioutil.NopCloser(bytes.NewReader(nil)),
-			}, nil
+			return &http.Response{Body: getEmptyBody()}, nil
 		},
 		)
 
@@ -388,9 +381,7 @@ func TestListError(t *testing.T) {
 
 			resp, _ := json.Marshal(response)
 
-			return &http.Response{
-				Body: ioutil.NopCloser(bytes.NewReader(resp)),
-			}, errors.New("listing error")
+			return &http.Response{Body: ioutil.NopCloser(bytes.NewReader(resp))}, errors.New("listing error")
 		},
 		).AnyTimes()
 
@@ -404,6 +395,48 @@ func TestListError(t *testing.T) {
 	assert.Len(t, resp, 0)
 	assert.NotNil(t, err)
 	assert.Equal(t, "listing error", err.Error())
+}
+
+func TestListPagingError(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	testClient := NewMockBaseClient(mockCtrl)
+
+	testClient.EXPECT().AccountSid().DoAndReturn(func() string {
+		return "AC222222222222222222222222222222"
+	}).AnyTimes()
+
+	gomock.InOrder(
+		testClient.EXPECT().SendRequest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(method string, rawURL string, data url.Values,
+				headers map[string]interface{}) (*http.Response, error) {
+				response := map[string]interface{}{
+					"recordings": []map[string]interface{}{
+						{
+							"test_string": "first",
+						},
+						{
+							"test_string": "second",
+						},
+					},
+					"next_page_uri": "/2010-04-01/Accounts/AC12345678123456781234567812345678/Calls.json?From=9999999999&PageNumber=&To=4444444444&PageSize=5&Page=1&PageToken=PASMc49f620580b24424bcfa885b1f741130",
+				}
+
+				resp, _ := json.Marshal(response)
+
+				return &http.Response{Body: ioutil.NopCloser(bytes.NewReader(resp))}, nil
+			}),
+		testClient.EXPECT().SendRequest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(method string, rawURL string, data url.Values,
+				headers map[string]interface{}) (*http.Response, error) {
+				return &http.Response{Body: ioutil.NopCloser(bytes.NewReader(nil))}, nil
+			}),
+	)
+
+	twilio := NewApiServiceWithClient(testClient)
+
+	resp, err := twilio.ListCallRecording("CA123", nil)
+	assert.Len(t, resp, 0)
+	assert.NotNil(t, err)
 }
 
 func TestListNoNextPage(t *testing.T) {
@@ -437,9 +470,7 @@ func TestListNoNextPage(t *testing.T) {
 
 			resp, _ := json.Marshal(response)
 
-			return &http.Response{
-				Body: ioutil.NopCloser(bytes.NewReader(resp)),
-			}, nil
+			return &http.Response{Body: ioutil.NopCloser(bytes.NewReader(resp))}, nil
 		}).AnyTimes()
 
 	twilio := NewApiServiceWithClient(testClient)
@@ -471,10 +502,14 @@ func TestPageToken(t *testing.T) {
 		gomock.Any()).
 		DoAndReturn(func(method string, rawURL string, data url.Values, headers map[string]interface{}) (*http.Response, error) {
 			assert.Equal(t, expectedData, data)
-			return &http.Response{Body: ioutil.NopCloser(bytes.NewReader(nil))}, nil
+			return &http.Response{Body: getEmptyBody()}, nil
 		}).AnyTimes()
 
 	twilio := NewApiServiceWithClient(testClient)
 
 	_, _ = twilio.PageCredentialAws(nil, pageToken, pageNumber)
+}
+
+func getEmptyBody() io.ReadCloser {
+	return ioutil.NopCloser(bytes.NewReader([]byte("{}")))
 }

--- a/src/main/resources/twilio-go/api.mustache
+++ b/src/main/resources/twilio-go/api.mustache
@@ -104,60 +104,71 @@ func (c *ApiService) Page{{{vendorExtensions.x-domain-name}}}({{#allParams}}{{#r
 
 // Lists {{{vendorExtensions.x-domain-name}}} records from the API as a list. Unlike stream, this operation is eager and loads 'limit' records into memory before returning.
 func (c *ApiService) List{{{vendorExtensions.x-domain-name}}}({{#allParams}}{{#required}}{{paramName}} {{{dataType}}}{{^last}}, {{/last}}{{/required}}{{/allParams}}params *{{{nickname}}}Params) ({{{returnType}}}, error) {
-    response, err := c.Stream{{{vendorExtensions.x-domain-name}}}({{#allParams}}{{#required}}{{paramName}}{{^last}}, {{/last}}{{/required}}{{/allParams}}params)
-    if err != nil {
-        return nil, err
-    }
+	response, errors := c.Stream{{{vendorExtensions.x-domain-name}}}({{#allParams}}{{#required}}{{paramName}}{{^last}}, {{/last}}{{/required}}{{/allParams}}params)
 
-    records := make({{{returnType}}}, 0)
+	records := make({{{returnType}}}, 0)
+	for record := range response {
+		records = append(records, record)
+	}
 
-    for record := range response {
-        records = append(records, record)
-    }
+	if err := <-errors; err != nil {
+		return nil, err
+	}
 
-    return records, err
+	return records, nil
 }
 
 // Streams {{{vendorExtensions.x-domain-name}}} records from the API as a channel stream. This operation lazily loads records as efficiently as possible until the limit is reached.
-func (c *ApiService) Stream{{{vendorExtensions.x-domain-name}}}({{#allParams}}{{#required}}{{paramName}} {{{dataType}}}{{^last}}, {{/last}}{{/required}}{{/allParams}}params *{{{nickname}}}Params) (chan {{{returnBaseType}}}, error) {
-    if params == nil {
-        params = &{{{nickname}}}Params{}
-    }
-    params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
+func (c *ApiService) Stream{{{vendorExtensions.x-domain-name}}}({{#allParams}}{{#required}}{{paramName}} {{{dataType}}}{{^last}}, {{/last}}{{/required}}{{/allParams}}params *{{{nickname}}}Params) (chan {{{returnBaseType}}}, chan error) {
+	if params == nil {
+		params = &{{{nickname}}}Params{}
+	}
+	params.SetPageSize(client.ReadLimits(params.PageSize, params.Limit))
 
-    response, err := c.Page{{{vendorExtensions.x-domain-name}}}({{#allParams}}{{#required}}{{paramName}}{{^last}}, {{/last}}{{/required}}{{/allParams}}params, "", "")
-    if err != nil {
-        return nil, err
-    }
+	recordChannel := make(chan {{{returnBaseType}}}, 1)
+	errorChannel := make(chan error, 1)
 
-    curRecord := 1
-    //set buffer size of the channel to 1
-    channel := make(chan {{{returnBaseType}}}, 1)
+	response, err := c.Page{{{vendorExtensions.x-domain-name}}}({{#allParams}}{{#required}}{{paramName}}{{^last}}, {{/last}}{{/required}}{{/allParams}}params, "", "")
+	if err != nil {
+		errorChannel <- err
+		close(recordChannel)
+		close(errorChannel)
+	} else {
+		go c.stream{{{vendorExtensions.x-domain-name}}}(response, params, recordChannel, errorChannel)
+	}
 
-    go func() {
-        for response != nil {
-            responseRecords := response.{{{vendorExtensions.x-payload-field-name}}}
-            for item := range responseRecords {
-                channel <- responseRecords[item]
-                curRecord += 1
-                if params.Limit != nil && *params.Limit < curRecord {
-                    close(channel)
-                    return
-                }
-            }
+	return recordChannel, errorChannel
+}
 
-            var record interface{}
-            if record, err = client.GetNext(c.baseURL, response, c.getNext{{{returnContainer}}}); record == nil || err != nil {
-                close(channel)
-                return
-            }
 
-            response = record.(*{{{returnContainer}}})
-        }
-        close(channel)
-    }()
+func (c *ApiService) stream{{{vendorExtensions.x-domain-name}}}(response *{{{returnContainer}}}, params *{{{nickname}}}Params, recordChannel chan {{{returnBaseType}}}, errorChannel chan error) {
+	curRecord := 1
 
-    return channel, err
+	for response != nil {
+		responseRecords := response.{{{vendorExtensions.x-payload-field-name}}}
+		for item := range responseRecords {
+			recordChannel <- responseRecords[item]
+			curRecord += 1
+			if params.Limit != nil && *params.Limit < curRecord {
+				close(recordChannel)
+				close(errorChannel)
+				return
+			}
+		}
+
+		record, err := client.GetNext(c.baseURL, response, c.getNext{{{returnContainer}}})
+		if err != nil {
+			errorChannel <- err
+			break
+		} else if record == nil {
+			break
+		}
+
+		response = record.(*{{{returnContainer}}})
+	}
+
+	close(recordChannel)
+	close(errorChannel)
 }
 
 func (c *ApiService) getNext{{{returnContainer}}}(nextPageUrl string) (interface{}, error) {


### PR DESCRIPTION
This allows for pushing errors while paginating.