### PR TITLE
chore: refactor ConventionResolver to be more reusable

### DIFF
--- a/src/main/java/com/twilio/oai/TwilioJavaGenerator.java
+++ b/src/main/java/com/twilio/oai/TwilioJavaGenerator.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 
 import com.twilio.oai.common.EnumConstants;
+import com.twilio.oai.common.Utility;
 import com.twilio.oai.mlambdas.ReplaceHyphenLambda;
 import com.twilio.oai.resolver.java.JavaCaseResolver;
 import com.twilio.oai.resource.ResourceMap;
@@ -201,6 +202,7 @@ public class TwilioJavaGenerator extends JavaClientCodegen {
                     .collect(Collectors.toCollection(() -> this.allModels));
         }
         setObjectFormatMap(this.allModels);
+        Utility.setComplexDataMapping(this.allModels, this.modelFormatMap);
         // Return an empty collection so no model files get generated.
         return new HashMap<>();
     }
@@ -619,20 +621,6 @@ public class TwilioJavaGenerator extends JavaClientCodegen {
         catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private void setObjectFormatMap(final List<CodegenModel> allModels) {
-        allModels.forEach(item -> {
-            ObjectMapper objectMapper = new ObjectMapper();
-            try {
-                JsonNode jsonNode = objectMapper.readTree(item.modelJson);
-                if (jsonNode.get("type").textValue().equals("object") && jsonNode.has("format")) {
-                    modelFormatMap.put(item.classFilename, jsonNode.get("format").textValue());
-                }
-            } catch (JsonProcessingException e) {
-                e.printStackTrace();
-            }
-        });
     }
 
     private void updateCodeOperationParams(final CodegenOperation co, String resourceName) {

--- a/src/main/java/com/twilio/oai/TwilioJavaGenerator.java
+++ b/src/main/java/com/twilio/oai/TwilioJavaGenerator.java
@@ -9,6 +9,7 @@ import com.twilio.oai.common.EnumConstants;
 import com.twilio.oai.common.Utility;
 import com.twilio.oai.mlambdas.ReplaceHyphenLambda;
 import com.twilio.oai.resolver.java.JavaCaseResolver;
+import com.twilio.oai.resolver.java.JavaConventionResolver;
 import com.twilio.oai.resource.ResourceMap;
 
 import io.swagger.v3.oas.models.OpenAPI;
@@ -201,7 +202,6 @@ public class TwilioJavaGenerator extends JavaClientCodegen {
                     .map(CodegenModel.class::cast)
                     .collect(Collectors.toCollection(() -> this.allModels));
         }
-        setObjectFormatMap(this.allModels);
         Utility.setComplexDataMapping(this.allModels, this.modelFormatMap);
         // Return an empty collection so no model files get generated.
         return new HashMap<>();
@@ -277,7 +277,7 @@ public class TwilioJavaGenerator extends JavaClientCodegen {
             co.queryParams = preProcessQueryParameters(co);
             co.pathParams = null;
             co.hasParams = !co.allParams.isEmpty();
-            co.allParams.forEach(ConventionResolver::resolveParamTypes);
+            co.allParams.forEach(JavaConventionResolver::resolveParamTypes);
             co.hasRequiredParams = !co.requiredParams.isEmpty();
             resource.put("resourcePathParams", co.pathParams);
             resource.put("resourceRequiredParams", co.requiredParams);
@@ -292,8 +292,8 @@ public class TwilioJavaGenerator extends JavaClientCodegen {
               .map(response -> response.dataType)
               .filter(Objects::nonNull)
               .map(modelName -> this.getModelCoPath(modelName, co, recordKey))
-              .map(ConventionResolver::resolve)
-              .map(item -> ConventionResolver.resolveComplexType(item, modelFormatMap))
+              .map(JavaConventionResolver::resolve)
+              .map(item -> JavaConventionResolver.resolveComplexType(item, modelFormatMap))
               .flatMap(Optional::stream)
               .forEach(model -> {
                   resource.put("serialVersionUID", calculateSerialVersionUid(model.vars));
@@ -626,46 +626,46 @@ public class TwilioJavaGenerator extends JavaClientCodegen {
     private void updateCodeOperationParams(final CodegenOperation co, String resourceName) {
         co.allParams = co.allParams
                 .stream()
-                .map(ConventionResolver::resolveParameter)
+                .map(JavaConventionResolver::resolveParameter)
                 .map(Optional::get)
                 .map(item -> this.resolveEnumParameter(item, resourceName))
                 .collect(Collectors.toList());
         co.pathParams = co.pathParams
                 .stream()
-                .map(ConventionResolver::resolveParameter)
+                .map(JavaConventionResolver::resolveParameter)
                 .map(Optional::get)
                 .map(item -> this.resolveEnumParameter(item, resourceName))
                 .collect(Collectors.toList());
         co.pathParams.stream().
-                map(ConventionResolver::resolveParamTypes)
+                map(JavaConventionResolver::resolveParamTypes)
                 .map(item -> this.resolveEnumParameter(item, resourceName))
                 .forEach(param -> param.paramName = "path"+param.paramName);
-        co.queryParams = co.queryParams.stream().map(ConventionResolver::resolveParameter)
+        co.queryParams = co.queryParams.stream().map(JavaConventionResolver::resolveParameter)
                 .map(Optional::get)
-                .map(ConventionResolver::prefixedCollapsibleMap)
+                .map(JavaConventionResolver::prefixedCollapsibleMap)
                 .map(item -> this.resolveEnumParameter(item, resourceName))
                 .collect(Collectors.toList());
         co.queryParams = preProcessQueryParameters(co);
-        co.formParams = co.formParams.stream().map(ConventionResolver::resolveParameter)
+        co.formParams = co.formParams.stream().map(JavaConventionResolver::resolveParameter)
                 .map(Optional::get)
-                .map(ConventionResolver::prefixedCollapsibleMap)
+                .map(JavaConventionResolver::prefixedCollapsibleMap)
                 .map(item -> this.resolveEnumParameter(item, resourceName))
                 .collect(Collectors.toList());
         co.formParams = preProcessFormParams(co);
-        co.headerParams = co.headerParams.stream().map(ConventionResolver::resolveParameter)
+        co.headerParams = co.headerParams.stream().map(JavaConventionResolver::resolveParameter)
                 .map(Optional::get)
-                .map(ConventionResolver::prefixedCollapsibleMap)
+                .map(JavaConventionResolver::prefixedCollapsibleMap)
                 .map(item -> this.resolveEnumParameter(item, resourceName))
                 .collect(Collectors.toList());
         co.optionalParams = co.optionalParams
                 .stream()
-                .map(ConventionResolver::resolveParameter)
+                .map(JavaConventionResolver::resolveParameter)
                 .map(Optional::get)
                 .map(item -> this.resolveEnumParameter(item, resourceName))
                 .collect(Collectors.toList());
         co.requiredParams = co.requiredParams
                 .stream()
-                .map(ConventionResolver::resolveParameter)
+                .map(JavaConventionResolver::resolveParameter)
                 .map(Optional::get)
                 .map(item -> this.resolveEnumParameter(item, resourceName))
                 .collect(Collectors.toList());

--- a/src/main/java/com/twilio/oai/TwilioJavaGenerator.java
+++ b/src/main/java/com/twilio/oai/TwilioJavaGenerator.java
@@ -295,9 +295,8 @@ public class TwilioJavaGenerator extends JavaClientCodegen {
               .map(response -> response.dataType)
               .filter(Objects::nonNull)
               .map(modelName -> this.getModelCoPath(modelName, co, recordKey))
-              .map(conventionResolver::resolve)
+              .map(item -> conventionResolver.resolve(item.get()))
               .map(item -> conventionResolver.resolveComplexType(item, modelFormatMap))
-              .flatMap(Optional::stream)
               .forEach(model -> {
                   resource.put("serialVersionUID", calculateSerialVersionUid(model.vars));
                   CodegenModel responseModel = processEnumVarsForAll(model, co, resourceName);
@@ -639,13 +638,11 @@ public class TwilioJavaGenerator extends JavaClientCodegen {
         co.allParams = co.allParams
                 .stream()
                 .map(conventionResolver::resolveParameter)
-                .map(Optional::get)
                 .map(item -> this.resolveEnumParameter(item, resourceName))
                 .collect(Collectors.toList());
         co.pathParams = co.pathParams
                 .stream()
                 .map(conventionResolver::resolveParameter)
-                .map(Optional::get)
                 .map(item -> this.resolveEnumParameter(item, resourceName))
                 .collect(Collectors.toList());
         co.pathParams.stream().
@@ -653,32 +650,27 @@ public class TwilioJavaGenerator extends JavaClientCodegen {
                 .map(item -> this.resolveEnumParameter(item, resourceName))
                 .forEach(param -> param.paramName = "path"+param.paramName);
         co.queryParams = co.queryParams.stream().map(conventionResolver::resolveParameter)
-                .map(Optional::get)
                 .map(conventionResolver::prefixedCollapsibleMap)
                 .map(item -> this.resolveEnumParameter(item, resourceName))
                 .collect(Collectors.toList());
         co.queryParams = preProcessQueryParameters(co);
         co.formParams = co.formParams.stream().map(conventionResolver::resolveParameter)
-                .map(Optional::get)
                 .map(conventionResolver::prefixedCollapsibleMap)
                 .map(item -> this.resolveEnumParameter(item, resourceName))
                 .collect(Collectors.toList());
         co.formParams = preProcessFormParams(co);
         co.headerParams = co.headerParams.stream().map(conventionResolver::resolveParameter)
-                .map(Optional::get)
                 .map(conventionResolver::prefixedCollapsibleMap)
                 .map(item -> this.resolveEnumParameter(item, resourceName))
                 .collect(Collectors.toList());
         co.optionalParams = co.optionalParams
                 .stream()
                 .map(conventionResolver::resolveParameter)
-                .map(Optional::get)
                 .map(item -> this.resolveEnumParameter(item, resourceName))
                 .collect(Collectors.toList());
         co.requiredParams = co.requiredParams
                 .stream()
                 .map(conventionResolver::resolveParameter)
-                .map(Optional::get)
                 .map(item -> this.resolveEnumParameter(item, resourceName))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/twilio/oai/common/EnumConstants.java
+++ b/src/main/java/com/twilio/oai/common/EnumConstants.java
@@ -31,8 +31,24 @@ public class EnumConstants {
 
     @Getter
     @RequiredArgsConstructor
-    public enum CsharpDataTypes {
+    public enum CsharpDataTypes implements LanguageDataType {
         LIST("List<");
+
+        private final String value;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum JavaDataTypes implements LanguageDataType {
+        LIST("List<");
+
+        private final String value;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum NodeDataTypes implements LanguageDataType {
+        LIST("Array<");
 
         private final String value;
     }

--- a/src/main/java/com/twilio/oai/common/LanguageDataType.java
+++ b/src/main/java/com/twilio/oai/common/LanguageDataType.java
@@ -1,0 +1,5 @@
+package com.twilio.oai.common;
+
+public interface LanguageDataType {
+    String getValue();
+}

--- a/src/main/java/com/twilio/oai/resolver/common/CodegenModelComplexResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/common/CodegenModelComplexResolver.java
@@ -1,7 +1,6 @@
 package com.twilio.oai.resolver.common;
 
 import com.twilio.oai.Segments;
-import com.twilio.oai.StringHelper;
 import com.twilio.oai.resolver.Resolver;
 import org.openapitools.codegen.CodegenProperty;
 
@@ -12,6 +11,13 @@ public class CodegenModelComplexResolver implements Resolver<CodegenProperty> {
 
     private Map<String, Map<String, Object>> conventionMap;
     private Map<String, String> modelFormatMap = new HashMap<>();
+    private String listStart;
+    private String listEnd;
+
+    public CodegenModelComplexResolver(final String listStart, final String listEnd) {
+        this.listStart = listStart;
+        this.listEnd = listEnd;
+    }
 
     public CodegenProperty resolve(CodegenProperty property){
         if (this.modelFormatMap.isEmpty()) {
@@ -23,8 +29,11 @@ public class CodegenModelComplexResolver implements Resolver<CodegenProperty> {
             String complexType = modelFormatMap.get(property.complexType);
 
             if (propertyMap.containsKey(complexType)) {
-                final String resolvedDataType = (String)propertyMap.get(complexType);
-                property.dataType = resolvedDataType;
+                if (property.containerType != null && property.containerType.equals("array")) {
+                    property.dataType = listStart + propertyMap.get(complexType) + listEnd;
+                } else {
+                    property.dataType = (String)propertyMap.get(complexType);
+                }
             }
         }
         return property;

--- a/src/main/java/com/twilio/oai/resolver/common/CodegenModelComplexResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/common/CodegenModelComplexResolver.java
@@ -1,0 +1,40 @@
+package com.twilio.oai.resolver.common;
+
+import com.twilio.oai.Segments;
+import com.twilio.oai.StringHelper;
+import com.twilio.oai.resolver.Resolver;
+import org.openapitools.codegen.CodegenProperty;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CodegenModelComplexResolver implements Resolver<CodegenProperty> {
+
+    private Map<String, Map<String, Object>> conventionMap;
+    private Map<String, String> modelFormatMap = new HashMap<>();
+
+    public CodegenProperty resolve(CodegenProperty property){
+        if (this.modelFormatMap.isEmpty()) {
+            return property;
+        }
+
+        if (modelFormatMap.containsKey(property.complexType)) {
+            Map<String, Object> propertyMap = conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment());
+            String complexType = modelFormatMap.get(property.complexType);
+
+            if (propertyMap.containsKey(complexType)) {
+                final String resolvedDataType = (String)propertyMap.get(complexType);
+                property.dataType = resolvedDataType;
+            }
+        }
+        return property;
+    }
+
+    public void setConventionalMap(Map<String, Map<String, Object>> conventionMap) {
+        this.conventionMap = conventionMap;
+    }
+
+    public void setModelFormatMap(final Map<String, String> modelFormatMap) {
+        this.modelFormatMap = new HashMap<>(modelFormatMap);
+    }
+}

--- a/src/main/java/com/twilio/oai/resolver/common/CodegenModelContainerDataTypeResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/common/CodegenModelContainerDataTypeResolver.java
@@ -12,7 +12,8 @@ public class CodegenModelContainerDataTypeResolver implements Resolver<CodegenPr
     private CodegenModelDataTypeResolver codegenModelDataTypeResolver;
     private List<? extends LanguageDataType> languageDataTypes;
 
-    public CodegenModelContainerDataTypeResolver(CodegenModelDataTypeResolver codegenModelDataTypeResolver, List<? extends LanguageDataType> languageDataTypes) {
+    public CodegenModelContainerDataTypeResolver(CodegenModelDataTypeResolver codegenModelDataTypeResolver,
+                                                 List<? extends LanguageDataType> languageDataTypes) {
         this.codegenModelDataTypeResolver = codegenModelDataTypeResolver;
         this.languageDataTypes = languageDataTypes;
     }

--- a/src/main/java/com/twilio/oai/resolver/common/CodegenModelContainerDataTypeResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/common/CodegenModelContainerDataTypeResolver.java
@@ -1,0 +1,63 @@
+package com.twilio.oai.resolver.common;
+
+import com.twilio.oai.common.ApplicationConstants;
+import com.twilio.oai.common.LanguageDataType;
+import com.twilio.oai.resolver.Resolver;
+import org.openapitools.codegen.CodegenProperty;
+
+import java.util.List;
+import java.util.Stack;
+
+public class CodegenModelContainerDataTypeResolver implements Resolver<CodegenProperty> {
+    private CodegenModelDataTypeResolver codegenModelDataTypeResolver;
+    private List<? extends LanguageDataType> languageDataTypes;
+
+    public CodegenModelContainerDataTypeResolver(CodegenModelDataTypeResolver codegenModelDataTypeResolver, List<? extends LanguageDataType> languageDataTypes) {
+        this.codegenModelDataTypeResolver = codegenModelDataTypeResolver;
+        this.languageDataTypes = languageDataTypes;
+    }
+
+    public CodegenProperty resolve(CodegenProperty codegenProperty) {
+        Stack<String> containerTypes = new Stack<>();
+
+        codegenProperty.dataType = unwrapContainerType(codegenProperty,containerTypes);
+        codegenModelDataTypeResolver.resolve(codegenProperty);
+        rewrapContainerType(codegenProperty,containerTypes);
+
+        return codegenProperty;
+    }
+
+    private String unwrapContainerType(CodegenProperty codegenProperty,Stack<String> containerTypes) {
+        String codegenPropertyDataType = "";
+        codegenPropertyDataType = codegenProperty.dataType;
+
+        String currentContainerType = "";
+        boolean isContainerType = false;
+
+        while(codegenPropertyDataType != null && !codegenPropertyDataType.isEmpty()) {
+            for (LanguageDataType dataType : languageDataTypes) {
+                if (codegenPropertyDataType.startsWith(dataType.getValue())) {
+                    isContainerType = true;
+                    currentContainerType = dataType.getValue();
+                }
+            }
+            if(isContainerType) {
+                containerTypes.push(currentContainerType);
+                codegenPropertyDataType = codegenPropertyDataType.replaceFirst(currentContainerType, "");
+                codegenPropertyDataType = codegenPropertyDataType.substring(0, codegenPropertyDataType.length()-1);
+                isContainerType = false;
+            }
+            else
+                return codegenPropertyDataType;
+        }
+        return codegenPropertyDataType;
+    }
+
+    private static void rewrapContainerType(CodegenProperty codegenProperty,Stack<String> containerTypes) {
+        String currentContainerType = "";
+        while(!containerTypes.empty()) {
+            currentContainerType = containerTypes.pop();
+            codegenProperty.dataType = currentContainerType + codegenProperty.dataType + ApplicationConstants.LIST_END;
+        }
+    }
+}

--- a/src/main/java/com/twilio/oai/resolver/common/CodegenModelDataTypeResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/common/CodegenModelDataTypeResolver.java
@@ -7,14 +7,23 @@ import org.openapitools.codegen.CodegenProperty;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.twilio.oai.common.ApplicationConstants.LIST_START;
+import static com.twilio.oai.common.ApplicationConstants.OBJECT;
+
 public class CodegenModelDataTypeResolver implements Resolver<CodegenProperty> {
 
     private Map<String, Map<String, Object>> conventionMap;
-    private CodegenModelComplexResolver codegenModelComplexResolver = new CodegenModelComplexResolver();
+    private CodegenModelComplexResolver codegenModelComplexResolver;
     private  Map<String, String> modelFormatMap = new HashMap<>();
+
+    public CodegenModelDataTypeResolver(final String listStart, final String listEnd) {
+        codegenModelComplexResolver = new CodegenModelComplexResolver(listStart, listEnd);
+    }
 
     public CodegenProperty resolve(CodegenProperty property) {
         assignDataType(property);
+        // Exceptional case, data format does not exist for Object type.
+        assignDataTypeObjectForNullDataFormat(property);
 
         if (property.complexType != null && modelFormatMap.containsKey(property.complexType)) {
             codegenModelComplexResolver.setModelFormatMap(modelFormatMap);
@@ -32,6 +41,16 @@ public class CodegenModelDataTypeResolver implements Resolver<CodegenProperty> {
             property.dataType = (String)conventionMap.get(propertyFieldName).get(property.dataFormat);
         } else if (conventionMap.get(propertyFieldName).containsKey(property.dataType)) {
             property.dataType = (String)conventionMap.get(propertyFieldName).get(property.dataType);
+        }
+    }
+
+    private void assignDataTypeObjectForNullDataFormat(CodegenProperty property){
+        if (property.dataFormat == null) {
+            if (property.dataType.equals(OBJECT)) {
+                property.dataType = "object";
+            } else if (property.dataType.equals(LIST_START + OBJECT )) {
+                property.dataType = "List<object";
+            }
         }
     }
 

--- a/src/main/java/com/twilio/oai/resolver/common/CodegenModelDataTypeResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/common/CodegenModelDataTypeResolver.java
@@ -1,0 +1,45 @@
+package com.twilio.oai.resolver.common;
+
+import com.twilio.oai.Segments;
+import com.twilio.oai.resolver.Resolver;
+import org.openapitools.codegen.CodegenProperty;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CodegenModelDataTypeResolver implements Resolver<CodegenProperty> {
+
+    private Map<String, Map<String, Object>> conventionMap;
+    private CodegenModelComplexResolver codegenModelComplexResolver = new CodegenModelComplexResolver();
+    private  Map<String, String> modelFormatMap = new HashMap<>();
+
+    public CodegenProperty resolve(CodegenProperty property) {
+        assignDataType(property);
+
+        if (property.complexType != null && modelFormatMap.containsKey(property.complexType)) {
+            codegenModelComplexResolver.setModelFormatMap(modelFormatMap);
+            codegenModelComplexResolver.setConventionalMap(conventionMap);
+            codegenModelComplexResolver.resolve(property);
+        }
+
+        return property;
+    }
+
+    private void assignDataType(CodegenProperty property) {
+        String propertyFieldName = Segments.SEGMENT_PROPERTIES.getSegment();
+
+        if (conventionMap.get(propertyFieldName).containsKey(property.dataFormat)) {
+            property.dataType = (String)conventionMap.get(propertyFieldName).get(property.dataFormat);
+        } else if (conventionMap.get(propertyFieldName).containsKey(property.dataType)) {
+            property.dataType = (String)conventionMap.get(propertyFieldName).get(property.dataType);
+        }
+    }
+
+    public void setConventionMap(Map<String, Map<String, Object>> conventionMap) {
+        this.conventionMap = conventionMap;
+    }
+
+    public void setModelFormatMap(final Map<String, String> modelFormatMap) {
+        this.modelFormatMap = new HashMap<>(modelFormatMap);
+    }
+}

--- a/src/main/java/com/twilio/oai/resolver/common/CodegenModelResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/common/CodegenModelResolver.java
@@ -14,13 +14,18 @@ public class CodegenModelResolver implements Resolver<CodegenModel> {
     private List<? extends LanguageDataType> languageDataTypes;
     private String className;
     private Map<String, String> modelFormatMap;
-    private CodegenModelDataTypeResolver codegenModelDataTypeResolver = new CodegenModelDataTypeResolver();
+    private CodegenModelDataTypeResolver codegenModelDataTypeResolver;
     private CodegenModelContainerDataTypeResolver codegenModelContainerDataTypeResolver;
 
-    public CodegenModelResolver(Map<String, Map<String, Object>> conventionMap, List<? extends LanguageDataType> languageDataTypes) {
+    public CodegenModelResolver(Map<String, Map<String, Object>> conventionMap,
+                                List<? extends LanguageDataType> languageDataTypes,
+                                String listStart,
+                                String listEnd) {
         this.conventionMap = conventionMap;
         this.languageDataTypes = languageDataTypes;
-        codegenModelContainerDataTypeResolver = new CodegenModelContainerDataTypeResolver(codegenModelDataTypeResolver, languageDataTypes);
+        codegenModelDataTypeResolver = new CodegenModelDataTypeResolver(listStart, listEnd);
+        codegenModelContainerDataTypeResolver = new CodegenModelContainerDataTypeResolver(codegenModelDataTypeResolver,
+                languageDataTypes);
     }
 
     @Override

--- a/src/main/java/com/twilio/oai/resolver/common/CodegenModelResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/common/CodegenModelResolver.java
@@ -5,6 +5,7 @@ import com.twilio.oai.resolver.Resolver;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenProperty;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -13,7 +14,7 @@ public class CodegenModelResolver implements Resolver<CodegenModel> {
     private Map<String, Map<String, Object>> conventionMap;
     private List<? extends LanguageDataType> languageDataTypes;
     private String className;
-    private Map<String, String> modelFormatMap;
+    private Map<String, String> modelFormatMap = new HashMap<>();
     private CodegenModelDataTypeResolver codegenModelDataTypeResolver;
     private CodegenModelContainerDataTypeResolver codegenModelContainerDataTypeResolver;
 

--- a/src/main/java/com/twilio/oai/resolver/common/CodegenModelResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/common/CodegenModelResolver.java
@@ -1,0 +1,62 @@
+package com.twilio.oai.resolver.common;
+
+import com.twilio.oai.common.LanguageDataType;
+import com.twilio.oai.resolver.Resolver;
+import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.CodegenProperty;
+
+import java.util.List;
+import java.util.Map;
+
+public class CodegenModelResolver implements Resolver<CodegenModel> {
+
+    private Map<String, Map<String, Object>> conventionMap;
+    private List<? extends LanguageDataType> languageDataTypes;
+    private String className;
+    private Map<String, String> modelFormatMap;
+    private CodegenModelDataTypeResolver codegenModelDataTypeResolver = new CodegenModelDataTypeResolver();
+    private CodegenModelContainerDataTypeResolver codegenModelContainerDataTypeResolver;
+
+    public CodegenModelResolver(Map<String, Map<String, Object>> conventionMap, List<? extends LanguageDataType> languageDataTypes) {
+        this.conventionMap = conventionMap;
+        this.languageDataTypes = languageDataTypes;
+        codegenModelContainerDataTypeResolver = new CodegenModelContainerDataTypeResolver(codegenModelDataTypeResolver, languageDataTypes);
+    }
+
+    @Override
+    public CodegenModel resolve(CodegenModel model) {
+        if (model == null) {
+            return null;
+        }
+
+        for (CodegenProperty property : model.vars) {
+            codegenModelDataTypeResolver.setModelFormatMap(modelFormatMap);
+            codegenModelDataTypeResolver.setConventionMap(conventionMap);
+
+            if (isContainerType(property)) {
+                codegenModelContainerDataTypeResolver.resolve(property);
+            } else {
+                codegenModelDataTypeResolver.resolve(property);
+            }
+        }
+
+        return model;
+    }
+
+    private boolean isContainerType(CodegenProperty codegenProperty) {
+        for (LanguageDataType dataType : languageDataTypes) {
+            if (codegenProperty.dataType != null && codegenProperty.dataType.startsWith(dataType.getValue())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
+    public void setModelFormatMap(Map<String, String> modelFormatMap) {
+        this.modelFormatMap = modelFormatMap;
+    }
+}

--- a/src/main/java/com/twilio/oai/resolver/common/CodegenParameterContainerDataTypeResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/common/CodegenParameterContainerDataTypeResolver.java
@@ -1,0 +1,45 @@
+package com.twilio.oai.resolver.common;
+
+import com.twilio.oai.common.ApplicationConstants;
+import com.twilio.oai.common.LanguageDataType;
+import com.twilio.oai.resolver.Resolver;
+import org.openapitools.codegen.CodegenParameter;
+
+import java.util.List;
+
+public class CodegenParameterContainerDataTypeResolver implements Resolver<CodegenParameter> {
+
+    private CodegenParameterDataTypeResolver codegenParameterDataTypeResolver;
+    private List<? extends LanguageDataType> languageDataTypes;
+
+    public CodegenParameterContainerDataTypeResolver(CodegenParameterDataTypeResolver codegenParameterDataTypeResolver,
+                                                     List<? extends LanguageDataType> languageDataTypes) {
+        this.codegenParameterDataTypeResolver = codegenParameterDataTypeResolver;
+        this.languageDataTypes = languageDataTypes;
+    }
+
+    public CodegenParameter resolve(CodegenParameter parameter) {
+        String unwrappedContainer = unwrapContainerType(parameter);
+        codegenParameterDataTypeResolver.resolve(parameter);
+        rewrapContainerType(parameter,unwrappedContainer);
+        return parameter;
+    }
+
+    private String unwrapContainerType(CodegenParameter parameter) {
+        String unwrappedContainer = null;
+        for (LanguageDataType dataType: languageDataTypes) {
+            if (parameter.dataType != null && parameter.dataType.startsWith(dataType.getValue())) {
+                unwrappedContainer = dataType.getValue();
+                break;
+            }
+        }
+        parameter.dataType = parameter.dataType.replace(unwrappedContainer, "");
+        parameter.dataType = parameter.dataType.substring(0, parameter.dataType.length()-1);
+
+        return unwrappedContainer;
+    }
+
+    private void rewrapContainerType(CodegenParameter parameter,String unwrappedContainer) {
+        parameter.dataType = unwrappedContainer + parameter.dataType + ApplicationConstants.LIST_END;
+    }
+}

--- a/src/main/java/com/twilio/oai/resolver/common/CodegenParameterDataTypeResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/common/CodegenParameterDataTypeResolver.java
@@ -1,0 +1,31 @@
+package com.twilio.oai.resolver.common;
+
+import com.twilio.oai.Segments;
+import com.twilio.oai.resolver.Resolver;
+import org.openapitools.codegen.CodegenParameter;
+
+import java.util.Map;
+
+public class CodegenParameterDataTypeResolver implements Resolver<CodegenParameter> {
+
+    private Map<String, Map<String, Object>> conventionMap;
+
+    public CodegenParameter resolve(CodegenParameter parameter) {
+        assignDataType(parameter);
+        return parameter;
+    }
+
+    private void assignDataType(CodegenParameter parameter){
+        String propertyFieldName = Segments.SEGMENT_PROPERTIES.getSegment();
+
+        if (conventionMap.get(propertyFieldName).containsKey(parameter.dataFormat)) {
+            parameter.dataType = (String) conventionMap.get(propertyFieldName).get(parameter.dataFormat);
+        } else if (conventionMap.get(propertyFieldName).containsKey(parameter.dataType)) {
+            parameter.dataType = (String) conventionMap.get(propertyFieldName).get(parameter.dataType);
+        }
+    }
+
+    public void setConventionMap(Map<String, Map<String, Object>> conventionMap) {
+        this.conventionMap = conventionMap;
+    }
+}

--- a/src/main/java/com/twilio/oai/resolver/common/CodegenParameterResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/common/CodegenParameterResolver.java
@@ -1,0 +1,49 @@
+package com.twilio.oai.resolver.common;
+
+import com.twilio.oai.common.LanguageDataType;
+import com.twilio.oai.resolver.Resolver;
+import org.openapitools.codegen.CodegenParameter;
+
+import java.util.List;
+import java.util.Map;
+
+public class CodegenParameterResolver implements Resolver<CodegenParameter> {
+
+    private final Map<String, Map<String, Object>> conventionMap;
+    private List<? extends LanguageDataType> languageDataTypes;
+    private CodegenParameterDataTypeResolver codegenParameterDataTypeResolver = new CodegenParameterDataTypeResolver();
+    private CodegenParameterContainerDataTypeResolver codegenParameterContainerDataTypeResolver;
+
+    public CodegenParameterResolver(Map<String, Map<String, Object>> conventionMap,
+                                    List<? extends LanguageDataType> languageDataTypes) {
+        this.conventionMap = conventionMap;
+        this.languageDataTypes = languageDataTypes;
+        codegenParameterContainerDataTypeResolver = new CodegenParameterContainerDataTypeResolver(codegenParameterDataTypeResolver,
+                languageDataTypes);
+    }
+
+    public CodegenParameter resolve(CodegenParameter parameter) {
+        if (parameter == null) {
+            return null;
+        }
+
+        codegenParameterDataTypeResolver.setConventionMap(conventionMap);
+
+        if (isContainerType(parameter)) {
+            codegenParameterContainerDataTypeResolver.resolve(parameter);
+        } else {
+            codegenParameterDataTypeResolver.resolve(parameter);
+        }
+
+        return parameter;
+    }
+
+    private boolean isContainerType(CodegenParameter parameter) {
+        for (LanguageDataType dataType : languageDataTypes) {
+            if (parameter.dataType != null && parameter.dataType.startsWith(dataType.getValue())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/twilio/oai/resolver/java/JavaConventionResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/java/JavaConventionResolver.java
@@ -2,59 +2,54 @@ package com.twilio.oai.resolver.java;
 
 import java.util.*;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.oai.Segments;
 import com.twilio.oai.StringHelper;
 import com.twilio.oai.common.ApplicationConstants;
+import com.twilio.oai.common.EnumConstants;
+import com.twilio.oai.resolver.common.CodegenModelResolver;
+import com.twilio.oai.resolver.common.CodegenParameterResolver;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenParameter;
 import org.openapitools.codegen.CodegenProperty;
 
 public class JavaConventionResolver {
-    final static Map<String, Map<String, Object>> conventionMap = getConventionalMap() ;
-    final static String VENDOR_PREFIX = "x-";
-    final static String PREFIXED_COLLAPSIBLE_MAP = "prefixed-collapsible-map";
-    final static String X_PREFIXED_COLLAPSIBLE_MAP = "x-prefixed-collapsible-map";
-    final static String HYPHEN = "-";
-    public static final String OBJECT = "object";
+    private final String VENDOR_PREFIX = "x-";
+    private final String PREFIXED_COLLAPSIBLE_MAP = "prefixed-collapsible-map";
+    private final String X_PREFIXED_COLLAPSIBLE_MAP = "x-prefixed-collapsible-map";
+    private final String HYPHEN = "-";
+    private final String OBJECT = "object";
 
-    public static final String LIST_OBJECT = "List<Object>";
+    private final String LIST_OBJECT = "List<Object>";
 
-    public static final String PHONE_NUMBER_FORMAT = "phone-number";
+    private final String PHONE_NUMBER_FORMAT = "phone-number";
 
-    final static String X_IS_PHONE_NUMBER_FORMAT = "x-is-phone-number-format";
+    private final String X_IS_PHONE_NUMBER_FORMAT = "x-is-phone-number-format";
 
-    // Resolves the vendor extensions, property datatype, and datatype for each property in the OAS schema object
-    public static Optional<CodegenModel> resolve(Optional<CodegenModel> model) {
-        // Loop through all properties (without parent's properties) of an OAS schema object
+    private Map<String, Map<String, Object>> conventionMap;
+    private CodegenModelResolver codegenModelResolver;
+    private CodegenParameterResolver codegenParameterResolver;
+
+    public JavaConventionResolver(Map<String, Map<String, Object>> conventionMap) {
+        this.conventionMap = conventionMap;
+        codegenModelResolver = new CodegenModelResolver(conventionMap,
+                Arrays.asList(EnumConstants.JavaDataTypes.values()),
+                EnumConstants.JavaDataTypes.LIST.getValue(),
+                ApplicationConstants.LIST_END);
+        codegenParameterResolver = new CodegenParameterResolver(conventionMap,
+                Arrays.asList(EnumConstants.JavaDataTypes.values()));
+    }
+
+    public Optional<CodegenModel> resolve(Optional<CodegenModel> model) {
+        codegenModelResolver.resolve(model.get());
         for (CodegenProperty property : model.get().vars) {
             Map<String, Map<String, Object>> vendorExtensions = new HashMap<>();
 
-            // Builds the vendorExtensions map
-            for (Segments segment: Segments.values()) {     // ["library", "properties", "serialize", "deserialize", ...] in java.json
+            for (Segments segment: Segments.values()) {
                 Map<String, Object> segmentMap = conventionMap.get(segment.getSegment());
                 if (segmentMap.containsKey(property.dataFormat)) {
                     Map<String, Object> segmentElements = new HashMap<>();
                     segmentElements.put(VENDOR_PREFIX + property.dataFormat, String.format(segmentMap.get(property.dataFormat).toString() , property.name));
-                    vendorExtensions.put(segment.getSegment(), segmentElements);    // i.e. ["properties"]->[["x-date"]->["ZonedDateTime"]]
-                }
-            }
-
-            // Checks if the conventionMap.properties has the current property data format
-            //      If so, sets the property.dataType value to the conventionMap.properties[property.dataFormat] string value
-            boolean hasProperty = conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).containsKey(property.dataFormat);
-            if (hasProperty) {
-                property.dataType = (String)conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).get(property.dataFormat);
-            }
-
-            // If the property.dataType is an "object" or a "List<Object>",
-            //      convert property.dataType to conventionMap.properties["object"], or "List<" + conventionMap.properties["object"] + ">"
-            if(property.dataType.equalsIgnoreCase(OBJECT) || property.dataType.equals(LIST_OBJECT)) {
-                if (property.dataType.equals(LIST_OBJECT)) {
-                    property.dataType = "List<" + conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).get(OBJECT) + ">";
-                } else {
-                    property.dataType = (String) conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).get(OBJECT);
+                    vendorExtensions.put(segment.getSegment(), segmentElements);
                 }
             }
 
@@ -69,11 +64,7 @@ public class JavaConventionResolver {
         return model;
     }
 
-    // Resolves the Java datatypes (basetype and datatype), "promotions", and "properties" for the OAS operation parameter.
-    // Relies on the vendorExtensions map being assigned to the parameter
-    public static Optional<CodegenParameter> resolveParameter(CodegenParameter parameter) {
-
-        // Sets the parameter's dataType property
+    public Optional<CodegenParameter> resolveParameter(CodegenParameter parameter) {
         if(parameter.dataType.equalsIgnoreCase(OBJECT) || parameter.dataType.equals(LIST_OBJECT)) {
             if (parameter.dataType.equals(LIST_OBJECT)) {
                 parameter.dataType = "List<" + conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).get(OBJECT)+ ">";
@@ -84,9 +75,6 @@ public class JavaConventionResolver {
             parameter.isFreeFormObject = true;
         }
 
-        // TODO: This can be replaced with the common.CodegenParameterDataTypeResolver
-        // Check if the parameter dataFormat has a "promotion" in the conventionMap.promotions
-        //      If so, set the parameter vendorExtensions "x-promotions" to the (formatted) promotion map
         boolean hasPromotion = conventionMap.get(Segments.SEGMENT_PROMOTIONS.getSegment()).containsKey(parameter.dataFormat);
         if (hasPromotion) {
             // cloning to prevent update in source map
@@ -96,15 +84,8 @@ public class JavaConventionResolver {
             parameter.vendorExtensions.put("x-promotions", promotionsMap);
         }
 
-        // TODO: This can be replaced with the common.CodegenParameterDataTypeResolver
-        // Check if the parameter dataFormat has a "properties" in the conventionMap.properties
-        //      If so, set the parameter dataType value to the conventionMap value
-        boolean hasProperty = conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).containsKey(parameter.dataFormat);
-        if (hasProperty) {
-            parameter.dataType = (String)conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).get(parameter.dataFormat);
-        }
+        codegenParameterResolver.resolve(parameter);
 
-        // If it's a phone number format, put an vendor extension to flag its a phone number
         if( PHONE_NUMBER_FORMAT.equals(parameter.dataFormat)) {
             parameter.vendorExtensions.put(X_IS_PHONE_NUMBER_FORMAT, true);
         }
@@ -112,8 +93,7 @@ public class JavaConventionResolver {
         return Optional.of(parameter);
     }
 
-    // Resolves the data type for the given OAS operation parameter
-    public static CodegenParameter resolveParamTypes(CodegenParameter codegenParameter) {
+    public CodegenParameter resolveParamTypes(CodegenParameter codegenParameter) {
         boolean hasProperty = conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).containsKey(codegenParameter.dataFormat);
         if (hasProperty) {
             codegenParameter.dataType = (String) conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).get(codegenParameter.dataFormat);
@@ -121,10 +101,7 @@ public class JavaConventionResolver {
         return codegenParameter;
     }
 
-    // If the OAS operation parameter dataFormat starts with "prefixed-collapsible-map"
-    //      Put a "x-prefixed-collapsible-map" vendor extension and set to "prefixed"
-    //      Sets the parameter.dataType to prefixed-collapsible-map conventionMap property value
-    public static CodegenParameter prefixedCollapsibleMap(CodegenParameter parameter) {
+    public CodegenParameter prefixedCollapsibleMap(CodegenParameter parameter) {
         if (parameter.dataFormat != null && parameter.dataFormat.startsWith(PREFIXED_COLLAPSIBLE_MAP)) {
             String[] split_format_array = parameter.dataFormat.split(HYPHEN);
             parameter.vendorExtensions.put(X_PREFIXED_COLLAPSIBLE_MAP, split_format_array[split_format_array.length - 1]);
@@ -134,30 +111,10 @@ public class JavaConventionResolver {
         return parameter;
     }
 
-    // Reads the conventionMap configuration JSON file, deserialize it, and return it 
-    public static Map<String, Map<String, Object>> getConventionalMap() {
-        try {
-            return new ObjectMapper().readValue(Thread.currentThread().getContextClassLoader().getResourceAsStream(ApplicationConstants.CONFIG_JAVA_JSON_PATH), new TypeReference<Map<String, Map<String, Object>>>(){});
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return null;
-    }
-
     // Resolves the dataType for a property if the property.complexType is in the given modelFormatMap
-    public static Optional<CodegenModel> resolveComplexType(Optional<CodegenModel> item, Map<String, String> modelFormatMap) {
-        for (CodegenProperty prop: item.get().vars) {
-            if(modelFormatMap.containsKey(prop.complexType)) {
-                boolean hasProperty =  conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).containsKey(modelFormatMap.get(prop.complexType));
-                if (hasProperty) {
-                    if ( prop.containerType != null && prop.containerType.equals("array")) {
-                        prop.dataType = "List<" + conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).get(modelFormatMap.get(prop.complexType)) + ">";
-                    } else {
-                        prop.dataType = (String)conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).get(modelFormatMap.get(prop.complexType));
-                    }
-                }
-            }
-        }
+    public Optional<CodegenModel> resolveComplexType(Optional<CodegenModel> item, Map<String, String> modelFormatMap) {
+        codegenModelResolver.setModelFormatMap(modelFormatMap);
+        codegenModelResolver.resolve(item.get());
         return item;
     }
 }

--- a/src/main/java/com/twilio/oai/resolver/java/JavaConventionResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/java/JavaConventionResolver.java
@@ -14,14 +14,14 @@ import org.openapitools.codegen.CodegenProperty;
 
 public class JavaConventionResolver {
     private final String VENDOR_PREFIX = "x-";
-    private final String PREFIXED_COLLAPSIBLE_MAP = "prefixed-collapsible-map";
+    private final String PREFIXED_COLLAPSIBLE_MAP = "prefixed_collapsible_map";
     private final String X_PREFIXED_COLLAPSIBLE_MAP = "x-prefixed-collapsible-map";
     private final String HYPHEN = "-";
     private final String OBJECT = "object";
 
     private final String LIST_OBJECT = "List<Object>";
 
-    private final String PHONE_NUMBER_FORMAT = "phone-number";
+    private final String PHONE_NUMBER_FORMAT = "phone_number";
 
     private final String X_IS_PHONE_NUMBER_FORMAT = "x-is-phone-number-format";
 
@@ -39,9 +39,9 @@ public class JavaConventionResolver {
                 Arrays.asList(EnumConstants.JavaDataTypes.values()));
     }
 
-    public Optional<CodegenModel> resolve(Optional<CodegenModel> model) {
-        codegenModelResolver.resolve(model.get());
-        for (CodegenProperty property : model.get().vars) {
+    public CodegenModel resolve(CodegenModel model) {
+        codegenModelResolver.resolve(model);
+        for (CodegenProperty property : model.vars) {
             Map<String, Map<String, Object>> vendorExtensions = new HashMap<>();
 
             for (Segments segment: Segments.values()) {
@@ -64,7 +64,7 @@ public class JavaConventionResolver {
         return model;
     }
 
-    public Optional<CodegenParameter> resolveParameter(CodegenParameter parameter) {
+    public CodegenParameter resolveParameter(CodegenParameter parameter) {
         if(parameter.dataType.equalsIgnoreCase(OBJECT) || parameter.dataType.equals(LIST_OBJECT)) {
             if (parameter.dataType.equals(LIST_OBJECT)) {
                 parameter.dataType = "List<" + conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).get(OBJECT)+ ">";
@@ -90,7 +90,7 @@ public class JavaConventionResolver {
             parameter.vendorExtensions.put(X_IS_PHONE_NUMBER_FORMAT, true);
         }
         parameter.paramName = StringHelper.toFirstLetterLower(parameter.paramName);
-        return Optional.of(parameter);
+        return parameter;
     }
 
     public CodegenParameter resolveParamTypes(CodegenParameter codegenParameter) {
@@ -112,9 +112,9 @@ public class JavaConventionResolver {
     }
 
     // Resolves the dataType for a property if the property.complexType is in the given modelFormatMap
-    public Optional<CodegenModel> resolveComplexType(Optional<CodegenModel> item, Map<String, String> modelFormatMap) {
+    public CodegenModel resolveComplexType(CodegenModel item, Map<String, String> modelFormatMap) {
         codegenModelResolver.setModelFormatMap(modelFormatMap);
-        codegenModelResolver.resolve(item.get());
+        codegenModelResolver.resolve(item);
         return item;
     }
 }

--- a/src/main/java/com/twilio/oai/resolver/java/JavaConventionResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/java/JavaConventionResolver.java
@@ -1,14 +1,17 @@
-package com.twilio.oai;
+package com.twilio.oai.resolver.java;
 
 import java.util.*;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.twilio.oai.Segments;
+import com.twilio.oai.StringHelper;
+import com.twilio.oai.common.ApplicationConstants;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenParameter;
 import org.openapitools.codegen.CodegenProperty;
 
-public class ConventionResolver {
+public class JavaConventionResolver {
     final static Map<String, Map<String, Object>> conventionMap = getConventionalMap() ;
     final static String VENDOR_PREFIX = "x-";
     final static String PREFIXED_COLLAPSIBLE_MAP = "prefixed-collapsible-map";
@@ -22,26 +25,31 @@ public class ConventionResolver {
 
     final static String X_IS_PHONE_NUMBER_FORMAT = "x-is-phone-number-format";
 
-    final static String CONFIG_JAVA_JSON_PATH = "config/java.json";
-
-    final static String LIST_PREFIX = "list-";
-
+    // Resolves the vendor extensions, property datatype, and datatype for each property in the OAS schema object
     public static Optional<CodegenModel> resolve(Optional<CodegenModel> model) {
+        // Loop through all properties (without parent's properties) of an OAS schema object
         for (CodegenProperty property : model.get().vars) {
             Map<String, Map<String, Object>> vendorExtensions = new HashMap<>();
-            for (Segments segment: Segments.values()) {
+
+            // Builds the vendorExtensions map
+            for (Segments segment: Segments.values()) {     // ["library", "properties", "serialize", "deserialize", ...] in java.json
                 Map<String, Object> segmentMap = conventionMap.get(segment.getSegment());
                 if (segmentMap.containsKey(property.dataFormat)) {
                     Map<String, Object> segmentElements = new HashMap<>();
                     segmentElements.put(VENDOR_PREFIX + property.dataFormat, String.format(segmentMap.get(property.dataFormat).toString() , property.name));
-                    vendorExtensions.put(segment.getSegment(), segmentElements);
+                    vendorExtensions.put(segment.getSegment(), segmentElements);    // i.e. ["properties"]->[["x-date"]->["ZonedDateTime"]]
                 }
             }
+
+            // Checks if the conventionMap.properties has the current property data format
+            //      If so, sets the property.dataType value to the conventionMap.properties[property.dataFormat] string value
             boolean hasProperty = conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).containsKey(property.dataFormat);
             if (hasProperty) {
                 property.dataType = (String)conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).get(property.dataFormat);
             }
 
+            // If the property.dataType is an "object" or a "List<Object>",
+            //      convert property.dataType to conventionMap.properties["object"], or "List<" + conventionMap.properties["object"] + ">"
             if(property.dataType.equalsIgnoreCase(OBJECT) || property.dataType.equals(LIST_OBJECT)) {
                 if (property.dataType.equals(LIST_OBJECT)) {
                     property.dataType = "List<" + conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).get(OBJECT) + ">";
@@ -49,15 +57,23 @@ public class ConventionResolver {
                     property.dataType = (String) conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).get(OBJECT);
                 }
             }
+
+            // Converts property.nameInSnakeCase to all lowercase
             property.nameInSnakeCase = property.nameInSnakeCase.toLowerCase(Locale.ROOT);
+
+            // Merges the vendorExtensions map with the existing property's vendor extensions
             vendorExtensions.forEach(
-                    (key, value) -> property.getVendorExtensions().merge(key, value, (oldValue, newValue) -> newValue));
+                    (key, value) -> property.getVendorExtensions().merge(key, value, (oldValue, newValue) -> newValue)
+            );
         }
         return model;
     }
 
+    // Resolves the Java datatypes (basetype and datatype), "promotions", and "properties" for the OAS operation parameter.
+    // Relies on the vendorExtensions map being assigned to the parameter
     public static Optional<CodegenParameter> resolveParameter(CodegenParameter parameter) {
 
+        // Sets the parameter's dataType property
         if(parameter.dataType.equalsIgnoreCase(OBJECT) || parameter.dataType.equals(LIST_OBJECT)) {
             if (parameter.dataType.equals(LIST_OBJECT)) {
                 parameter.dataType = "List<" + conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).get(OBJECT)+ ">";
@@ -67,6 +83,10 @@ public class ConventionResolver {
             }
             parameter.isFreeFormObject = true;
         }
+
+        // TODO: This can be replaced with the common.CodegenParameterDataTypeResolver
+        // Check if the parameter dataFormat has a "promotion" in the conventionMap.promotions
+        //      If so, set the parameter vendorExtensions "x-promotions" to the (formatted) promotion map
         boolean hasPromotion = conventionMap.get(Segments.SEGMENT_PROMOTIONS.getSegment()).containsKey(parameter.dataFormat);
         if (hasPromotion) {
             // cloning to prevent update in source map
@@ -76,10 +96,15 @@ public class ConventionResolver {
             parameter.vendorExtensions.put("x-promotions", promotionsMap);
         }
 
+        // TODO: This can be replaced with the common.CodegenParameterDataTypeResolver
+        // Check if the parameter dataFormat has a "properties" in the conventionMap.properties
+        //      If so, set the parameter dataType value to the conventionMap value
         boolean hasProperty = conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).containsKey(parameter.dataFormat);
         if (hasProperty) {
             parameter.dataType = (String)conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).get(parameter.dataFormat);
         }
+
+        // If it's a phone number format, put an vendor extension to flag its a phone number
         if( PHONE_NUMBER_FORMAT.equals(parameter.dataFormat)) {
             parameter.vendorExtensions.put(X_IS_PHONE_NUMBER_FORMAT, true);
         }
@@ -87,6 +112,7 @@ public class ConventionResolver {
         return Optional.of(parameter);
     }
 
+    // Resolves the data type for the given OAS operation parameter
     public static CodegenParameter resolveParamTypes(CodegenParameter codegenParameter) {
         boolean hasProperty = conventionMap.get(Segments.SEGMENT_PROPERTIES.getSegment()).containsKey(codegenParameter.dataFormat);
         if (hasProperty) {
@@ -95,6 +121,9 @@ public class ConventionResolver {
         return codegenParameter;
     }
 
+    // If the OAS operation parameter dataFormat starts with "prefixed-collapsible-map"
+    //      Put a "x-prefixed-collapsible-map" vendor extension and set to "prefixed"
+    //      Sets the parameter.dataType to prefixed-collapsible-map conventionMap property value
     public static CodegenParameter prefixedCollapsibleMap(CodegenParameter parameter) {
         if (parameter.dataFormat != null && parameter.dataFormat.startsWith(PREFIXED_COLLAPSIBLE_MAP)) {
             String[] split_format_array = parameter.dataFormat.split(HYPHEN);
@@ -105,15 +134,17 @@ public class ConventionResolver {
         return parameter;
     }
 
+    // Reads the conventionMap configuration JSON file, deserialize it, and return it 
     public static Map<String, Map<String, Object>> getConventionalMap() {
         try {
-            return new ObjectMapper().readValue(Thread.currentThread().getContextClassLoader().getResourceAsStream(CONFIG_JAVA_JSON_PATH), new TypeReference<Map<String, Map<String, Object>>>(){});
+            return new ObjectMapper().readValue(Thread.currentThread().getContextClassLoader().getResourceAsStream(ApplicationConstants.CONFIG_JAVA_JSON_PATH), new TypeReference<Map<String, Map<String, Object>>>(){});
         } catch (Exception e) {
             e.printStackTrace();
         }
         return null;
     }
 
+    // Resolves the dataType for a property if the property.complexType is in the given modelFormatMap
     public static Optional<CodegenModel> resolveComplexType(Optional<CodegenModel> item, Map<String, String> modelFormatMap) {
         for (CodegenProperty prop: item.get().vars) {
             if(modelFormatMap.containsKey(prop.complexType)) {

--- a/src/main/resources/config/java.json
+++ b/src/main/resources/config/java.json
@@ -81,35 +81,37 @@
   },
   "hydrate": {
     "_": "{value}",
-    "date_time<rfc2822>": "DateConverter.rfc2822DateTimeFromString({value})",
-    "date_time<iso8601>": "DateConverter.iso8601DateTimeFromString({value})",
-    "date": "DateConverter.localDateFromString({value})"
+    "date_time<rfc2822>": "DateConverter.rfc2822DateTimeFromString(%s)",
+    "date_time<iso8601>": "DateConverter.iso8601DateTimeFromString(%s)",
+    "date_time_rfc_2822": "DateConverter.rfc2822DateTimeFromString(%s)",
+    "date_time": "DateConverter.iso8601DateTimeFromString(%s)",
+    "date": "DateConverter.localDateFromString(%s)"
   },
   "promotions": {
     "uri": {
-      "string": "Promoter.uriFromString({})"
+      "string": "Promoter.uriFromString(%s)"
     },
     "url": {
-      "string": "Promoter.uriFromString({})"
+      "string": "Promoter.phoneNumberFromString(%s)"
     },
     "phone_number": {
-      "string": "Promoter.phoneNumberFromString({})"
+      "string": "Promoter.phoneNumberFromString(%s)"
     },
     "twiml": {
-      "string": "Promoter.twimlFromString({})"
+      "string": "Promoter.twimlFromString(%s)"
     }
   },
   "serialize": {
-    "_": "{value}.toString()",
-    "endpoint": "{value}.getEndpoint()",
-    "iso_country_code": "{value}",
-    "object": "Converter.mapToJson({value})",
-    "date": "DateConverter.dateStringFromLocalDate({value})",
-    "date_time": "{value}.toInstant().toString()",
-    "date_or_time": "{value}.toInstant().toString()",
-    "string": "{value}",
-    "sid": "{value}",
-    "prefixed_collapsible_map": "PrefixedCollapsibleMap.serialize({value}, {trait})"
+    "_": "%s.toString()",
+    "endpoint": "%s.getEndpoint()",
+    "iso_country_code": "%s",
+    "object": "Converter.mapToJson(%s)",
+    "date": "DateConverter.dateStringFromLocalDate(%s)",
+    "date_time": "%s.toInstant().toString()",
+    "date_or_time": "%s.toInstant().toString()",
+    "string": "%s",
+    "sid": "%s",
+    "prefixed_collapsible_map": "PrefixedCollapsibleMap.serialize(%s, %s)"
   },
   "deserialize": {
     "currency": "com.twilio.converter.CurrencyDeserializer"

--- a/src/main/resources/config/java.json
+++ b/src/main/resources/config/java.json
@@ -1,130 +1,121 @@
 {
   "library": {
-    "_": "",
-    "currency": ["java.util.Currency"],
+    "_": null,
+    "currency": "java.util.Currency",
     "date": [
       "java.time.LocalDate",
       "com.twilio.converter.DateConverter"
     ],
-    "date-time": [
+    "date_time": [
       "java.time.ZonedDateTime",
       "com.twilio.converter.DateConverter"
     ],
-    "date-time-rfc-2822": [
+    "date_or_time": [
       "java.time.ZonedDateTime",
       "com.twilio.converter.DateConverter"
     ],
-    "date-or-time": [
+    "date_time_range": [
       "java.time.ZonedDateTime",
       "com.twilio.converter.DateConverter"
     ],
-    "date-time-range": [
-      "java.time.ZonedDateTime",
-      "com.twilio.converter.DateConverter"
-    ],
-    "decimal": ["java.math.BigDecimal"],
-    "endpoint": ["com.twilio.type.Endpoint"],
-    "http-method": ["com.twilio.http.HttpMethod"],
-    "url": ["java.net.URI"],
-    "ice-server": ["com.twilio.type.IceServer"],
-    "subscribe-rule": ["com.twilio.type.SubscribeRule"],
-    "recording-rule": ["com.twilio.type.RecordingRule"],
-    "phone-number-capabilities": ["com.twilio.type.PhoneNumberCapabilities"],
-    "feedback-issue": ["com.twilio.type.FeedbackIssue"],
+    "decimal": "java.math.BigDecimal",
+    "endpoint": "com.twilio.type.Endpoint",
+    "http_method": "com.twilio.http.HttpMethod",
+    "url": "java.net.URI",
+    "ice_server": "com.twilio.type.IceServer",
+    "subscribe_rule": "com.twilio.type.SubscribeRule",
+    "recording_rule": "com.twilio.type.RecordingRule",
+    "phone_number_capabilities": "com.twilio.type.PhoneNumberCapabilities",
+    "feedback_issue": "com.twilio.type.FeedbackIssue",
     "object": ["java.util.Map", "com.twilio.converter.Converter"],
-    "phone-number-price": ["com.twilio.type.PhoneNumberPrice"],
-    "outbound-sms-price": ["com.twilio.type.OutboundSmsPrice"],
-    "inbound-sms-price": ["com.twilio.type.InboundSmsPrice"],
-    "outbound-prefix-price": ["com.twilio.type.OutboundPrefixPrice"],
-    "inbound-call-price": ["com.twilio.type.InboundCallPrice"],
-    "outbound-call-price": ["com.twilio.type.OutboundCallPrice"],
-    "outbound-call-price-with-origin": ["com.twilio.type.OutboundCallPriceWithOrigin"],
-    "outbound-prefix-price-with-origin": ["com.twilio.type.OutboundPrefixPriceWithOrigin"],
-    "prefixed-collapsible-map": ["com.twilio.converter.PrefixedCollapsibleMap", "java.util.Map"],
-    "twiml": ["com.twilio.type.Twiml"]
+    "phone_number_price": "com.twilio.type.PhoneNumberPrice",
+    "outbound_sms_price": "com.twilio.type.OutboundSmsPrice",
+    "inbound_sms_price": "com.twilio.type.InboundSmsPrice",
+    "outbound_prefix_price": "com.twilio.type.OutboundPrefixPrice",
+    "inbound_call_price": "com.twilio.type.InboundCallPrice",
+    "outbound_call_price": "com.twilio.type.OutboundCallPrice",
+    "outbound_call_price_with_origin": "com.twilio.type.OutboundCallPriceWithOrigin",
+    "outbound_prefix_price_with_origin": "com.twilio.type.OutboundPrefixPriceWithOrigin",
+    "prefixed_collapsible_map": ["com.twilio.converter.PrefixedCollapsibleMap", "java.util.Map"],
+    "twiml": "com.twilio.type.Twiml"
   },
-
   "properties": {
     "_": "String",
     "boolean": "Boolean",
     "currency": "Currency",
     "date": "LocalDate",
-    "date-range": "LocalDate",
-    "date-time": "ZonedDateTime",
-    "date-time-rfc-2822": "ZonedDateTime",
-    "date-or-time": "ZonedDateTime",
-    "date-time-range": "ZonedDateTime",
+    "date_range": "LocalDate",
+    "date_time": "ZonedDateTime",
+    "date_or_time": "ZonedDateTime",
+    "date_time_range": "ZonedDateTime",
     "decimal": "BigDecimal",
     "endpoint": "com.twilio.type.Endpoint",
-    "feedback-issue": "FeedbackIssue",
-    "http-method": "HttpMethod",
-    "ice-servers": "IceServer",
-    "subscribe-rule": "SubscribeRule",
-    "recording-rule": "RecordingRule",
-    "inbound-call-price": "InboundCallPrice",
-    "inbound-sms-price": "InboundSmsPrice",
+    "feedback_issue": "FeedbackIssue",
+    "http_method": "HttpMethod",
+    "ice_server": "IceServer",
+    "subscribe_rule": "SubscribeRule",
+    "recording_rule": "RecordingRule",
+    "inbound_call_price": "InboundCallPrice",
+    "inbound_sms_price": "InboundSmsPrice",
     "integer": "Integer",
     "long": "Long",
     "object": "Map<String, Object>",
-    "outbound-call-price": "OutboundCallPrice",
-    "outbound-call-price-with-origin": "OutboundCallPriceWithOrigin",
-    "outbound-prefix-price": "OutboundPrefixPrice",
-    "outbound-sms-price": "OutboundSmsPrice",
-    "phone-number": "com.twilio.type.PhoneNumber",
-    "phone-number-capabilities": "PhoneNumberCapabilities",
-    "phone-number-price": "PhoneNumberPrice",
-    "prefixed-collapsible-map": "Map<String, String>",
-    "outbound-prefix-price-with-origin": "OutboundPrefixPriceWithOrigin",
-    "string-map": "Map<String, String>",
+    "outbound_call_price": "OutboundCallPrice",
+    "outbound_call_price_with_origin": "OutboundCallPriceWithOrigin",
+    "outbound_prefix_price": "OutboundPrefixPrice",
+    "outbound_sms_price": "OutboundSmsPrice",
+    "phone_number": "com.twilio.type.PhoneNumber",
+    "phone_number_capabilities": "PhoneNumberCapabilities",
+    "phone_number_price": "PhoneNumberPrice",
+    "prefixed_collapsible_map": "Map<String, Object>",
+    "outbound_prefix_price_with_origin": "OutboundPrefixPriceWithOrigin",
+    "string_map": "Map<String, String>",
     "twiml": "com.twilio.type.Twiml",
-    "uri-map": "Map<String, String>",
+    "uri_map": "Map<String, String>",
     "url": "URI"
   },
-
   "json": {
     "_": "String",
-    "date-time": "String",
+    "date_time": "String",
     "date": "String"
   },
-
   "hydrate": {
-    "_": "%s",
-    "date-time-rfc-2822": "DateConverter.rfc2822DateTimeFromString(%s)",
-    "date-time": "DateConverter.iso8601DateTimeFromString(%s)",
-    "date": "DateConverter.localDateFromString(%s)"
+    "_": "{value}",
+    "date_time<rfc2822>": "DateConverter.rfc2822DateTimeFromString({value})",
+    "date_time<iso8601>": "DateConverter.iso8601DateTimeFromString({value})",
+    "date": "DateConverter.localDateFromString({value})"
   },
-
   "promotions": {
     "uri": {
-      "string": "Promoter.uriFromString(%s)"
+      "string": "Promoter.uriFromString({})"
     },
-    "phone-number": {
-      "string": "Promoter.phoneNumberFromString(%s)"
+    "url": {
+      "string": "Promoter.uriFromString({})"
+    },
+    "phone_number": {
+      "string": "Promoter.phoneNumberFromString({})"
     },
     "twiml": {
-      "string": "Promoter.twimlFromString(%s)"
+      "string": "Promoter.twimlFromString({})"
     }
   },
-
   "serialize": {
-    "_": "%s.toString()",
-    "endpoint": "%s.getEndpoint()",
-    "iso-country-code": "%s",
-    "object": "Converter.mapToJson(%s)",
-    "date": "DateConverter.dateStringFromLocalDate(%s)",
-    "date-time": "%s.toInstant().toString()",
-    "date-or-time": "%s.toInstant().toString()",
-    "string": "%s",
-    "sid": "%s",
-    "prefixed-collapsible-map": "PrefixedCollapsibleMap.serialize(%s, %s)"
+    "_": "{value}.toString()",
+    "endpoint": "{value}.getEndpoint()",
+    "iso_country_code": "{value}",
+    "object": "Converter.mapToJson({value})",
+    "date": "DateConverter.dateStringFromLocalDate({value})",
+    "date_time": "{value}.toInstant().toString()",
+    "date_or_time": "{value}.toInstant().toString()",
+    "string": "{value}",
+    "sid": "{value}",
+    "prefixed_collapsible_map": "PrefixedCollapsibleMap.serialize({value}, {trait})"
   },
-
   "deserialize": {
     "currency": "com.twilio.converter.CurrencyDeserializer"
   },
-
   "cardinality": {
     "_": "single",
-    "prefixed-collapsible-map": "multi"
+    "prefixed_collapsible_map": "multi"
   }
 }


### PR DESCRIPTION
Refactored the ConventionResolver to be more reusable when generating different language helper libraries. Added a `common` package to `com.twilio.oai.resolver` and generic, reusable *Resolver, *DataTypeResolver, *ContainerDataTypeResolver, and *ComplexResolver classes to resolve property values in Codegen* objects against the provided language-specific semantic type configuration/conventionalMap. These [Resolver](https://github.com/twilio/twilio-oai-generator/blob/main/src/main/java/com/twilio/oai/resolver/Resolver.java) implementing classes are based on the CSharp implementation, but only contain type resolving logic that is applicable to both Java and Node.

Added:
- Added a `com.twilio.oai.resolver.common` package for generic Resolver classes
- Generic *Resolver, *DataTypeResolver, *ContainerDataTypeResolver, and *ComplexResolver classes for resolving CodegenModel properties against the given semantic type configuration/conventionalMap
- Generic *Resolver, *DataTypeResolver, *ContainerDataTypeResolver classes for resolving CodegenParameter properties against the given semantic type configuration/conventionalMap

Updated:
- Renamed ConventionResolver to JavaConventionResolver
- Update field names in `config/java.json` to be inline with field names in the [twilio-oai semantic type configuration for Java](https://github.com/twilio/twilio-oai/blob/main/types/java.json)
- Changed array-type values to strings in the `config/java.json` type configuration for fields with a single value