### PR TITLE
test: refactor the required body param test to fix regression in prism

### DIFF
--- a/examples/go/go-client/helper/rest/api/v2010/api_test.go
+++ b/examples/go/go-client/helper/rest/api/v2010/api_test.go
@@ -122,13 +122,13 @@ func TestCustomHeaders(t *testing.T) {
 func TestRequiredParameters(t *testing.T) {
 	params := &CreateCallFeedbackSummaryParams{}
 	params.SetStartDate("2021-04-04")
-	params.SetEndDate("2021-04-05")
 
-	// StartDate and EndDate are required parameters
-	resp, err := testApiService.CreateCallFeedbackSummary(nil)
+	// EndDate is a required parameter.
+	resp, err := testApiService.CreateCallFeedbackSummary(params)
 	assert.NotNil(t, err)
 	assert.Nil(t, resp)
 
+	params.SetEndDate("2021-04-05")
 	resp, err = testApiService.CreateCallFeedbackSummary(params)
 
 	assert.Nil(t, err)

--- a/examples/prism/docker-compose.yml
+++ b/examples/prism/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - prism_twilio
 
   prism_twilio:
-    image: stoplight/prism:4.10.1
+    image: stoplight/prism:4
     volumes:
       - ../twilio_api_v2010.yaml:/tmp/oai.yaml
     ports:

--- a/examples/prism/docker-compose.yml
+++ b/examples/prism/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - prism_twilio
 
   prism_twilio:
-    image: stoplight/prism:4
+    image: stoplight/prism:4.10.1
     volumes:
       - ../twilio_api_v2010.yaml:/tmp/oai.yaml
     ports:

--- a/prism.sh
+++ b/prism.sh
@@ -2,7 +2,7 @@
 set -e
 
 cd examples/prism
-docker-compose build
+docker-compose build --pull
 docker-compose up -d --force-recreate --remove-orphans
 
 function wait_for() {


### PR DESCRIPTION
Seeing a regression in prism where an operation with required body params was not being rejected when no body was present. Updated to sending one of the required params but not both.

Relates to https://github.com/stoplightio/prism/pull/2103