### PR TITLE
fix: update node getter functions to only require last path param

### DIFF
--- a/examples/node/lib/rest/api/v2010/account/call.ts
+++ b/examples/node/lib/rest/api/v2010/account/call.ts
@@ -35,8 +35,8 @@ export interface CallListInstanceCreateOptions {
 
 
 export interface CallListInstance {
-    (accountSid: string, testInteger: number): CallContext;
-    get(accountSid: string, testInteger: number): CallContext;
+    (testInteger: number): CallContext;
+    get(testInteger: number): CallContext;
 
     feedback_call_summary: FeedbackCallSummaryListInstance;
 
@@ -69,9 +69,9 @@ class CallListInstanceImpl implements CallListInstance {
 }
 
 export function CallListInstance(version: V2010, accountSid: string): CallListInstance {
-    const instance = ((accountSid, testInteger) => instance.get(accountSid, testInteger)) as CallListInstanceImpl;
+    const instance = ((testInteger) => instance.get(testInteger)) as CallListInstanceImpl;
 
-    instance.get = function get(accountSid, testInteger): CallContext {
+    instance.get = function get(testInteger): CallContext {
         return new CallContextImpl(version, accountSid, testInteger);
     }
 

--- a/examples/node/spec/unit/account/call.spec.ts
+++ b/examples/node/spec/unit/account/call.spec.ts
@@ -25,7 +25,7 @@ describe('call', () => {
             .get('/v2010/2010-04-01/Accounts/123/Calls/1.json')
             .reply(307, {account_sid: '123', sid: 1});
 
-        return twilio.api.v2010.accounts('123').calls('123', 1).fetch()
+        return twilio.api.v2010.accounts('123').calls(1).fetch()
             .then(() => scope.done());
     });
 
@@ -34,7 +34,7 @@ describe('call', () => {
             .delete('/v2010/2010-04-01/Accounts/123/Calls/1.json')
             .reply(204);
 
-        return twilio.api.v2010.accounts('123').calls('123', 1).remove()
+        return twilio.api.v2010.accounts('123').calls(1).remove()
             .then(() => scope.done());
     });
 
@@ -51,5 +51,4 @@ describe('call', () => {
             .create({endDate: '2022-08-01', startDate: '2022-08-01'})
             .then(() => scope.done())
     });
-
 });

--- a/src/main/resources/twilio-node/api-single.mustache
+++ b/src/main/resources/twilio-node/api-single.mustache
@@ -35,8 +35,8 @@ export interface {{resourceName}}{{vendorExtensions.x-name}}Options {
 
 export interface {{resourceName}} {
     {{#instanceResource}}
-    ({{#resourcePathParams}}{{paramName}}: {{dataType}}{{^-last}}, {{/-last}}{{/resourcePathParams}}): {{resourceName}};
-    get({{#resourcePathParams}}{{paramName}}: {{dataType}}{{^-last}}, {{/-last}}{{/resourcePathParams}}): {{resourceName}};
+    ({{#resourcePathParams}}{{#-last}}{{paramName}}: {{dataType}}{{/-last}}{{/resourcePathParams}}): {{resourceName}};
+    get({{#resourcePathParams}}{{#-last}}{{paramName}}: {{dataType}}{{/-last}}{{/resourcePathParams}}): {{resourceName}};
     {{/instanceResource}}
 
     {{#dependents}}
@@ -109,9 +109,9 @@ class {{resourceName}}Impl implements {{resourceName}} {
 
 export function {{resourceName}}(version: {{apiVersionClass}}{{#resourcePathParams}}, {{paramName}}: {{{dataType}}}{{/resourcePathParams}}): {{resourceName}} {
     {{#instanceResource}}
-    const instance = (({{#resourcePathParams}}{{paramName}}{{^-last}}, {{/-last}}{{/resourcePathParams}}) => instance.get({{#resourcePathParams}}{{paramName}}{{^-last}}, {{/-last}}{{/resourcePathParams}})) as {{parentResourceName}}Impl;
+    const instance = (({{#resourcePathParams}}{{#-last}}{{paramName}}{{/-last}}{{/resourcePathParams}}) => instance.get({{#resourcePathParams}}{{#-last}}{{paramName}}{{/-last}}{{/resourcePathParams}})) as {{parentResourceName}}Impl;
 
-    instance.get = function get({{#resourcePathParams}}{{paramName}}{{^-last}}, {{/-last}}{{/resourcePathParams}}): {{resourceName}} {
+    instance.get = function get({{#resourcePathParams}}{{#-last}}{{paramName}}{{/-last}}{{/resourcePathParams}}): {{resourceName}} {
         return new {{resourceName}}Impl(version{{#resourcePathParams}}, {{paramName}}{{/resourcePathParams}});
     }
     {{/instanceResource}}


### PR DESCRIPTION
All other path params come from the parent container.