### PR TITLE
fix: Only generate pagination when necessary for Node

### DIFF
--- a/examples/node/lib/rest/api/V2010.ts
+++ b/examples/node/lib/rest/api/V2010.ts
@@ -34,5 +34,4 @@ export default class V2010 extends Version {
     this._accounts = this._accounts || AccountListInstance(this);
     return this._accounts;
   }
-
 }

--- a/examples/node/lib/rest/api/V2010.ts
+++ b/examples/node/lib/rest/api/V2010.ts
@@ -34,4 +34,5 @@ export default class V2010 extends Version {
     this._accounts = this._accounts || AccountListInstance(this);
     return this._accounts;
   }
+
 }

--- a/examples/node/lib/rest/api/v2010/account.ts
+++ b/examples/node/lib/rest/api/v2010/account.ts
@@ -122,11 +122,11 @@ export interface AccountContext {
    *
    * @param { function } [callback] - Callback to handle processed record
    *
-   * @returns { Promise } Resolves to processed AccountInstance
+   * @returns { Promise } Resolves to processed boolean
    */
   remove(
-    callback?: (error: Error | null, item?: AccountInstance) => any
-  ): Promise<AccountInstance>;
+    callback?: (error: Error | null, item?: boolean) => any
+  ): Promise<boolean>;
 
   /**
    * Fetch a AccountInstance
@@ -181,17 +181,12 @@ export class AccountContextImpl implements AccountContext {
     return this._calls;
   }
 
-  remove(callback?: any): Promise<AccountInstance> {
+  remove(callback?: any): Promise<boolean> {
     let operationVersion = this._version,
       operationPromise = operationVersion.remove({
         uri: this._uri,
         method: "delete",
       });
-
-    operationPromise = operationPromise.then(
-      (payload) =>
-        new AccountInstance(operationVersion, payload, this._solution.sid)
-    );
 
     operationPromise = this._version.setPromiseCallback(
       operationPromise,
@@ -353,11 +348,11 @@ export class AccountInstance {
    *
    * @param { function } [callback] - Callback to handle processed record
    *
-   * @returns { Promise } Resolves to processed AccountInstance
+   * @returns { Promise } Resolves to processed boolean
    */
   remove(
-    callback?: (error: Error | null, item?: AccountInstance) => any
-  ): Promise<AccountInstance> {
+    callback?: (error: Error | null, item?: boolean) => any
+  ): Promise<boolean> {
     return this._proxy.remove(callback);
   }
 
@@ -425,9 +420,6 @@ export class AccountInstance {
   [inspect.custom](_depth: any, options: InspectOptions) {
     return inspect(this.toJSON(), options);
   }
-}
-export interface AccountSolution {
-  sid?: string;
 }
 
 export interface AccountListInstance {

--- a/examples/node/lib/rest/api/v2010/account.ts
+++ b/examples/node/lib/rest/api/v2010/account.ts
@@ -12,7 +12,6 @@
  * Do not edit the class manually.
  */
 
-
 import { inspect, InspectOptions } from "util";
 import Page from "../../../base/Page";
 import Response from "../../../http/response";
@@ -21,39 +20,37 @@ const deserialize = require("../../../base/deserialize");
 const serialize = require("../../../base/serialize");
 import { CallListInstance } from "./account/call";
 
-
 /**
  * Options to pass to update a AccountInstance
  *
- * @property { TestEnumStatus } status 
- * @property { string } [pauseBehavior] 
+ * @property { TestEnumStatus } status
+ * @property { string } [pauseBehavior]
  */
 export interface AccountContextUpdateOptions {
   status: TestEnumStatus;
   pauseBehavior?: string;
 }
 
-
 /**
  * Options to pass to create a AccountInstance
  *
- * @property { 'true' | 'false' } [xTwilioWebhookEnabled] 
- * @property { string } [recordingStatusCallback] 
- * @property { Array<string> } [recordingStatusCallbackEvent] 
+ * @property { 'true' | 'false' } [xTwilioWebhookEnabled]
+ * @property { string } [recordingStatusCallback]
+ * @property { Array<string> } [recordingStatusCallbackEvent]
  */
 export interface AccountListInstanceCreateOptions {
-  xTwilioWebhookEnabled?: 'true' | 'false';
+  xTwilioWebhookEnabled?: "true" | "false";
   recordingStatusCallback?: string;
   recordingStatusCallbackEvent?: Array<string>;
 }
 /**
  * Options to pass to each
  *
- * @property { Date } [dateCreated] 
- * @property { string } [dateTest] 
- * @property { Date } [dateCreatedBefore] 
- * @property { Date } [dateCreatedAfter] 
- * @property { number } [pageSize] 
+ * @property { Date } [dateCreated]
+ * @property { string } [dateTest]
+ * @property { Date } [dateCreatedBefore]
+ * @property { Date } [dateCreatedAfter]
+ * @property { number } [pageSize]
  * @property { Function } [callback] -
  *                         Function to process each record. If this and a positional
  *                         callback are passed, this one will be used
@@ -77,11 +74,11 @@ export interface AccountListInstanceEachOptions {
 /**
  * Options to pass to list
  *
- * @property { Date } [dateCreated] 
- * @property { string } [dateTest] 
- * @property { Date } [dateCreatedBefore] 
- * @property { Date } [dateCreatedAfter] 
- * @property { number } [pageSize] 
+ * @property { Date } [dateCreated]
+ * @property { string } [dateTest]
+ * @property { Date } [dateCreatedBefore]
+ * @property { Date } [dateCreatedAfter]
+ * @property { number } [pageSize]
  * @property { number } [limit] -
  *                         Upper limit for the number of records to return.
  *                         list() guarantees never to return more than limit.
@@ -99,11 +96,11 @@ export interface AccountListInstanceOptions {
 /**
  * Options to pass to page
  *
- * @property { Date } [dateCreated] 
- * @property { string } [dateTest] 
- * @property { Date } [dateCreatedBefore] 
- * @property { Date } [dateCreatedAfter] 
- * @property { number } [pageSize] 
+ * @property { Date } [dateCreated]
+ * @property { string } [dateTest]
+ * @property { Date } [dateCreatedBefore]
+ * @property { Date } [dateCreatedAfter]
+ * @property { number } [pageSize]
  * @property { number } [pageNumber] - Page Number, this value is simply for client state
  * @property { string } [pageToken] - PageToken provided by the API
  */
@@ -117,10 +114,7 @@ export interface AccountListInstancePageOptions {
   pageToken?: string;
 }
 
-
-
 export interface AccountContext {
-
   calls: CallListInstance;
 
   /**
@@ -128,16 +122,11 @@ export interface AccountContext {
    *
    * @param { function } [callback] - Callback to handle processed record
    *
-   * @returns { Promise } Resolves to processed boolean
+   * @returns { Promise } Resolves to processed AccountInstance
    */
-<<<<<<< Updated upstream
   remove(
     callback?: (error: Error | null, item?: AccountInstance) => any
-  ): Promise<boolean>;
-=======
-  remove(callback?: (error: Error | null, item?: boolean) => any): Promise<boolean>
-
->>>>>>> Stashed changes
+  ): Promise<AccountInstance>;
 
   /**
    * Fetch a AccountInstance
@@ -146,8 +135,9 @@ export interface AccountContext {
    *
    * @returns { Promise } Resolves to processed AccountInstance
    */
-  fetch(callback?: (error: Error | null, item?: AccountInstance) => any): Promise<AccountInstance>
-
+  fetch(
+    callback?: (error: Error | null, item?: AccountInstance) => any
+  ): Promise<AccountInstance>;
 
   /**
    * Update a AccountInstance
@@ -157,9 +147,11 @@ export interface AccountContext {
    *
    * @returns { Promise } Resolves to processed AccountInstance
    */
-  update(params: AccountContextUpdateOptions, callback?: (error: Error | null, item?: AccountInstance) => any): Promise<AccountInstance>;
-  update(params: any, callback?: any): Promise<AccountInstance>
-
+  update(
+    params: AccountContextUpdateOptions,
+    callback?: (error: Error | null, item?: AccountInstance) => any
+  ): Promise<AccountInstance>;
+  update(params: any, callback?: any): Promise<AccountInstance>;
 
   /**
    * Provide a user-friendly representation
@@ -180,40 +172,51 @@ export class AccountContextImpl implements AccountContext {
   }
 
   get calls(): CallListInstance {
-    this._calls = this._calls || CallListInstance(this._version, this._solution.sid);
+    this._calls =
+      this._calls || CallListInstance(this._version, this._solution.sid);
     return this._calls;
   }
 
-  remove(callback?: any): Promise<boolean> {
-  
+  remove(callback?: any): Promise<AccountInstance> {
     let operationVersion = this._version,
-        operationPromise = operationVersion.remove({ uri: this._uri, method: 'delete' });
-    
+      operationPromise = operationVersion.remove({
+        uri: this._uri,
+        method: "delete",
+      });
 
-    operationPromise = this._version.setPromiseCallback(operationPromise,callback);
+    operationPromise = operationPromise.then(
+      (payload) =>
+        new AccountInstance(operationVersion, payload, this._solution.sid)
+    );
+
+    operationPromise = this._version.setPromiseCallback(
+      operationPromise,
+      callback
+    );
     return operationPromise;
-
-
-
   }
 
   fetch(callback?: any): Promise<AccountInstance> {
-  
     let operationVersion = this._version,
-        operationPromise = operationVersion.fetch({ uri: this._uri, method: 'get' });
-    
-    operationPromise = operationPromise.then(payload => new AccountInstance(operationVersion, payload, this._solution.sid));
-    
+      operationPromise = operationVersion.fetch({
+        uri: this._uri,
+        method: "get",
+      });
 
-    operationPromise = this._version.setPromiseCallback(operationPromise,callback);
+    operationPromise = operationPromise.then(
+      (payload) =>
+        new AccountInstance(operationVersion, payload, this._solution.sid)
+    );
+
+    operationPromise = this._version.setPromiseCallback(
+      operationPromise,
+      callback
+    );
     return operationPromise;
-
-
-
   }
 
   update(params: any, callback?: any): Promise<AccountInstance> {
-      if (params === null || params === undefined) {
+    if (params === null || params === undefined) {
       throw new Error('Required parameter "params" missing.');
     }
 
@@ -223,23 +226,31 @@ export class AccountContextImpl implements AccountContext {
 
     const data: any = {};
 
-    if (params.pauseBehavior !== undefined) data['PauseBehavior'] = params.pauseBehavior;
-    data['Status'] = params.status;
+    if (params.pauseBehavior !== undefined)
+      data["PauseBehavior"] = params.pauseBehavior;
+    data["Status"] = params.status;
 
     const headers: any = {};
-    headers['Content-Type'] = 'application/x-www-form-urlencoded'
+    headers["Content-Type"] = "application/x-www-form-urlencoded";
 
     let operationVersion = this._version,
-        operationPromise = operationVersion.update({ uri: this._uri, method: 'post', params: data, headers });
-    
-    operationPromise = operationPromise.then(payload => new AccountInstance(operationVersion, payload, this._solution.sid));
-    
+      operationPromise = operationVersion.update({
+        uri: this._uri,
+        method: "post",
+        params: data,
+        headers,
+      });
 
-    operationPromise = this._version.setPromiseCallback(operationPromise,callback);
+    operationPromise = operationPromise.then(
+      (payload) =>
+        new AccountInstance(operationVersion, payload, this._solution.sid)
+    );
+
+    operationPromise = this._version.setPromiseCallback(
+      operationPromise,
+      callback
+    );
     return operationPromise;
-
-
-
   }
 
   /**
@@ -256,8 +267,7 @@ export class AccountContextImpl implements AccountContext {
   }
 }
 
-interface AccountPayload extends AccountResource, Page.TwilioResponsePayload {
-}
+interface AccountPayload extends AccountResource, Page.TwilioResponsePayload {}
 
 interface AccountResource {
   account_sid?: string | null;
@@ -280,7 +290,11 @@ export class AccountInstance {
   protected _solution: AccountSolution;
   protected _context?: AccountContext;
 
-  constructor(protected _version: V2010, payload: AccountPayload, sid?: string) {
+  constructor(
+    protected _version: V2010,
+    payload: AccountPayload,
+    sid?: string
+  ) {
     this.accountSid = payload.account_sid;
     this.sid = payload.sid;
     this.testString = payload.test_string;
@@ -318,7 +332,9 @@ export class AccountInstance {
   testArrayOfEnum?: Array<object> | null;
 
   private get _proxy(): AccountContext {
-    this._context = this._context || new AccountContextImpl(this._version, this._solution.sid);
+    this._context =
+      this._context ||
+      new AccountContextImpl(this._version, this._solution.sid);
     return this._context;
   }
 
@@ -327,16 +343,11 @@ export class AccountInstance {
    *
    * @param { function } [callback] - Callback to handle processed record
    *
-   * @returns { Promise } Resolves to processed boolean
+   * @returns { Promise } Resolves to processed AccountInstance
    */
-<<<<<<< Updated upstream
   remove(
     callback?: (error: Error | null, item?: AccountInstance) => any
-  ): Promise<boolean> {
-=======
-  remove(callback?: (error: Error | null, item?: boolean) => any): Promise<boolean>
-     {
->>>>>>> Stashed changes
+  ): Promise<AccountInstance> {
     return this._proxy.remove(callback);
   }
 
@@ -347,8 +358,9 @@ export class AccountInstance {
    *
    * @returns { Promise } Resolves to processed AccountInstance
    */
-  fetch(callback?: (error: Error | null, item?: AccountInstance) => any): Promise<AccountInstance>
-     {
+  fetch(
+    callback?: (error: Error | null, item?: AccountInstance) => any
+  ): Promise<AccountInstance> {
     return this._proxy.fetch(callback);
   }
 
@@ -360,9 +372,11 @@ export class AccountInstance {
    *
    * @returns { Promise } Resolves to processed AccountInstance
    */
-  update(params: AccountContextUpdateOptions, callback?: (error: Error | null, item?: AccountInstance) => any): Promise<AccountInstance>;
-  update(params: any, callback?: any): Promise<AccountInstance>
-     {
+  update(
+    params: AccountContextUpdateOptions,
+    callback?: (error: Error | null, item?: AccountInstance) => any
+  ): Promise<AccountInstance>;
+  update(params: any, callback?: any): Promise<AccountInstance> {
     return this._proxy.update(params, callback);
   }
 
@@ -380,7 +394,6 @@ export class AccountInstance {
    */
   toJSON() {
     return {
-<<<<<<< Updated upstream
       accountSid: this.accountSid,
       sid: this.sid,
       testString: this.testString,
@@ -396,24 +409,6 @@ export class AccountInstance {
       testArrayOfObjects: this.testArrayOfObjects,
       testArrayOfEnum: this.testArrayOfEnum,
     };
-=======
-      accountSid: this.accountSid, 
-      sid: this.sid, 
-      testString: this.testString, 
-      testInteger: this.testInteger, 
-      testObject: this.testObject, 
-      testDateTime: this.testDateTime, 
-      testNumber: this.testNumber, 
-      priceUnit: this.priceUnit, 
-      testNumberFloat: this.testNumberFloat, 
-      testEnum: this.testEnum, 
-      a2pProfileBundleSid: this.a2pProfileBundleSid, 
-      testArrayOfIntegers: this.testArrayOfIntegers, 
-      testArrayOfArrayOfIntegers: this.testArrayOfArrayOfIntegers, 
-      testArrayOfObjects: this.testArrayOfObjects, 
-      testArrayOfEnum: this.testArrayOfEnum
-    }
->>>>>>> Stashed changes
   }
 
   [inspect.custom](_depth: any, options: InspectOptions) {
@@ -424,12 +419,9 @@ export interface AccountSolution {
   sid?: string;
 }
 
-
-
 export interface AccountListInstance {
   (sid: string): AccountContext;
   get(sid: string): AccountContext;
-
 
   /**
    * Create a AccountInstance
@@ -438,7 +430,9 @@ export interface AccountListInstance {
    *
    * @returns { Promise } Resolves to processed AccountInstance
    */
-  create(callback?: (error: Error | null, item?: AccountInstance) => any): Promise<AccountInstance>;
+  create(
+    callback?: (error: Error | null, item?: AccountInstance) => any
+  ): Promise<AccountInstance>;
   /**
    * Create a AccountInstance
    *
@@ -447,10 +441,11 @@ export interface AccountListInstance {
    *
    * @returns { Promise } Resolves to processed AccountInstance
    */
-  create(params: AccountListInstanceCreateOptions, callback?: (error: Error | null, item?: AccountInstance) => any): Promise<AccountInstance>;
-  create(params?: any, callback?: any): Promise<AccountInstance>
-
-
+  create(
+    params: AccountListInstanceCreateOptions,
+    callback?: (error: Error | null, item?: AccountInstance) => any
+  ): Promise<AccountInstance>;
+  create(params?: any, callback?: any): Promise<AccountInstance>;
 
   /**
    * Streams AccountInstance records from the API.
@@ -466,7 +461,9 @@ export interface AccountListInstance {
    *
    * @param { function } [callback] - Function to process each record
    */
-  each(callback?: (item: AccountInstance, done: (err?: Error) => void) => void): void;
+  each(
+    callback?: (item: AccountInstance, done: (err?: Error) => void) => void
+  ): void;
   /**
    * Streams AccountInstance records from the API.
    *
@@ -482,7 +479,10 @@ export interface AccountListInstance {
    * @param { AccountListInstanceEachOptions } [params] - Options for request
    * @param { function } [callback] - Function to process each record
    */
-  each(params?: AccountListInstanceEachOptions, callback?: (item: AccountInstance, done: (err?: Error) => void) => void): void;
+  each(
+    params?: AccountListInstanceEachOptions,
+    callback?: (item: AccountInstance, done: (err?: Error) => void) => void
+  ): void;
   each(params?: any, callback?: any): void;
   /**
    * Retrieve a single target page of AccountInstance records from the API.
@@ -494,7 +494,9 @@ export interface AccountListInstance {
    *
    * @param { function } [callback] - Callback to handle list of records
    */
-  getPage(callback?: (error: Error | null, items: AccountPage) => any): Promise<AccountPage>;
+  getPage(
+    callback?: (error: Error | null, items: AccountPage) => any
+  ): Promise<AccountPage>;
   /**
    * Retrieve a single target page of AccountInstance records from the API.
    *
@@ -506,7 +508,10 @@ export interface AccountListInstance {
    * @param { string } [targetUrl] - API-generated URL for the requested results page
    * @param { function } [callback] - Callback to handle list of records
    */
-  getPage(targetUrl?: string, callback?: (error: Error | null, items: AccountPage) => any): Promise<AccountPage>;
+  getPage(
+    targetUrl?: string,
+    callback?: (error: Error | null, items: AccountPage) => any
+  ): Promise<AccountPage>;
   getPage(params?: any, callback?: any): Promise<AccountPage>;
   /**
    * Lists AccountInstance records from the API as a list.
@@ -516,7 +521,9 @@ export interface AccountListInstance {
    *
    * @param { function } [callback] - Callback to handle list of records
    */
-  list(callback?: (error: Error | null, items: AccountInstance[]) => any): Promise<AccountInstance[]>;
+  list(
+    callback?: (error: Error | null, items: AccountInstance[]) => any
+  ): Promise<AccountInstance[]>;
   /**
    * Lists AccountInstance records from the API as a list.
    *
@@ -526,7 +533,10 @@ export interface AccountListInstance {
    * @param { AccountListInstanceOptions } [params] - Options for request
    * @param { function } [callback] - Callback to handle list of records
    */
-  list(params?: AccountListInstanceOptions, callback?: (error: Error | null, items: AccountInstance[]) => any): Promise<AccountInstance[]>;
+  list(
+    params?: AccountListInstanceOptions,
+    callback?: (error: Error | null, items: AccountInstance[]) => any
+  ): Promise<AccountInstance[]>;
   list(params?: any, callback?: any): Promise<AccountInstance[]>;
   /**
    * Retrieve a single page of AccountInstance records from the API.
@@ -538,7 +548,9 @@ export interface AccountListInstance {
    *
    * @param { function } [callback] - Callback to handle list of records
    */
-  page(callback?: (error: Error | null, items: AccountPage) => any): Promise<AccountPage>;
+  page(
+    callback?: (error: Error | null, items: AccountPage) => any
+  ): Promise<AccountPage>;
   /**
    * Retrieve a single page of AccountInstance records from the API.
    *
@@ -550,7 +562,10 @@ export interface AccountListInstance {
    * @param { AccountListInstancePageOptions } [params] - Options for request
    * @param { function } [callback] - Callback to handle list of records
    */
-  page(params: AccountListInstancePageOptions, callback?: (error: Error | null, items: AccountPage) => any): Promise<AccountPage>;
+  page(
+    params: AccountListInstancePageOptions,
+    callback?: (error: Error | null, items: AccountPage) => any
+  ): Promise<AccountPage>;
   page(params?: any, callback?: any): Promise<AccountPage>;
 
   /**
@@ -565,7 +580,6 @@ class AccountListInstanceImpl implements AccountListInstance {
   _version?: V2010;
   _solution?: AccountSolution;
   _uri?: string;
-
 }
 
 export function AccountListInstance(version: V2010): AccountListInstance {
@@ -573,13 +587,16 @@ export function AccountListInstance(version: V2010): AccountListInstance {
 
   instance.get = function get(sid): AccountContext {
     return new AccountContextImpl(version, sid);
-  }
+  };
 
   instance._version = version;
-  instance._solution = {  };
+  instance._solution = {};
   instance._uri = `/Accounts.json`;
 
-  instance.create = function create(params?: any, callback?: any): Promise<AccountInstance> {
+  instance.create = function create(
+    params?: any,
+    callback?: any
+  ): Promise<AccountInstance> {
     if (typeof params === "function") {
       callback = params;
       params = {};
@@ -589,27 +606,42 @@ export function AccountListInstance(version: V2010): AccountListInstance {
 
     const data: any = {};
 
-    if (params.recordingStatusCallback !== undefined) data['RecordingStatusCallback'] = params.recordingStatusCallback;
-    if (params.recordingStatusCallbackEvent !== undefined) data['RecordingStatusCallbackEvent'] = serialize.map(params.recordingStatusCallbackEvent, ((e) => e));
+    if (params.recordingStatusCallback !== undefined)
+      data["RecordingStatusCallback"] = params.recordingStatusCallback;
+    if (params.recordingStatusCallbackEvent !== undefined)
+      data["RecordingStatusCallbackEvent"] = serialize.map(
+        params.recordingStatusCallbackEvent,
+        (e) => e
+      );
 
     const headers: any = {};
-    headers['Content-Type'] = 'application/x-www-form-urlencoded'
-    if (params.xTwilioWebhookEnabled !== undefined) headers['X-Twilio-Webhook-Enabled'] = params.xTwilioWebhookEnabled;
+    headers["Content-Type"] = "application/x-www-form-urlencoded";
+    if (params.xTwilioWebhookEnabled !== undefined)
+      headers["X-Twilio-Webhook-Enabled"] = params.xTwilioWebhookEnabled;
 
     let operationVersion = version,
-        operationPromise = operationVersion.create({ uri: this._uri, method: 'post', params: data, headers });
-    
-    operationPromise = operationPromise.then(payload => new AccountInstance(operationVersion, payload));
-    
+      operationPromise = operationVersion.create({
+        uri: this._uri,
+        method: "post",
+        params: data,
+        headers,
+      });
 
-    operationPromise = this._version.setPromiseCallback(operationPromise,callback);
+    operationPromise = operationPromise.then(
+      (payload) => new AccountInstance(operationVersion, payload)
+    );
+
+    operationPromise = this._version.setPromiseCallback(
+      operationPromise,
+      callback
+    );
     return operationPromise;
+  };
 
-
-
-    }
-
-  instance.page = function page(params?: any, callback?: any): Promise<AccountPage> {
+  instance.page = function page(
+    params?: any,
+    callback?: any
+  ): Promise<AccountPage> {
     if (typeof params === "function") {
       callback = params;
       params = {};
@@ -619,75 +651,107 @@ export function AccountListInstance(version: V2010): AccountListInstance {
 
     const data: any = {};
 
-    if (params.dateCreated !== undefined) data['DateCreated'] = serialize.iso8601DateTime(params.dateCreated);
-    if (params.dateTest !== undefined) data['Date.Test'] = serialize.iso8601Date(params.dateTest);
-    if (params.dateCreatedBefore !== undefined) data['DateCreated<'] = serialize.iso8601DateTime(params.dateCreatedBefore);
-    if (params.dateCreatedAfter !== undefined) data['DateCreated>'] = serialize.iso8601DateTime(params.dateCreatedAfter);
-    if (params.pageSize !== undefined) data['PageSize'] = params.pageSize;
-    if (params.page !== undefined) data['Page'] = params.pageNumber;
-    if (params.pageToken !== undefined) data['PageToken'] = params.pageToken;
+    if (params.dateCreated !== undefined)
+      data["DateCreated"] = serialize.iso8601DateTime(params.dateCreated);
+    if (params.dateTest !== undefined)
+      data["Date.Test"] = serialize.iso8601Date(params.dateTest);
+    if (params.dateCreatedBefore !== undefined)
+      data["DateCreated<"] = serialize.iso8601DateTime(
+        params.dateCreatedBefore
+      );
+    if (params.dateCreatedAfter !== undefined)
+      data["DateCreated>"] = serialize.iso8601DateTime(params.dateCreatedAfter);
+    if (params.pageSize !== undefined) data["PageSize"] = params.pageSize;
+    if (params.page !== undefined) data["Page"] = params.pageNumber;
+    if (params.pageToken !== undefined) data["PageToken"] = params.pageToken;
 
     const headers: any = {};
 
     let operationVersion = version,
-        operationPromise = operationVersion.page({ uri: this._uri, method: 'get', params: data, headers });
-    
-    operationPromise = operationPromise.then(payload => new AccountPage(operationVersion, payload, this._solution));
+      operationPromise = operationVersion.page({
+        uri: this._uri,
+        method: "get",
+        params: data,
+        headers,
+      });
 
-    operationPromise = this._version.setPromiseCallback(operationPromise,callback);
+    operationPromise = operationPromise.then(
+      (payload) => new AccountPage(operationVersion, payload, this._solution)
+    );
+
+    operationPromise = this._version.setPromiseCallback(
+      operationPromise,
+      callback
+    );
     return operationPromise;
-
-  }
+  };
   instance.each = instance._version.each;
   instance.list = instance._version.list;
 
-  instance.getPage = function getPage(targetUrl?: any, callback?: any): Promise<AccountPage> {
-    let operationPromise = this._version._domain.twilio.request({method: 'get', uri: targetUrl});
+  instance.getPage = function getPage(
+    targetUrl?: any,
+    callback?: any
+  ): Promise<AccountPage> {
+    let operationPromise = this._version._domain.twilio.request({
+      method: "get",
+      uri: targetUrl,
+    });
 
-    operationPromise = operationPromise.then(payload => new AccountPage(this._version, payload, this._solution));
-    operationPromise = this._version.setPromiseCallback(operationPromise,callback);
+    operationPromise = operationPromise.then(
+      (payload) => new AccountPage(this._version, payload, this._solution)
+    );
+    operationPromise = this._version.setPromiseCallback(
+      operationPromise,
+      callback
+    );
     return operationPromise;
-  }
-
-
+  };
 
   instance.toJSON = function toJSON() {
     return this._solution;
-  }
+  };
 
-  instance[inspect.custom] = function inspectImpl(_depth: any, options: InspectOptions) {
+  instance[inspect.custom] = function inspectImpl(
+    _depth: any,
+    options: InspectOptions
+  ) {
     return inspect(this.toJSON(), options);
-  }
+  };
 
   return instance;
 }
 
-    export class AccountPage extends Page<V2010, AccountPayload, AccountResource, AccountInstance> {
-    /**
-    * Initialize the AccountPage
-    *
-    * @param version - Version of the resource
-    * @param response - Response from the API
-    * @param solution - Path solution
-    */
-    constructor(version: V2010, response: Response<string>, solution: AccountSolution) {
-        super(version, response, solution);
-        }
+export class AccountPage extends Page<
+  V2010,
+  AccountPayload,
+  AccountResource,
+  AccountInstance
+> {
+  /**
+   * Initialize the AccountPage
+   *
+   * @param version - Version of the resource
+   * @param response - Response from the API
+   * @param solution - Path solution
+   */
+  constructor(
+    version: V2010,
+    response: Response<string>,
+    solution: AccountSolution
+  ) {
+    super(version, response, solution);
+  }
 
-        /**
-        * Build an instance of AccountInstance
-        *
-        * @param payload - Payload response from the API
-        */
-        getInstance(payload: AccountPayload): AccountInstance {
-        return new AccountInstance(
-        this._version,
-        payload,
-        );
-        }
+  /**
+   * Build an instance of AccountInstance
+   *
+   * @param payload - Payload response from the API
+   */
+  getInstance(payload: AccountPayload): AccountInstance {
+    return new AccountInstance(this._version, payload);
+  }
 
-        [inspect.custom](depth: any, options: InspectOptions) {
-        return inspect(this.toJSON(), options);
-        }
-        }
-
+  [inspect.custom](depth: any, options: InspectOptions) {
+    return inspect(this.toJSON(), options);
+  }
+}

--- a/examples/node/lib/rest/api/v2010/account.ts
+++ b/examples/node/lib/rest/api/v2010/account.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+
 import { inspect, InspectOptions } from "util";
 import Page from "../../../base/Page";
 import Response from "../../../http/response";
@@ -20,37 +21,39 @@ const deserialize = require("../../../base/deserialize");
 const serialize = require("../../../base/serialize");
 import { CallListInstance } from "./account/call";
 
+
 /**
  * Options to pass to update a AccountInstance
  *
- * @property { TestEnumStatus } status
- * @property { string } [pauseBehavior]
+ * @property { TestEnumStatus } status 
+ * @property { string } [pauseBehavior] 
  */
 export interface AccountContextUpdateOptions {
   status: TestEnumStatus;
   pauseBehavior?: string;
 }
 
+
 /**
  * Options to pass to create a AccountInstance
  *
- * @property { 'true' | 'false' } [xTwilioWebhookEnabled]
- * @property { string } [recordingStatusCallback]
- * @property { Array<string> } [recordingStatusCallbackEvent]
+ * @property { 'true' | 'false' } [xTwilioWebhookEnabled] 
+ * @property { string } [recordingStatusCallback] 
+ * @property { Array<string> } [recordingStatusCallbackEvent] 
  */
 export interface AccountListInstanceCreateOptions {
-  xTwilioWebhookEnabled?: "true" | "false";
+  xTwilioWebhookEnabled?: 'true' | 'false';
   recordingStatusCallback?: string;
   recordingStatusCallbackEvent?: Array<string>;
 }
 /**
  * Options to pass to each
  *
- * @property { Date } [dateCreated]
- * @property { string } [dateTest]
- * @property { Date } [dateCreatedBefore]
- * @property { Date } [dateCreatedAfter]
- * @property { number } [pageSize]
+ * @property { Date } [dateCreated] 
+ * @property { string } [dateTest] 
+ * @property { Date } [dateCreatedBefore] 
+ * @property { Date } [dateCreatedAfter] 
+ * @property { number } [pageSize] 
  * @property { Function } [callback] -
  *                         Function to process each record. If this and a positional
  *                         callback are passed, this one will be used
@@ -74,11 +77,11 @@ export interface AccountListInstanceEachOptions {
 /**
  * Options to pass to list
  *
- * @property { Date } [dateCreated]
- * @property { string } [dateTest]
- * @property { Date } [dateCreatedBefore]
- * @property { Date } [dateCreatedAfter]
- * @property { number } [pageSize]
+ * @property { Date } [dateCreated] 
+ * @property { string } [dateTest] 
+ * @property { Date } [dateCreatedBefore] 
+ * @property { Date } [dateCreatedAfter] 
+ * @property { number } [pageSize] 
  * @property { number } [limit] -
  *                         Upper limit for the number of records to return.
  *                         list() guarantees never to return more than limit.
@@ -96,11 +99,11 @@ export interface AccountListInstanceOptions {
 /**
  * Options to pass to page
  *
- * @property { Date } [dateCreated]
- * @property { string } [dateTest]
- * @property { Date } [dateCreatedBefore]
- * @property { Date } [dateCreatedAfter]
- * @property { number } [pageSize]
+ * @property { Date } [dateCreated] 
+ * @property { string } [dateTest] 
+ * @property { Date } [dateCreatedBefore] 
+ * @property { Date } [dateCreatedAfter] 
+ * @property { number } [pageSize] 
  * @property { number } [pageNumber] - Page Number, this value is simply for client state
  * @property { string } [pageToken] - PageToken provided by the API
  */
@@ -114,7 +117,10 @@ export interface AccountListInstancePageOptions {
   pageToken?: string;
 }
 
+
+
 export interface AccountContext {
+
   calls: CallListInstance;
 
   /**
@@ -124,9 +130,14 @@ export interface AccountContext {
    *
    * @returns { Promise } Resolves to processed boolean
    */
+<<<<<<< Updated upstream
   remove(
     callback?: (error: Error | null, item?: AccountInstance) => any
   ): Promise<boolean>;
+=======
+  remove(callback?: (error: Error | null, item?: boolean) => any): Promise<boolean>
+
+>>>>>>> Stashed changes
 
   /**
    * Fetch a AccountInstance
@@ -135,9 +146,8 @@ export interface AccountContext {
    *
    * @returns { Promise } Resolves to processed AccountInstance
    */
-  fetch(
-    callback?: (error: Error | null, item?: AccountInstance) => any
-  ): Promise<AccountInstance>;
+  fetch(callback?: (error: Error | null, item?: AccountInstance) => any): Promise<AccountInstance>
+
 
   /**
    * Update a AccountInstance
@@ -147,11 +157,9 @@ export interface AccountContext {
    *
    * @returns { Promise } Resolves to processed AccountInstance
    */
-  update(
-    params: AccountContextUpdateOptions,
-    callback?: (error: Error | null, item?: AccountInstance) => any
-  ): Promise<AccountInstance>;
-  update(params: any, callback?: any): Promise<AccountInstance>;
+  update(params: AccountContextUpdateOptions, callback?: (error: Error | null, item?: AccountInstance) => any): Promise<AccountInstance>;
+  update(params: any, callback?: any): Promise<AccountInstance>
+
 
   /**
    * Provide a user-friendly representation
@@ -172,46 +180,40 @@ export class AccountContextImpl implements AccountContext {
   }
 
   get calls(): CallListInstance {
-    this._calls =
-      this._calls || CallListInstance(this._version, this._solution.sid);
+    this._calls = this._calls || CallListInstance(this._version, this._solution.sid);
     return this._calls;
   }
 
   remove(callback?: any): Promise<boolean> {
+  
     let operationVersion = this._version,
-      operationPromise = operationVersion.remove({
-        uri: this._uri,
-        method: "delete",
-      });
+        operationPromise = operationVersion.remove({ uri: this._uri, method: 'delete' });
+    
 
-    operationPromise = this._version.setPromiseCallback(
-      operationPromise,
-      callback
-    );
+    operationPromise = this._version.setPromiseCallback(operationPromise,callback);
     return operationPromise;
+
+
+
   }
 
   fetch(callback?: any): Promise<AccountInstance> {
+  
     let operationVersion = this._version,
-      operationPromise = operationVersion.fetch({
-        uri: this._uri,
-        method: "get",
-      });
+        operationPromise = operationVersion.fetch({ uri: this._uri, method: 'get' });
+    
+    operationPromise = operationPromise.then(payload => new AccountInstance(operationVersion, payload, this._solution.sid));
+    
 
-    operationPromise = operationPromise.then(
-      (payload) =>
-        new AccountInstance(operationVersion, payload, this._solution.sid)
-    );
-
-    operationPromise = this._version.setPromiseCallback(
-      operationPromise,
-      callback
-    );
+    operationPromise = this._version.setPromiseCallback(operationPromise,callback);
     return operationPromise;
+
+
+
   }
 
   update(params: any, callback?: any): Promise<AccountInstance> {
-    if (params === null || params === undefined) {
+      if (params === null || params === undefined) {
       throw new Error('Required parameter "params" missing.');
     }
 
@@ -221,31 +223,23 @@ export class AccountContextImpl implements AccountContext {
 
     const data: any = {};
 
-    if (params.pauseBehavior !== undefined)
-      data["PauseBehavior"] = params.pauseBehavior;
-    data["Status"] = params.status;
+    if (params.pauseBehavior !== undefined) data['PauseBehavior'] = params.pauseBehavior;
+    data['Status'] = params.status;
 
     const headers: any = {};
-    headers["Content-Type"] = "application/x-www-form-urlencoded";
+    headers['Content-Type'] = 'application/x-www-form-urlencoded'
 
     let operationVersion = this._version,
-      operationPromise = operationVersion.update({
-        uri: this._uri,
-        method: "post",
-        params: data,
-        headers,
-      });
+        operationPromise = operationVersion.update({ uri: this._uri, method: 'post', params: data, headers });
+    
+    operationPromise = operationPromise.then(payload => new AccountInstance(operationVersion, payload, this._solution.sid));
+    
 
-    operationPromise = operationPromise.then(
-      (payload) =>
-        new AccountInstance(operationVersion, payload, this._solution.sid)
-    );
-
-    operationPromise = this._version.setPromiseCallback(
-      operationPromise,
-      callback
-    );
+    operationPromise = this._version.setPromiseCallback(operationPromise,callback);
     return operationPromise;
+
+
+
   }
 
   /**
@@ -262,7 +256,8 @@ export class AccountContextImpl implements AccountContext {
   }
 }
 
-interface AccountPayload extends AccountResource, Page.TwilioResponsePayload {}
+interface AccountPayload extends AccountResource, Page.TwilioResponsePayload {
+}
 
 interface AccountResource {
   account_sid?: string | null;
@@ -285,11 +280,7 @@ export class AccountInstance {
   protected _solution: AccountSolution;
   protected _context?: AccountContext;
 
-  constructor(
-    protected _version: V2010,
-    payload: AccountPayload,
-    sid?: string
-  ) {
+  constructor(protected _version: V2010, payload: AccountPayload, sid?: string) {
     this.accountSid = payload.account_sid;
     this.sid = payload.sid;
     this.testString = payload.test_string;
@@ -327,9 +318,7 @@ export class AccountInstance {
   testArrayOfEnum?: Array<object> | null;
 
   private get _proxy(): AccountContext {
-    this._context =
-      this._context ||
-      new AccountContextImpl(this._version, this._solution.sid);
+    this._context = this._context || new AccountContextImpl(this._version, this._solution.sid);
     return this._context;
   }
 
@@ -340,9 +329,14 @@ export class AccountInstance {
    *
    * @returns { Promise } Resolves to processed boolean
    */
+<<<<<<< Updated upstream
   remove(
     callback?: (error: Error | null, item?: AccountInstance) => any
   ): Promise<boolean> {
+=======
+  remove(callback?: (error: Error | null, item?: boolean) => any): Promise<boolean>
+     {
+>>>>>>> Stashed changes
     return this._proxy.remove(callback);
   }
 
@@ -353,9 +347,8 @@ export class AccountInstance {
    *
    * @returns { Promise } Resolves to processed AccountInstance
    */
-  fetch(
-    callback?: (error: Error | null, item?: AccountInstance) => any
-  ): Promise<AccountInstance> {
+  fetch(callback?: (error: Error | null, item?: AccountInstance) => any): Promise<AccountInstance>
+     {
     return this._proxy.fetch(callback);
   }
 
@@ -367,11 +360,9 @@ export class AccountInstance {
    *
    * @returns { Promise } Resolves to processed AccountInstance
    */
-  update(
-    params: AccountContextUpdateOptions,
-    callback?: (error: Error | null, item?: AccountInstance) => any
-  ): Promise<AccountInstance>;
-  update(params: any, callback?: any): Promise<AccountInstance> {
+  update(params: AccountContextUpdateOptions, callback?: (error: Error | null, item?: AccountInstance) => any): Promise<AccountInstance>;
+  update(params: any, callback?: any): Promise<AccountInstance>
+     {
     return this._proxy.update(params, callback);
   }
 
@@ -389,6 +380,7 @@ export class AccountInstance {
    */
   toJSON() {
     return {
+<<<<<<< Updated upstream
       accountSid: this.accountSid,
       sid: this.sid,
       testString: this.testString,
@@ -404,6 +396,24 @@ export class AccountInstance {
       testArrayOfObjects: this.testArrayOfObjects,
       testArrayOfEnum: this.testArrayOfEnum,
     };
+=======
+      accountSid: this.accountSid, 
+      sid: this.sid, 
+      testString: this.testString, 
+      testInteger: this.testInteger, 
+      testObject: this.testObject, 
+      testDateTime: this.testDateTime, 
+      testNumber: this.testNumber, 
+      priceUnit: this.priceUnit, 
+      testNumberFloat: this.testNumberFloat, 
+      testEnum: this.testEnum, 
+      a2pProfileBundleSid: this.a2pProfileBundleSid, 
+      testArrayOfIntegers: this.testArrayOfIntegers, 
+      testArrayOfArrayOfIntegers: this.testArrayOfArrayOfIntegers, 
+      testArrayOfObjects: this.testArrayOfObjects, 
+      testArrayOfEnum: this.testArrayOfEnum
+    }
+>>>>>>> Stashed changes
   }
 
   [inspect.custom](_depth: any, options: InspectOptions) {
@@ -414,44 +424,12 @@ export interface AccountSolution {
   sid?: string;
 }
 
-export class AccountPage extends Page<
-  V2010,
-  AccountPayload,
-  AccountResource,
-  AccountInstance
-> {
-  /**
-   * Initialize the AccountPage
-   *
-   * @param version - Version of the resource
-   * @param response - Response from the API
-   * @param solution - Path solution
-   */
-  constructor(
-    version: V2010,
-    response: Response<string>,
-    solution: AccountSolution
-  ) {
-    super(version, response, solution);
-  }
 
-  /**
-   * Build an instance of AccountInstance
-   *
-   * @param payload - Payload response from the API
-   */
-  getInstance(payload: AccountPayload): AccountInstance {
-    return new AccountInstance(this._version, payload, this._solution.sid);
-  }
-
-  [inspect.custom](depth: any, options: InspectOptions) {
-    return inspect(this.toJSON(), options);
-  }
-}
 
 export interface AccountListInstance {
   (sid: string): AccountContext;
   get(sid: string): AccountContext;
+
 
   /**
    * Create a AccountInstance
@@ -460,9 +438,7 @@ export interface AccountListInstance {
    *
    * @returns { Promise } Resolves to processed AccountInstance
    */
-  create(
-    callback?: (error: Error | null, item?: AccountInstance) => any
-  ): Promise<AccountInstance>;
+  create(callback?: (error: Error | null, item?: AccountInstance) => any): Promise<AccountInstance>;
   /**
    * Create a AccountInstance
    *
@@ -471,11 +447,10 @@ export interface AccountListInstance {
    *
    * @returns { Promise } Resolves to processed AccountInstance
    */
-  create(
-    params: AccountListInstanceCreateOptions,
-    callback?: (error: Error | null, item?: AccountInstance) => any
-  ): Promise<AccountInstance>;
-  create(params?: any, callback?: any): Promise<AccountInstance>;
+  create(params: AccountListInstanceCreateOptions, callback?: (error: Error | null, item?: AccountInstance) => any): Promise<AccountInstance>;
+  create(params?: any, callback?: any): Promise<AccountInstance>
+
+
 
   /**
    * Streams AccountInstance records from the API.
@@ -491,9 +466,7 @@ export interface AccountListInstance {
    *
    * @param { function } [callback] - Function to process each record
    */
-  each(
-    callback?: (item: AccountInstance, done: (err?: Error) => void) => void
-  ): void;
+  each(callback?: (item: AccountInstance, done: (err?: Error) => void) => void): void;
   /**
    * Streams AccountInstance records from the API.
    *
@@ -509,10 +482,7 @@ export interface AccountListInstance {
    * @param { AccountListInstanceEachOptions } [params] - Options for request
    * @param { function } [callback] - Function to process each record
    */
-  each(
-    params?: AccountListInstanceEachOptions,
-    callback?: (item: AccountInstance, done: (err?: Error) => void) => void
-  ): void;
+  each(params?: AccountListInstanceEachOptions, callback?: (item: AccountInstance, done: (err?: Error) => void) => void): void;
   each(params?: any, callback?: any): void;
   /**
    * Retrieve a single target page of AccountInstance records from the API.
@@ -524,9 +494,7 @@ export interface AccountListInstance {
    *
    * @param { function } [callback] - Callback to handle list of records
    */
-  getPage(
-    callback?: (error: Error | null, items: AccountPage) => any
-  ): Promise<AccountPage>;
+  getPage(callback?: (error: Error | null, items: AccountPage) => any): Promise<AccountPage>;
   /**
    * Retrieve a single target page of AccountInstance records from the API.
    *
@@ -538,10 +506,7 @@ export interface AccountListInstance {
    * @param { string } [targetUrl] - API-generated URL for the requested results page
    * @param { function } [callback] - Callback to handle list of records
    */
-  getPage(
-    targetUrl?: string,
-    callback?: (error: Error | null, items: AccountPage) => any
-  ): Promise<AccountPage>;
+  getPage(targetUrl?: string, callback?: (error: Error | null, items: AccountPage) => any): Promise<AccountPage>;
   getPage(params?: any, callback?: any): Promise<AccountPage>;
   /**
    * Lists AccountInstance records from the API as a list.
@@ -551,9 +516,7 @@ export interface AccountListInstance {
    *
    * @param { function } [callback] - Callback to handle list of records
    */
-  list(
-    callback?: (error: Error | null, items: AccountInstance[]) => any
-  ): Promise<AccountInstance[]>;
+  list(callback?: (error: Error | null, items: AccountInstance[]) => any): Promise<AccountInstance[]>;
   /**
    * Lists AccountInstance records from the API as a list.
    *
@@ -563,10 +526,7 @@ export interface AccountListInstance {
    * @param { AccountListInstanceOptions } [params] - Options for request
    * @param { function } [callback] - Callback to handle list of records
    */
-  list(
-    params?: AccountListInstanceOptions,
-    callback?: (error: Error | null, items: AccountInstance[]) => any
-  ): Promise<AccountInstance[]>;
+  list(params?: AccountListInstanceOptions, callback?: (error: Error | null, items: AccountInstance[]) => any): Promise<AccountInstance[]>;
   list(params?: any, callback?: any): Promise<AccountInstance[]>;
   /**
    * Retrieve a single page of AccountInstance records from the API.
@@ -578,9 +538,7 @@ export interface AccountListInstance {
    *
    * @param { function } [callback] - Callback to handle list of records
    */
-  page(
-    callback?: (error: Error | null, items: AccountPage) => any
-  ): Promise<AccountPage>;
+  page(callback?: (error: Error | null, items: AccountPage) => any): Promise<AccountPage>;
   /**
    * Retrieve a single page of AccountInstance records from the API.
    *
@@ -592,10 +550,7 @@ export interface AccountListInstance {
    * @param { AccountListInstancePageOptions } [params] - Options for request
    * @param { function } [callback] - Callback to handle list of records
    */
-  page(
-    params: AccountListInstancePageOptions,
-    callback?: (error: Error | null, items: AccountPage) => any
-  ): Promise<AccountPage>;
+  page(params: AccountListInstancePageOptions, callback?: (error: Error | null, items: AccountPage) => any): Promise<AccountPage>;
   page(params?: any, callback?: any): Promise<AccountPage>;
 
   /**
@@ -610,6 +565,7 @@ class AccountListInstanceImpl implements AccountListInstance {
   _version?: V2010;
   _solution?: AccountSolution;
   _uri?: string;
+
 }
 
 export function AccountListInstance(version: V2010): AccountListInstance {
@@ -617,16 +573,13 @@ export function AccountListInstance(version: V2010): AccountListInstance {
 
   instance.get = function get(sid): AccountContext {
     return new AccountContextImpl(version, sid);
-  };
+  }
 
   instance._version = version;
-  instance._solution = {};
+  instance._solution = {  };
   instance._uri = `/Accounts.json`;
 
-  instance.create = function create(
-    params?: any,
-    callback?: any
-  ): Promise<AccountInstance> {
+  instance.create = function create(params?: any, callback?: any): Promise<AccountInstance> {
     if (typeof params === "function") {
       callback = params;
       params = {};
@@ -636,42 +589,27 @@ export function AccountListInstance(version: V2010): AccountListInstance {
 
     const data: any = {};
 
-    if (params.recordingStatusCallback !== undefined)
-      data["RecordingStatusCallback"] = params.recordingStatusCallback;
-    if (params.recordingStatusCallbackEvent !== undefined)
-      data["RecordingStatusCallbackEvent"] = serialize.map(
-        params.recordingStatusCallbackEvent,
-        (e) => e
-      );
+    if (params.recordingStatusCallback !== undefined) data['RecordingStatusCallback'] = params.recordingStatusCallback;
+    if (params.recordingStatusCallbackEvent !== undefined) data['RecordingStatusCallbackEvent'] = serialize.map(params.recordingStatusCallbackEvent, ((e) => e));
 
     const headers: any = {};
-    headers["Content-Type"] = "application/x-www-form-urlencoded";
-    if (params.xTwilioWebhookEnabled !== undefined)
-      headers["X-Twilio-Webhook-Enabled"] = params.xTwilioWebhookEnabled;
+    headers['Content-Type'] = 'application/x-www-form-urlencoded'
+    if (params.xTwilioWebhookEnabled !== undefined) headers['X-Twilio-Webhook-Enabled'] = params.xTwilioWebhookEnabled;
 
     let operationVersion = version,
-      operationPromise = operationVersion.create({
-        uri: this._uri,
-        method: "post",
-        params: data,
-        headers,
-      });
+        operationPromise = operationVersion.create({ uri: this._uri, method: 'post', params: data, headers });
+    
+    operationPromise = operationPromise.then(payload => new AccountInstance(operationVersion, payload));
+    
 
-    operationPromise = operationPromise.then(
-      (payload) => new AccountInstance(operationVersion, payload)
-    );
-
-    operationPromise = this._version.setPromiseCallback(
-      operationPromise,
-      callback
-    );
+    operationPromise = this._version.setPromiseCallback(operationPromise,callback);
     return operationPromise;
-  };
 
-  instance.page = function page(
-    params?: any,
-    callback?: any
-  ): Promise<AccountPage> {
+
+
+    }
+
+  instance.page = function page(params?: any, callback?: any): Promise<AccountPage> {
     if (typeof params === "function") {
       callback = params;
       params = {};
@@ -681,72 +619,75 @@ export function AccountListInstance(version: V2010): AccountListInstance {
 
     const data: any = {};
 
-    if (params.dateCreated !== undefined)
-      data["DateCreated"] = serialize.iso8601DateTime(params.dateCreated);
-    if (params.dateTest !== undefined)
-      data["Date.Test"] = serialize.iso8601Date(params.dateTest);
-    if (params.dateCreatedBefore !== undefined)
-      data["DateCreated<"] = serialize.iso8601DateTime(
-        params.dateCreatedBefore
-      );
-    if (params.dateCreatedAfter !== undefined)
-      data["DateCreated>"] = serialize.iso8601DateTime(params.dateCreatedAfter);
-    if (params.pageSize !== undefined) data["PageSize"] = params.pageSize;
-    if (params.page !== undefined) data["Page"] = params.pageNumber;
-    if (params.pageToken !== undefined) data["PageToken"] = params.pageToken;
+    if (params.dateCreated !== undefined) data['DateCreated'] = serialize.iso8601DateTime(params.dateCreated);
+    if (params.dateTest !== undefined) data['Date.Test'] = serialize.iso8601Date(params.dateTest);
+    if (params.dateCreatedBefore !== undefined) data['DateCreated<'] = serialize.iso8601DateTime(params.dateCreatedBefore);
+    if (params.dateCreatedAfter !== undefined) data['DateCreated>'] = serialize.iso8601DateTime(params.dateCreatedAfter);
+    if (params.pageSize !== undefined) data['PageSize'] = params.pageSize;
+    if (params.page !== undefined) data['Page'] = params.pageNumber;
+    if (params.pageToken !== undefined) data['PageToken'] = params.pageToken;
 
     const headers: any = {};
 
     let operationVersion = version,
-      operationPromise = operationVersion.page({
-        uri: this._uri,
-        method: "get",
-        params: data,
-        headers,
-      });
+        operationPromise = operationVersion.page({ uri: this._uri, method: 'get', params: data, headers });
+    
+    operationPromise = operationPromise.then(payload => new AccountPage(operationVersion, payload, this._solution));
 
-    operationPromise = operationPromise.then(
-      (payload) => new AccountPage(operationVersion, payload, this._solution)
-    );
-
-    operationPromise = this._version.setPromiseCallback(
-      operationPromise,
-      callback
-    );
+    operationPromise = this._version.setPromiseCallback(operationPromise,callback);
     return operationPromise;
-  };
+
+  }
   instance.each = instance._version.each;
   instance.list = instance._version.list;
 
-  instance.getPage = function getPage(
-    targetUrl?: any,
-    callback?: any
-  ): Promise<AccountPage> {
-    let operationPromise = this._version._domain.twilio.request({
-      method: "get",
-      uri: targetUrl,
-    });
+  instance.getPage = function getPage(targetUrl?: any, callback?: any): Promise<AccountPage> {
+    let operationPromise = this._version._domain.twilio.request({method: 'get', uri: targetUrl});
 
-    operationPromise = operationPromise.then(
-      (payload) => new AccountPage(this._version, payload, this._solution)
-    );
-    operationPromise = this._version.setPromiseCallback(
-      operationPromise,
-      callback
-    );
+    operationPromise = operationPromise.then(payload => new AccountPage(this._version, payload, this._solution));
+    operationPromise = this._version.setPromiseCallback(operationPromise,callback);
     return operationPromise;
-  };
+  }
+
+
 
   instance.toJSON = function toJSON() {
     return this._solution;
-  };
+  }
 
-  instance[inspect.custom] = function inspectImpl(
-    _depth: any,
-    options: InspectOptions
-  ) {
+  instance[inspect.custom] = function inspectImpl(_depth: any, options: InspectOptions) {
     return inspect(this.toJSON(), options);
-  };
+  }
 
   return instance;
 }
+
+    export class AccountPage extends Page<V2010, AccountPayload, AccountResource, AccountInstance> {
+    /**
+    * Initialize the AccountPage
+    *
+    * @param version - Version of the resource
+    * @param response - Response from the API
+    * @param solution - Path solution
+    */
+    constructor(version: V2010, response: Response<string>, solution: AccountSolution) {
+        super(version, response, solution);
+        }
+
+        /**
+        * Build an instance of AccountInstance
+        *
+        * @param payload - Payload response from the API
+        */
+        getInstance(payload: AccountPayload): AccountInstance {
+        return new AccountInstance(
+        this._version,
+        payload,
+        );
+        }
+
+        [inspect.custom](depth: any, options: InspectOptions) {
+        return inspect(this.toJSON(), options);
+        }
+        }
+

--- a/examples/node/lib/rest/api/v2010/account/call.ts
+++ b/examples/node/lib/rest/api/v2010/account/call.ts
@@ -12,29 +12,26 @@
  * Do not edit the class manually.
  */
 
-
 import { inspect, InspectOptions } from "util";
-import Page from "../../../../base/Page";
+
 import Response from "../../../../http/response";
 import V2010 from "../../V2010";
 const deserialize = require("../../../../base/deserialize");
 const serialize = require("../../../../base/serialize");
 import { FeedbackCallSummaryListInstance } from "./call/feedbackCallSummary";
 
-
 /**
  * Options to pass to create a CallInstance
  *
- * @property { string } requiredStringProperty 
- * @property { Array<string> } [testArrayOfStrings] 
- * @property { Array<string> } [testArrayOfUri] 
+ * @property { string } requiredStringProperty
+ * @property { Array<string> } [testArrayOfStrings]
+ * @property { Array<string> } [testArrayOfUri]
  */
 export interface CallListInstanceCreateOptions {
   requiredStringProperty: string;
   testArrayOfStrings?: Array<string>;
   testArrayOfUri?: Array<string>;
 }
-
 
 export interface CallListInstance {
   (testInteger: number): CallContext;
@@ -50,9 +47,11 @@ export interface CallListInstance {
    *
    * @returns { Promise } Resolves to processed CallInstance
    */
-  create(params: CallListInstanceCreateOptions, callback?: (error: Error | null, item?: CallInstance) => any): Promise<CallInstance>;
-  create(params: any, callback?: any): Promise<CallInstance>
-
+  create(
+    params: CallListInstanceCreateOptions,
+    callback?: (error: Error | null, item?: CallInstance) => any
+  ): Promise<CallInstance>;
+  create(params: any, callback?: any): Promise<CallInstance>;
 
   /**
    * Provide a user-friendly representation
@@ -70,12 +69,16 @@ class CallListInstanceImpl implements CallListInstance {
   _feedbackCallSummary?: FeedbackCallSummaryListInstance;
 }
 
-export function CallListInstance(version: V2010, accountSid: string): CallListInstance {
-  const instance = ((testInteger) => instance.get(testInteger)) as CallListInstanceImpl;
+export function CallListInstance(
+  version: V2010,
+  accountSid: string
+): CallListInstance {
+  const instance = ((testInteger) =>
+    instance.get(testInteger)) as CallListInstanceImpl;
 
   instance.get = function get(testInteger): CallContext {
     return new CallContextImpl(version, accountSid, testInteger);
-  }
+  };
 
   instance._version = version;
   instance._solution = { accountSid };
@@ -84,74 +87,91 @@ export function CallListInstance(version: V2010, accountSid: string): CallListIn
   Object.defineProperty(instance, "feedbackCallSummary", {
     get: function feedbackCallSummary() {
       if (!this._feedbackCallSummary) {
-        this._feedbackCallSummary = FeedbackCallSummaryListInstance(this._version, this._solution.accountSid);
+        this._feedbackCallSummary = FeedbackCallSummaryListInstance(
+          this._version,
+          this._solution.accountSid
+        );
       }
       return this._feedbackCallSummary;
-    }
+    },
   });
 
-  instance.create = function create(params: any, callback?: any): Promise<CallInstance> {
+  instance.create = function create(
+    params: any,
+    callback?: any
+  ): Promise<CallInstance> {
     if (params === null || params === undefined) {
       throw new Error('Required parameter "params" missing.');
     }
 
-    if (params.requiredStringProperty === null || params.requiredStringProperty === undefined) {
-      throw new Error('Required parameter "params.requiredStringProperty" missing.');
+    if (
+      params.requiredStringProperty === null ||
+      params.requiredStringProperty === undefined
+    ) {
+      throw new Error(
+        'Required parameter "params.requiredStringProperty" missing.'
+      );
     }
 
     const data: any = {};
 
-    data['RequiredStringProperty'] = params.requiredStringProperty;
-    if (params.testArrayOfStrings !== undefined) data['TestArrayOfStrings'] = serialize.map(params.testArrayOfStrings, ((e) => e));
-    if (params.testArrayOfUri !== undefined) data['TestArrayOfUri'] = serialize.map(params.testArrayOfUri, ((e) => e));
+    data["RequiredStringProperty"] = params.requiredStringProperty;
+    if (params.testArrayOfStrings !== undefined)
+      data["TestArrayOfStrings"] = serialize.map(
+        params.testArrayOfStrings,
+        (e) => e
+      );
+    if (params.testArrayOfUri !== undefined)
+      data["TestArrayOfUri"] = serialize.map(params.testArrayOfUri, (e) => e);
 
     const headers: any = {};
-    headers['Content-Type'] = 'application/x-www-form-urlencoded'
+    headers["Content-Type"] = "application/x-www-form-urlencoded";
 
     let operationVersion = version,
-        operationPromise = operationVersion.create({ uri: this._uri, method: 'post', params: data, headers });
-    
-    operationPromise = operationPromise.then(payload => new CallInstance(operationVersion, payload, this._solution.accountSid));
-    
+      operationPromise = operationVersion.create({
+        uri: this._uri,
+        method: "post",
+        params: data,
+        headers,
+      });
 
-    operationPromise = this._version.setPromiseCallback(operationPromise,callback);
+    operationPromise = operationPromise.then(
+      (payload) =>
+        new CallInstance(operationVersion, payload, this._solution.accountSid)
+    );
+
+    operationPromise = this._version.setPromiseCallback(
+      operationPromise,
+      callback
+    );
     return operationPromise;
-
-
-
-    }
+  };
 
   instance.toJSON = function toJSON() {
     return this._solution;
-  }
+  };
 
-  instance[inspect.custom] = function inspectImpl(_depth: any, options: InspectOptions) {
+  instance[inspect.custom] = function inspectImpl(
+    _depth: any,
+    options: InspectOptions
+  ) {
     return inspect(this.toJSON(), options);
-  }
+  };
 
   return instance;
 }
 
-
-
 export interface CallContext {
-
-
   /**
    * Remove a CallInstance
    *
    * @param { function } [callback] - Callback to handle processed record
    *
-   * @returns { Promise } Resolves to processed boolean
+   * @returns { Promise } Resolves to processed CallInstance
    */
-<<<<<<< Updated upstream
   remove(
     callback?: (error: Error | null, item?: CallInstance) => any
-  ): Promise<boolean>;
-=======
-  remove(callback?: (error: Error | null, item?: boolean) => any): Promise<boolean>
-
->>>>>>> Stashed changes
+  ): Promise<CallInstance>;
 
   /**
    * Fetch a CallInstance
@@ -160,8 +180,9 @@ export interface CallContext {
    *
    * @returns { Promise } Resolves to processed CallInstance
    */
-  fetch(callback?: (error: Error | null, item?: CallInstance) => any): Promise<CallInstance>
-
+  fetch(
+    callback?: (error: Error | null, item?: CallInstance) => any
+  ): Promise<CallInstance>;
 
   /**
    * Provide a user-friendly representation
@@ -174,38 +195,61 @@ export class CallContextImpl implements CallContext {
   protected _solution: CallSolution;
   protected _uri: string;
 
-
-  constructor(protected _version: V2010, accountSid: string, testInteger: number) {
+  constructor(
+    protected _version: V2010,
+    accountSid: string,
+    testInteger: number
+  ) {
     this._solution = { accountSid, testInteger };
     this._uri = `/Accounts/${accountSid}/Calls/${testInteger}.json`;
   }
 
-  remove(callback?: any): Promise<boolean> {
-  
+  remove(callback?: any): Promise<CallInstance> {
     let operationVersion = this._version,
-        operationPromise = operationVersion.remove({ uri: this._uri, method: 'delete' });
-    
+      operationPromise = operationVersion.remove({
+        uri: this._uri,
+        method: "delete",
+      });
 
-    operationPromise = this._version.setPromiseCallback(operationPromise,callback);
+    operationPromise = operationPromise.then(
+      (payload) =>
+        new CallInstance(
+          operationVersion,
+          payload,
+          this._solution.accountSid,
+          this._solution.testInteger
+        )
+    );
+
+    operationPromise = this._version.setPromiseCallback(
+      operationPromise,
+      callback
+    );
     return operationPromise;
-
-
-
   }
 
   fetch(callback?: any): Promise<CallInstance> {
-  
     let operationVersion = this._version,
-        operationPromise = operationVersion.fetch({ uri: this._uri, method: 'get' });
-    
-    operationPromise = operationPromise.then(payload => new CallInstance(operationVersion, payload, this._solution.accountSid, this._solution.testInteger));
-    
+      operationPromise = operationVersion.fetch({
+        uri: this._uri,
+        method: "get",
+      });
 
-    operationPromise = this._version.setPromiseCallback(operationPromise,callback);
+    operationPromise = operationPromise.then(
+      (payload) =>
+        new CallInstance(
+          operationVersion,
+          payload,
+          this._solution.accountSid,
+          this._solution.testInteger
+        )
+    );
+
+    operationPromise = this._version.setPromiseCallback(
+      operationPromise,
+      callback
+    );
     return operationPromise;
-
-
-
   }
 
   /**
@@ -222,8 +266,7 @@ export class CallContextImpl implements CallContext {
   }
 }
 
-interface CallPayload extends CallResource, Page.TwilioResponsePayload {
-}
+interface CallPayload extends CallResource {}
 
 interface CallResource {
   account_sid?: string | null;
@@ -246,7 +289,12 @@ export class CallInstance {
   protected _solution: CallSolution;
   protected _context?: CallContext;
 
-  constructor(protected _version: V2010, payload: CallPayload, accountSid: string, testInteger?: number) {
+  constructor(
+    protected _version: V2010,
+    payload: CallPayload,
+    accountSid: string,
+    testInteger?: number
+  ) {
     this.accountSid = payload.account_sid;
     this.sid = payload.sid;
     this.testString = payload.test_string;
@@ -262,7 +310,10 @@ export class CallInstance {
     this.testArrayOfObjects = payload.test_array_of_objects;
     this.testArrayOfEnum = payload.test_array_of_enum;
 
-    this._solution = { accountSid, testInteger: testInteger || this.testInteger };
+    this._solution = {
+      accountSid,
+      testInteger: testInteger || this.testInteger,
+    };
   }
 
   accountSid?: string | null;
@@ -284,7 +335,13 @@ export class CallInstance {
   testArrayOfEnum?: Array<object> | null;
 
   private get _proxy(): CallContext {
-    this._context = this._context || new CallContextImpl(this._version, this._solution.accountSid, this._solution.testInteger);
+    this._context =
+      this._context ||
+      new CallContextImpl(
+        this._version,
+        this._solution.accountSid,
+        this._solution.testInteger
+      );
     return this._context;
   }
 
@@ -293,16 +350,11 @@ export class CallInstance {
    *
    * @param { function } [callback] - Callback to handle processed record
    *
-   * @returns { Promise } Resolves to processed boolean
+   * @returns { Promise } Resolves to processed CallInstance
    */
-<<<<<<< Updated upstream
   remove(
     callback?: (error: Error | null, item?: CallInstance) => any
-  ): Promise<boolean> {
-=======
-  remove(callback?: (error: Error | null, item?: boolean) => any): Promise<boolean>
-     {
->>>>>>> Stashed changes
+  ): Promise<CallInstance> {
     return this._proxy.remove(callback);
   }
 
@@ -313,8 +365,9 @@ export class CallInstance {
    *
    * @returns { Promise } Resolves to processed CallInstance
    */
-  fetch(callback?: (error: Error | null, item?: CallInstance) => any): Promise<CallInstance>
-     {
+  fetch(
+    callback?: (error: Error | null, item?: CallInstance) => any
+  ): Promise<CallInstance> {
     return this._proxy.fetch(callback);
   }
 
@@ -325,7 +378,6 @@ export class CallInstance {
    */
   toJSON() {
     return {
-<<<<<<< Updated upstream
       accountSid: this.accountSid,
       sid: this.sid,
       testString: this.testString,
@@ -341,24 +393,6 @@ export class CallInstance {
       testArrayOfObjects: this.testArrayOfObjects,
       testArrayOfEnum: this.testArrayOfEnum,
     };
-=======
-      accountSid: this.accountSid, 
-      sid: this.sid, 
-      testString: this.testString, 
-      testInteger: this.testInteger, 
-      testObject: this.testObject, 
-      testDateTime: this.testDateTime, 
-      testNumber: this.testNumber, 
-      priceUnit: this.priceUnit, 
-      testNumberFloat: this.testNumberFloat, 
-      testEnum: this.testEnum, 
-      a2pProfileBundleSid: this.a2pProfileBundleSid, 
-      testArrayOfIntegers: this.testArrayOfIntegers, 
-      testArrayOfArrayOfIntegers: this.testArrayOfArrayOfIntegers, 
-      testArrayOfObjects: this.testArrayOfObjects, 
-      testArrayOfEnum: this.testArrayOfEnum
-    }
->>>>>>> Stashed changes
   }
 
   [inspect.custom](_depth: any, options: InspectOptions) {
@@ -369,5 +403,3 @@ export interface CallSolution {
   accountSid?: string;
   testInteger?: number;
 }
-
-

--- a/examples/node/lib/rest/api/v2010/account/call.ts
+++ b/examples/node/lib/rest/api/v2010/account/call.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+
 import { inspect, InspectOptions } from "util";
 import Page from "../../../../base/Page";
 import Response from "../../../../http/response";
@@ -20,18 +21,20 @@ const deserialize = require("../../../../base/deserialize");
 const serialize = require("../../../../base/serialize");
 import { FeedbackCallSummaryListInstance } from "./call/feedbackCallSummary";
 
+
 /**
  * Options to pass to create a CallInstance
  *
- * @property { string } requiredStringProperty
- * @property { Array<string> } [testArrayOfStrings]
- * @property { Array<string> } [testArrayOfUri]
+ * @property { string } requiredStringProperty 
+ * @property { Array<string> } [testArrayOfStrings] 
+ * @property { Array<string> } [testArrayOfUri] 
  */
 export interface CallListInstanceCreateOptions {
   requiredStringProperty: string;
   testArrayOfStrings?: Array<string>;
   testArrayOfUri?: Array<string>;
 }
+
 
 export interface CallListInstance {
   (testInteger: number): CallContext;
@@ -47,11 +50,9 @@ export interface CallListInstance {
    *
    * @returns { Promise } Resolves to processed CallInstance
    */
-  create(
-    params: CallListInstanceCreateOptions,
-    callback?: (error: Error | null, item?: CallInstance) => any
-  ): Promise<CallInstance>;
-  create(params: any, callback?: any): Promise<CallInstance>;
+  create(params: CallListInstanceCreateOptions, callback?: (error: Error | null, item?: CallInstance) => any): Promise<CallInstance>;
+  create(params: any, callback?: any): Promise<CallInstance>
+
 
   /**
    * Provide a user-friendly representation
@@ -69,16 +70,12 @@ class CallListInstanceImpl implements CallListInstance {
   _feedbackCallSummary?: FeedbackCallSummaryListInstance;
 }
 
-export function CallListInstance(
-  version: V2010,
-  accountSid: string
-): CallListInstance {
-  const instance = ((testInteger) =>
-    instance.get(testInteger)) as CallListInstanceImpl;
+export function CallListInstance(version: V2010, accountSid: string): CallListInstance {
+  const instance = ((testInteger) => instance.get(testInteger)) as CallListInstanceImpl;
 
   instance.get = function get(testInteger): CallContext {
     return new CallContextImpl(version, accountSid, testInteger);
-  };
+  }
 
   instance._version = version;
   instance._solution = { accountSid };
@@ -87,81 +84,59 @@ export function CallListInstance(
   Object.defineProperty(instance, "feedbackCallSummary", {
     get: function feedbackCallSummary() {
       if (!this._feedbackCallSummary) {
-        this._feedbackCallSummary = FeedbackCallSummaryListInstance(
-          this._version,
-          this._solution.accountSid
-        );
+        this._feedbackCallSummary = FeedbackCallSummaryListInstance(this._version, this._solution.accountSid);
       }
       return this._feedbackCallSummary;
-    },
+    }
   });
 
-  instance.create = function create(
-    params: any,
-    callback?: any
-  ): Promise<CallInstance> {
+  instance.create = function create(params: any, callback?: any): Promise<CallInstance> {
     if (params === null || params === undefined) {
       throw new Error('Required parameter "params" missing.');
     }
 
-    if (
-      params.requiredStringProperty === null ||
-      params.requiredStringProperty === undefined
-    ) {
-      throw new Error(
-        'Required parameter "params.requiredStringProperty" missing.'
-      );
+    if (params.requiredStringProperty === null || params.requiredStringProperty === undefined) {
+      throw new Error('Required parameter "params.requiredStringProperty" missing.');
     }
 
     const data: any = {};
 
-    data["RequiredStringProperty"] = params.requiredStringProperty;
-    if (params.testArrayOfStrings !== undefined)
-      data["TestArrayOfStrings"] = serialize.map(
-        params.testArrayOfStrings,
-        (e) => e
-      );
-    if (params.testArrayOfUri !== undefined)
-      data["TestArrayOfUri"] = serialize.map(params.testArrayOfUri, (e) => e);
+    data['RequiredStringProperty'] = params.requiredStringProperty;
+    if (params.testArrayOfStrings !== undefined) data['TestArrayOfStrings'] = serialize.map(params.testArrayOfStrings, ((e) => e));
+    if (params.testArrayOfUri !== undefined) data['TestArrayOfUri'] = serialize.map(params.testArrayOfUri, ((e) => e));
 
     const headers: any = {};
-    headers["Content-Type"] = "application/x-www-form-urlencoded";
+    headers['Content-Type'] = 'application/x-www-form-urlencoded'
 
     let operationVersion = version,
-      operationPromise = operationVersion.create({
-        uri: this._uri,
-        method: "post",
-        params: data,
-        headers,
-      });
+        operationPromise = operationVersion.create({ uri: this._uri, method: 'post', params: data, headers });
+    
+    operationPromise = operationPromise.then(payload => new CallInstance(operationVersion, payload, this._solution.accountSid));
+    
 
-    operationPromise = operationPromise.then(
-      (payload) =>
-        new CallInstance(operationVersion, payload, this._solution.accountSid)
-    );
-
-    operationPromise = this._version.setPromiseCallback(
-      operationPromise,
-      callback
-    );
+    operationPromise = this._version.setPromiseCallback(operationPromise,callback);
     return operationPromise;
-  };
+
+
+
+    }
 
   instance.toJSON = function toJSON() {
     return this._solution;
-  };
+  }
 
-  instance[inspect.custom] = function inspectImpl(
-    _depth: any,
-    options: InspectOptions
-  ) {
+  instance[inspect.custom] = function inspectImpl(_depth: any, options: InspectOptions) {
     return inspect(this.toJSON(), options);
-  };
+  }
 
   return instance;
 }
 
+
+
 export interface CallContext {
+
+
   /**
    * Remove a CallInstance
    *
@@ -169,9 +144,14 @@ export interface CallContext {
    *
    * @returns { Promise } Resolves to processed boolean
    */
+<<<<<<< Updated upstream
   remove(
     callback?: (error: Error | null, item?: CallInstance) => any
   ): Promise<boolean>;
+=======
+  remove(callback?: (error: Error | null, item?: boolean) => any): Promise<boolean>
+
+>>>>>>> Stashed changes
 
   /**
    * Fetch a CallInstance
@@ -180,9 +160,8 @@ export interface CallContext {
    *
    * @returns { Promise } Resolves to processed CallInstance
    */
-  fetch(
-    callback?: (error: Error | null, item?: CallInstance) => any
-  ): Promise<CallInstance>;
+  fetch(callback?: (error: Error | null, item?: CallInstance) => any): Promise<CallInstance>
+
 
   /**
    * Provide a user-friendly representation
@@ -195,51 +174,38 @@ export class CallContextImpl implements CallContext {
   protected _solution: CallSolution;
   protected _uri: string;
 
-  constructor(
-    protected _version: V2010,
-    accountSid: string,
-    testInteger: number
-  ) {
+
+  constructor(protected _version: V2010, accountSid: string, testInteger: number) {
     this._solution = { accountSid, testInteger };
     this._uri = `/Accounts/${accountSid}/Calls/${testInteger}.json`;
   }
 
   remove(callback?: any): Promise<boolean> {
+  
     let operationVersion = this._version,
-      operationPromise = operationVersion.remove({
-        uri: this._uri,
-        method: "delete",
-      });
+        operationPromise = operationVersion.remove({ uri: this._uri, method: 'delete' });
+    
 
-    operationPromise = this._version.setPromiseCallback(
-      operationPromise,
-      callback
-    );
+    operationPromise = this._version.setPromiseCallback(operationPromise,callback);
     return operationPromise;
+
+
+
   }
 
   fetch(callback?: any): Promise<CallInstance> {
+  
     let operationVersion = this._version,
-      operationPromise = operationVersion.fetch({
-        uri: this._uri,
-        method: "get",
-      });
+        operationPromise = operationVersion.fetch({ uri: this._uri, method: 'get' });
+    
+    operationPromise = operationPromise.then(payload => new CallInstance(operationVersion, payload, this._solution.accountSid, this._solution.testInteger));
+    
 
-    operationPromise = operationPromise.then(
-      (payload) =>
-        new CallInstance(
-          operationVersion,
-          payload,
-          this._solution.accountSid,
-          this._solution.testInteger
-        )
-    );
-
-    operationPromise = this._version.setPromiseCallback(
-      operationPromise,
-      callback
-    );
+    operationPromise = this._version.setPromiseCallback(operationPromise,callback);
     return operationPromise;
+
+
+
   }
 
   /**
@@ -256,7 +222,8 @@ export class CallContextImpl implements CallContext {
   }
 }
 
-interface CallPayload extends CallResource, Page.TwilioResponsePayload {}
+interface CallPayload extends CallResource, Page.TwilioResponsePayload {
+}
 
 interface CallResource {
   account_sid?: string | null;
@@ -279,12 +246,7 @@ export class CallInstance {
   protected _solution: CallSolution;
   protected _context?: CallContext;
 
-  constructor(
-    protected _version: V2010,
-    payload: CallPayload,
-    accountSid: string,
-    testInteger?: number
-  ) {
+  constructor(protected _version: V2010, payload: CallPayload, accountSid: string, testInteger?: number) {
     this.accountSid = payload.account_sid;
     this.sid = payload.sid;
     this.testString = payload.test_string;
@@ -300,10 +262,7 @@ export class CallInstance {
     this.testArrayOfObjects = payload.test_array_of_objects;
     this.testArrayOfEnum = payload.test_array_of_enum;
 
-    this._solution = {
-      accountSid,
-      testInteger: testInteger || this.testInteger,
-    };
+    this._solution = { accountSid, testInteger: testInteger || this.testInteger };
   }
 
   accountSid?: string | null;
@@ -325,13 +284,7 @@ export class CallInstance {
   testArrayOfEnum?: Array<object> | null;
 
   private get _proxy(): CallContext {
-    this._context =
-      this._context ||
-      new CallContextImpl(
-        this._version,
-        this._solution.accountSid,
-        this._solution.testInteger
-      );
+    this._context = this._context || new CallContextImpl(this._version, this._solution.accountSid, this._solution.testInteger);
     return this._context;
   }
 
@@ -342,9 +295,14 @@ export class CallInstance {
    *
    * @returns { Promise } Resolves to processed boolean
    */
+<<<<<<< Updated upstream
   remove(
     callback?: (error: Error | null, item?: CallInstance) => any
   ): Promise<boolean> {
+=======
+  remove(callback?: (error: Error | null, item?: boolean) => any): Promise<boolean>
+     {
+>>>>>>> Stashed changes
     return this._proxy.remove(callback);
   }
 
@@ -355,9 +313,8 @@ export class CallInstance {
    *
    * @returns { Promise } Resolves to processed CallInstance
    */
-  fetch(
-    callback?: (error: Error | null, item?: CallInstance) => any
-  ): Promise<CallInstance> {
+  fetch(callback?: (error: Error | null, item?: CallInstance) => any): Promise<CallInstance>
+     {
     return this._proxy.fetch(callback);
   }
 
@@ -368,6 +325,7 @@ export class CallInstance {
    */
   toJSON() {
     return {
+<<<<<<< Updated upstream
       accountSid: this.accountSid,
       sid: this.sid,
       testString: this.testString,
@@ -383,6 +341,24 @@ export class CallInstance {
       testArrayOfObjects: this.testArrayOfObjects,
       testArrayOfEnum: this.testArrayOfEnum,
     };
+=======
+      accountSid: this.accountSid, 
+      sid: this.sid, 
+      testString: this.testString, 
+      testInteger: this.testInteger, 
+      testObject: this.testObject, 
+      testDateTime: this.testDateTime, 
+      testNumber: this.testNumber, 
+      priceUnit: this.priceUnit, 
+      testNumberFloat: this.testNumberFloat, 
+      testEnum: this.testEnum, 
+      a2pProfileBundleSid: this.a2pProfileBundleSid, 
+      testArrayOfIntegers: this.testArrayOfIntegers, 
+      testArrayOfArrayOfIntegers: this.testArrayOfArrayOfIntegers, 
+      testArrayOfObjects: this.testArrayOfObjects, 
+      testArrayOfEnum: this.testArrayOfEnum
+    }
+>>>>>>> Stashed changes
   }
 
   [inspect.custom](_depth: any, options: InspectOptions) {
@@ -394,42 +370,4 @@ export interface CallSolution {
   testInteger?: number;
 }
 
-export class CallPage extends Page<
-  V2010,
-  CallPayload,
-  CallResource,
-  CallInstance
-> {
-  /**
-   * Initialize the CallPage
-   *
-   * @param version - Version of the resource
-   * @param response - Response from the API
-   * @param solution - Path solution
-   */
-  constructor(
-    version: V2010,
-    response: Response<string>,
-    solution: CallSolution
-  ) {
-    super(version, response, solution);
-  }
 
-  /**
-   * Build an instance of CallInstance
-   *
-   * @param payload - Payload response from the API
-   */
-  getInstance(payload: CallPayload): CallInstance {
-    return new CallInstance(
-      this._version,
-      payload,
-      this._solution.accountSid,
-      this._solution.testInteger
-    );
-  }
-
-  [inspect.custom](depth: any, options: InspectOptions) {
-    return inspect(this.toJSON(), options);
-  }
-}

--- a/examples/node/lib/rest/api/v2010/account/call.ts
+++ b/examples/node/lib/rest/api/v2010/account/call.ts
@@ -13,8 +13,6 @@
  */
 
 import { inspect, InspectOptions } from "util";
-
-import Response from "../../../../http/response";
 import V2010 from "../../V2010";
 const deserialize = require("../../../../base/deserialize");
 const serialize = require("../../../../base/serialize");

--- a/examples/node/lib/rest/api/v2010/account/call.ts
+++ b/examples/node/lib/rest/api/v2010/account/call.ts
@@ -169,11 +169,11 @@ export interface CallContext {
    *
    * @param { function } [callback] - Callback to handle processed record
    *
-   * @returns { Promise } Resolves to processed CallInstance
+   * @returns { Promise } Resolves to processed boolean
    */
   remove(
-    callback?: (error: Error | null, item?: CallInstance) => any
-  ): Promise<CallInstance>;
+    callback?: (error: Error | null, item?: boolean) => any
+  ): Promise<boolean>;
 
   /**
    * Fetch a CallInstance
@@ -211,22 +211,12 @@ export class CallContextImpl implements CallContext {
     this._uri = `/Accounts/${accountSid}/Calls/${testInteger}.json`;
   }
 
-  remove(callback?: any): Promise<CallInstance> {
+  remove(callback?: any): Promise<boolean> {
     let operationVersion = this._version,
       operationPromise = operationVersion.remove({
         uri: this._uri,
         method: "delete",
       });
-
-    operationPromise = operationPromise.then(
-      (payload) =>
-        new CallInstance(
-          operationVersion,
-          payload,
-          this._solution.accountSid,
-          this._solution.testInteger
-        )
-    );
 
     operationPromise = this._version.setPromiseCallback(
       operationPromise,
@@ -363,11 +353,11 @@ export class CallInstance {
    *
    * @param { function } [callback] - Callback to handle processed record
    *
-   * @returns { Promise } Resolves to processed CallInstance
+   * @returns { Promise } Resolves to processed boolean
    */
   remove(
-    callback?: (error: Error | null, item?: CallInstance) => any
-  ): Promise<CallInstance> {
+    callback?: (error: Error | null, item?: boolean) => any
+  ): Promise<boolean> {
     return this._proxy.remove(callback);
   }
 
@@ -412,8 +402,4 @@ export class CallInstance {
   [inspect.custom](_depth: any, options: InspectOptions) {
     return inspect(this.toJSON(), options);
   }
-}
-export interface CallSolution {
-  accountSid?: string;
-  testInteger?: number;
 }

--- a/examples/node/lib/rest/api/v2010/account/call/feedbackCallSummary.ts
+++ b/examples/node/lib/rest/api/v2010/account/call/feedbackCallSummary.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+
 import { inspect, InspectOptions } from "util";
 import Page from "../../../../../base/Page";
 import Response from "../../../../../http/response";
@@ -19,11 +20,19 @@ import V2010 from "../../../V2010";
 const deserialize = require("../../../../../base/deserialize");
 const serialize = require("../../../../../base/serialize");
 
+
+
 /**
  * Options to pass to update a FeedbackCallSummaryInstance
  *
+<<<<<<< Updated upstream
  * @property { string } endDate
  * @property { string } startDate
+=======
+ * @property { string } endDate 
+ * @property { string } startDate 
+ * @property { string } [accountSid2] 
+>>>>>>> Stashed changes
  */
 export interface FeedbackCallSummaryContextUpdateOptions {
   endDate: string;
@@ -34,6 +43,7 @@ export interface FeedbackCallSummaryListInstance {
   (sid: string): FeedbackCallSummaryContext;
   get(sid: string): FeedbackCallSummaryContext;
 
+
   /**
    * Provide a user-friendly representation
    */
@@ -41,26 +51,20 @@ export interface FeedbackCallSummaryListInstance {
   [inspect.custom](_depth: any, options: InspectOptions): any;
 }
 
-interface FeedbackCallSummaryListInstanceImpl
-  extends FeedbackCallSummaryListInstance {}
-class FeedbackCallSummaryListInstanceImpl
-  implements FeedbackCallSummaryListInstance
-{
+interface FeedbackCallSummaryListInstanceImpl extends FeedbackCallSummaryListInstance {}
+class FeedbackCallSummaryListInstanceImpl implements FeedbackCallSummaryListInstance {
   _version?: V2010;
   _solution?: FeedbackCallSummarySolution;
   _uri?: string;
+
 }
 
-export function FeedbackCallSummaryListInstance(
-  version: V2010,
-  accountSid: string
-): FeedbackCallSummaryListInstance {
-  const instance = ((sid) =>
-    instance.get(sid)) as FeedbackCallSummaryListInstanceImpl;
+export function FeedbackCallSummaryListInstance(version: V2010, accountSid: string): FeedbackCallSummaryListInstance {
+  const instance = ((sid) => instance.get(sid)) as FeedbackCallSummaryListInstanceImpl;
 
   instance.get = function get(sid): FeedbackCallSummaryContext {
     return new FeedbackCallSummaryContextImpl(version, accountSid, sid);
-  };
+  }
 
   instance._version = version;
   instance._solution = { accountSid };
@@ -68,19 +72,20 @@ export function FeedbackCallSummaryListInstance(
 
   instance.toJSON = function toJSON() {
     return this._solution;
-  };
+  }
 
-  instance[inspect.custom] = function inspectImpl(
-    _depth: any,
-    options: InspectOptions
-  ) {
+  instance[inspect.custom] = function inspectImpl(_depth: any, options: InspectOptions) {
     return inspect(this.toJSON(), options);
-  };
+  }
 
   return instance;
 }
 
+
+
 export interface FeedbackCallSummaryContext {
+
+
   /**
    * Update a FeedbackCallSummaryInstance
    *
@@ -89,11 +94,9 @@ export interface FeedbackCallSummaryContext {
    *
    * @returns { Promise } Resolves to processed FeedbackCallSummaryInstance
    */
-  update(
-    params: FeedbackCallSummaryContextUpdateOptions,
-    callback?: (error: Error | null, item?: FeedbackCallSummaryInstance) => any
-  ): Promise<FeedbackCallSummaryInstance>;
-  update(params: any, callback?: any): Promise<FeedbackCallSummaryInstance>;
+  update(params: FeedbackCallSummaryContextUpdateOptions, callback?: (error: Error | null, item?: FeedbackCallSummaryInstance) => any): Promise<FeedbackCallSummaryInstance>;
+  update(params: any, callback?: any): Promise<FeedbackCallSummaryInstance>
+
 
   /**
    * Provide a user-friendly representation
@@ -102,11 +105,10 @@ export interface FeedbackCallSummaryContext {
   [inspect.custom](_depth: any, options: InspectOptions): any;
 }
 
-export class FeedbackCallSummaryContextImpl
-  implements FeedbackCallSummaryContext
-{
+export class FeedbackCallSummaryContextImpl implements FeedbackCallSummaryContext {
   protected _solution: FeedbackCallSummarySolution;
   protected _uri: string;
+
 
   constructor(protected _version: V2010, accountSid: string, sid: string) {
     this._solution = { accountSid, sid };
@@ -114,7 +116,7 @@ export class FeedbackCallSummaryContextImpl
   }
 
   update(params: any, callback?: any): Promise<FeedbackCallSummaryInstance> {
-    if (params === null || params === undefined) {
+      if (params === null || params === undefined) {
       throw new Error('Required parameter "params" missing.');
     }
 
@@ -128,35 +130,29 @@ export class FeedbackCallSummaryContextImpl
 
     const data: any = {};
 
+<<<<<<< Updated upstream
     data["EndDate"] = serialize.iso8601Date(params.endDate);
     data["StartDate"] = serialize.iso8601Date(params.startDate);
+=======
+    if (params.accountSid2 !== undefined) data['AccountSid'] = params.accountSid2;
+    data['EndDate'] = serialize.iso8601Date(params.endDate);
+    data['StartDate'] = serialize.iso8601Date(params.startDate);
+>>>>>>> Stashed changes
 
     const headers: any = {};
-    headers["Content-Type"] = "application/x-www-form-urlencoded";
+    headers['Content-Type'] = 'application/x-www-form-urlencoded'
 
     let operationVersion = this._version,
-      operationPromise = operationVersion.update({
-        uri: this._uri,
-        method: "post",
-        params: data,
-        headers,
-      });
+        operationPromise = operationVersion.update({ uri: this._uri, method: 'post', params: data, headers });
+    
+    operationPromise = operationPromise.then(payload => new FeedbackCallSummaryInstance(operationVersion, payload, this._solution.accountSid, this._solution.sid));
+    
 
-    operationPromise = operationPromise.then(
-      (payload) =>
-        new FeedbackCallSummaryInstance(
-          operationVersion,
-          payload,
-          this._solution.accountSid,
-          this._solution.sid
-        )
-    );
-
-    operationPromise = this._version.setPromiseCallback(
-      operationPromise,
-      callback
-    );
+    operationPromise = this._version.setPromiseCallback(operationPromise,callback);
     return operationPromise;
+
+
+
   }
 
   /**
@@ -173,9 +169,8 @@ export class FeedbackCallSummaryContextImpl
   }
 }
 
-interface FeedbackCallSummaryPayload
-  extends FeedbackCallSummaryResource,
-    Page.TwilioResponsePayload {}
+interface FeedbackCallSummaryPayload extends FeedbackCallSummaryResource, Page.TwilioResponsePayload {
+}
 
 interface FeedbackCallSummaryResource {
   account_sid?: string | null;
@@ -198,12 +193,7 @@ export class FeedbackCallSummaryInstance {
   protected _solution: FeedbackCallSummarySolution;
   protected _context?: FeedbackCallSummaryContext;
 
-  constructor(
-    protected _version: V2010,
-    payload: FeedbackCallSummaryPayload,
-    accountSid: string,
-    sid?: string
-  ) {
+  constructor(protected _version: V2010, payload: FeedbackCallSummaryPayload, accountSid: string, sid?: string) {
     this.accountSid = payload.account_sid;
     this.sid = payload.sid;
     this.testString = payload.test_string;
@@ -241,13 +231,7 @@ export class FeedbackCallSummaryInstance {
   testArrayOfEnum?: Array<object> | null;
 
   private get _proxy(): FeedbackCallSummaryContext {
-    this._context =
-      this._context ||
-      new FeedbackCallSummaryContextImpl(
-        this._version,
-        this._solution.accountSid,
-        this._solution.sid
-      );
+    this._context = this._context || new FeedbackCallSummaryContextImpl(this._version, this._solution.accountSid, this._solution.sid);
     return this._context;
   }
 
@@ -259,11 +243,9 @@ export class FeedbackCallSummaryInstance {
    *
    * @returns { Promise } Resolves to processed FeedbackCallSummaryInstance
    */
-  update(
-    params: FeedbackCallSummaryContextUpdateOptions,
-    callback?: (error: Error | null, item?: FeedbackCallSummaryInstance) => any
-  ): Promise<FeedbackCallSummaryInstance>;
-  update(params: any, callback?: any): Promise<FeedbackCallSummaryInstance> {
+  update(params: FeedbackCallSummaryContextUpdateOptions, callback?: (error: Error | null, item?: FeedbackCallSummaryInstance) => any): Promise<FeedbackCallSummaryInstance>;
+  update(params: any, callback?: any): Promise<FeedbackCallSummaryInstance>
+     {
     return this._proxy.update(params, callback);
   }
 
@@ -274,6 +256,7 @@ export class FeedbackCallSummaryInstance {
    */
   toJSON() {
     return {
+<<<<<<< Updated upstream
       accountSid: this.accountSid,
       sid: this.sid,
       testString: this.testString,
@@ -289,6 +272,24 @@ export class FeedbackCallSummaryInstance {
       testArrayOfObjects: this.testArrayOfObjects,
       testArrayOfEnum: this.testArrayOfEnum,
     };
+=======
+      accountSid: this.accountSid, 
+      sid: this.sid, 
+      testString: this.testString, 
+      testInteger: this.testInteger, 
+      testObject: this.testObject, 
+      testDateTime: this.testDateTime, 
+      testNumber: this.testNumber, 
+      priceUnit: this.priceUnit, 
+      testNumberFloat: this.testNumberFloat, 
+      testEnum: this.testEnum, 
+      a2pProfileBundleSid: this.a2pProfileBundleSid, 
+      testArrayOfIntegers: this.testArrayOfIntegers, 
+      testArrayOfArrayOfIntegers: this.testArrayOfArrayOfIntegers, 
+      testArrayOfObjects: this.testArrayOfObjects, 
+      testArrayOfEnum: this.testArrayOfEnum
+    }
+>>>>>>> Stashed changes
   }
 
   [inspect.custom](_depth: any, options: InspectOptions) {
@@ -300,44 +301,4 @@ export interface FeedbackCallSummarySolution {
   sid?: string;
 }
 
-export class FeedbackCallSummaryPage extends Page<
-  V2010,
-  FeedbackCallSummaryPayload,
-  FeedbackCallSummaryResource,
-  FeedbackCallSummaryInstance
-> {
-  /**
-   * Initialize the FeedbackCallSummaryPage
-   *
-   * @param version - Version of the resource
-   * @param response - Response from the API
-   * @param solution - Path solution
-   */
-  constructor(
-    version: V2010,
-    response: Response<string>,
-    solution: FeedbackCallSummarySolution
-  ) {
-    super(version, response, solution);
-  }
 
-  /**
-   * Build an instance of FeedbackCallSummaryInstance
-   *
-   * @param payload - Payload response from the API
-   */
-  getInstance(
-    payload: FeedbackCallSummaryPayload
-  ): FeedbackCallSummaryInstance {
-    return new FeedbackCallSummaryInstance(
-      this._version,
-      payload,
-      this._solution.accountSid,
-      this._solution.sid
-    );
-  }
-
-  [inspect.custom](depth: any, options: InspectOptions) {
-    return inspect(this.toJSON(), options);
-  }
-}

--- a/examples/node/lib/rest/api/v2010/account/call/feedbackCallSummary.ts
+++ b/examples/node/lib/rest/api/v2010/account/call/feedbackCallSummary.ts
@@ -13,8 +13,6 @@
  */
 
 import { inspect, InspectOptions } from "util";
-
-import Response from "../../../../../http/response";
 import V2010 from "../../../V2010";
 const deserialize = require("../../../../../base/deserialize");
 const serialize = require("../../../../../base/serialize");

--- a/examples/node/lib/rest/api/v2010/account/call/feedbackCallSummary.ts
+++ b/examples/node/lib/rest/api/v2010/account/call/feedbackCallSummary.ts
@@ -311,7 +311,3 @@ export class FeedbackCallSummaryInstance {
     return inspect(this.toJSON(), options);
   }
 }
-export interface FeedbackCallSummarySolution {
-  accountSid?: string;
-  sid?: string;
-}

--- a/examples/node/lib/rest/api/v2010/account/call/feedbackCallSummary.ts
+++ b/examples/node/lib/rest/api/v2010/account/call/feedbackCallSummary.ts
@@ -12,27 +12,18 @@
  * Do not edit the class manually.
  */
 
-
 import { inspect, InspectOptions } from "util";
-import Page from "../../../../../base/Page";
+
 import Response from "../../../../../http/response";
 import V2010 from "../../../V2010";
 const deserialize = require("../../../../../base/deserialize");
 const serialize = require("../../../../../base/serialize");
 
-
-
 /**
  * Options to pass to update a FeedbackCallSummaryInstance
  *
-<<<<<<< Updated upstream
  * @property { string } endDate
  * @property { string } startDate
-=======
- * @property { string } endDate 
- * @property { string } startDate 
- * @property { string } [accountSid2] 
->>>>>>> Stashed changes
  */
 export interface FeedbackCallSummaryContextUpdateOptions {
   endDate: string;
@@ -43,7 +34,6 @@ export interface FeedbackCallSummaryListInstance {
   (sid: string): FeedbackCallSummaryContext;
   get(sid: string): FeedbackCallSummaryContext;
 
-
   /**
    * Provide a user-friendly representation
    */
@@ -51,20 +41,26 @@ export interface FeedbackCallSummaryListInstance {
   [inspect.custom](_depth: any, options: InspectOptions): any;
 }
 
-interface FeedbackCallSummaryListInstanceImpl extends FeedbackCallSummaryListInstance {}
-class FeedbackCallSummaryListInstanceImpl implements FeedbackCallSummaryListInstance {
+interface FeedbackCallSummaryListInstanceImpl
+  extends FeedbackCallSummaryListInstance {}
+class FeedbackCallSummaryListInstanceImpl
+  implements FeedbackCallSummaryListInstance
+{
   _version?: V2010;
   _solution?: FeedbackCallSummarySolution;
   _uri?: string;
-
 }
 
-export function FeedbackCallSummaryListInstance(version: V2010, accountSid: string): FeedbackCallSummaryListInstance {
-  const instance = ((sid) => instance.get(sid)) as FeedbackCallSummaryListInstanceImpl;
+export function FeedbackCallSummaryListInstance(
+  version: V2010,
+  accountSid: string
+): FeedbackCallSummaryListInstance {
+  const instance = ((sid) =>
+    instance.get(sid)) as FeedbackCallSummaryListInstanceImpl;
 
   instance.get = function get(sid): FeedbackCallSummaryContext {
     return new FeedbackCallSummaryContextImpl(version, accountSid, sid);
-  }
+  };
 
   instance._version = version;
   instance._solution = { accountSid };
@@ -72,20 +68,19 @@ export function FeedbackCallSummaryListInstance(version: V2010, accountSid: stri
 
   instance.toJSON = function toJSON() {
     return this._solution;
-  }
+  };
 
-  instance[inspect.custom] = function inspectImpl(_depth: any, options: InspectOptions) {
+  instance[inspect.custom] = function inspectImpl(
+    _depth: any,
+    options: InspectOptions
+  ) {
     return inspect(this.toJSON(), options);
-  }
+  };
 
   return instance;
 }
 
-
-
 export interface FeedbackCallSummaryContext {
-
-
   /**
    * Update a FeedbackCallSummaryInstance
    *
@@ -94,9 +89,11 @@ export interface FeedbackCallSummaryContext {
    *
    * @returns { Promise } Resolves to processed FeedbackCallSummaryInstance
    */
-  update(params: FeedbackCallSummaryContextUpdateOptions, callback?: (error: Error | null, item?: FeedbackCallSummaryInstance) => any): Promise<FeedbackCallSummaryInstance>;
-  update(params: any, callback?: any): Promise<FeedbackCallSummaryInstance>
-
+  update(
+    params: FeedbackCallSummaryContextUpdateOptions,
+    callback?: (error: Error | null, item?: FeedbackCallSummaryInstance) => any
+  ): Promise<FeedbackCallSummaryInstance>;
+  update(params: any, callback?: any): Promise<FeedbackCallSummaryInstance>;
 
   /**
    * Provide a user-friendly representation
@@ -105,10 +102,11 @@ export interface FeedbackCallSummaryContext {
   [inspect.custom](_depth: any, options: InspectOptions): any;
 }
 
-export class FeedbackCallSummaryContextImpl implements FeedbackCallSummaryContext {
+export class FeedbackCallSummaryContextImpl
+  implements FeedbackCallSummaryContext
+{
   protected _solution: FeedbackCallSummarySolution;
   protected _uri: string;
-
 
   constructor(protected _version: V2010, accountSid: string, sid: string) {
     this._solution = { accountSid, sid };
@@ -116,7 +114,7 @@ export class FeedbackCallSummaryContextImpl implements FeedbackCallSummaryContex
   }
 
   update(params: any, callback?: any): Promise<FeedbackCallSummaryInstance> {
-      if (params === null || params === undefined) {
+    if (params === null || params === undefined) {
       throw new Error('Required parameter "params" missing.');
     }
 
@@ -130,29 +128,35 @@ export class FeedbackCallSummaryContextImpl implements FeedbackCallSummaryContex
 
     const data: any = {};
 
-<<<<<<< Updated upstream
     data["EndDate"] = serialize.iso8601Date(params.endDate);
     data["StartDate"] = serialize.iso8601Date(params.startDate);
-=======
-    if (params.accountSid2 !== undefined) data['AccountSid'] = params.accountSid2;
-    data['EndDate'] = serialize.iso8601Date(params.endDate);
-    data['StartDate'] = serialize.iso8601Date(params.startDate);
->>>>>>> Stashed changes
 
     const headers: any = {};
-    headers['Content-Type'] = 'application/x-www-form-urlencoded'
+    headers["Content-Type"] = "application/x-www-form-urlencoded";
 
     let operationVersion = this._version,
-        operationPromise = operationVersion.update({ uri: this._uri, method: 'post', params: data, headers });
-    
-    operationPromise = operationPromise.then(payload => new FeedbackCallSummaryInstance(operationVersion, payload, this._solution.accountSid, this._solution.sid));
-    
+      operationPromise = operationVersion.update({
+        uri: this._uri,
+        method: "post",
+        params: data,
+        headers,
+      });
 
-    operationPromise = this._version.setPromiseCallback(operationPromise,callback);
+    operationPromise = operationPromise.then(
+      (payload) =>
+        new FeedbackCallSummaryInstance(
+          operationVersion,
+          payload,
+          this._solution.accountSid,
+          this._solution.sid
+        )
+    );
+
+    operationPromise = this._version.setPromiseCallback(
+      operationPromise,
+      callback
+    );
     return operationPromise;
-
-
-
   }
 
   /**
@@ -169,8 +173,7 @@ export class FeedbackCallSummaryContextImpl implements FeedbackCallSummaryContex
   }
 }
 
-interface FeedbackCallSummaryPayload extends FeedbackCallSummaryResource, Page.TwilioResponsePayload {
-}
+interface FeedbackCallSummaryPayload extends FeedbackCallSummaryResource {}
 
 interface FeedbackCallSummaryResource {
   account_sid?: string | null;
@@ -193,7 +196,12 @@ export class FeedbackCallSummaryInstance {
   protected _solution: FeedbackCallSummarySolution;
   protected _context?: FeedbackCallSummaryContext;
 
-  constructor(protected _version: V2010, payload: FeedbackCallSummaryPayload, accountSid: string, sid?: string) {
+  constructor(
+    protected _version: V2010,
+    payload: FeedbackCallSummaryPayload,
+    accountSid: string,
+    sid?: string
+  ) {
     this.accountSid = payload.account_sid;
     this.sid = payload.sid;
     this.testString = payload.test_string;
@@ -231,7 +239,13 @@ export class FeedbackCallSummaryInstance {
   testArrayOfEnum?: Array<object> | null;
 
   private get _proxy(): FeedbackCallSummaryContext {
-    this._context = this._context || new FeedbackCallSummaryContextImpl(this._version, this._solution.accountSid, this._solution.sid);
+    this._context =
+      this._context ||
+      new FeedbackCallSummaryContextImpl(
+        this._version,
+        this._solution.accountSid,
+        this._solution.sid
+      );
     return this._context;
   }
 
@@ -243,9 +257,11 @@ export class FeedbackCallSummaryInstance {
    *
    * @returns { Promise } Resolves to processed FeedbackCallSummaryInstance
    */
-  update(params: FeedbackCallSummaryContextUpdateOptions, callback?: (error: Error | null, item?: FeedbackCallSummaryInstance) => any): Promise<FeedbackCallSummaryInstance>;
-  update(params: any, callback?: any): Promise<FeedbackCallSummaryInstance>
-     {
+  update(
+    params: FeedbackCallSummaryContextUpdateOptions,
+    callback?: (error: Error | null, item?: FeedbackCallSummaryInstance) => any
+  ): Promise<FeedbackCallSummaryInstance>;
+  update(params: any, callback?: any): Promise<FeedbackCallSummaryInstance> {
     return this._proxy.update(params, callback);
   }
 
@@ -256,7 +272,6 @@ export class FeedbackCallSummaryInstance {
    */
   toJSON() {
     return {
-<<<<<<< Updated upstream
       accountSid: this.accountSid,
       sid: this.sid,
       testString: this.testString,
@@ -272,24 +287,6 @@ export class FeedbackCallSummaryInstance {
       testArrayOfObjects: this.testArrayOfObjects,
       testArrayOfEnum: this.testArrayOfEnum,
     };
-=======
-      accountSid: this.accountSid, 
-      sid: this.sid, 
-      testString: this.testString, 
-      testInteger: this.testInteger, 
-      testObject: this.testObject, 
-      testDateTime: this.testDateTime, 
-      testNumber: this.testNumber, 
-      priceUnit: this.priceUnit, 
-      testNumberFloat: this.testNumberFloat, 
-      testEnum: this.testEnum, 
-      a2pProfileBundleSid: this.a2pProfileBundleSid, 
-      testArrayOfIntegers: this.testArrayOfIntegers, 
-      testArrayOfArrayOfIntegers: this.testArrayOfArrayOfIntegers, 
-      testArrayOfObjects: this.testArrayOfObjects, 
-      testArrayOfEnum: this.testArrayOfEnum
-    }
->>>>>>> Stashed changes
   }
 
   [inspect.custom](_depth: any, options: InspectOptions) {
@@ -300,5 +297,3 @@ export interface FeedbackCallSummarySolution {
   accountSid?: string;
   sid?: string;
 }
-
-

--- a/examples/node/lib/rest/flexApi/v1/call.ts
+++ b/examples/node/lib/rest/flexApi/v1/call.ts
@@ -179,6 +179,3 @@ export class CallInstance {
     return inspect(this.toJSON(), options);
   }
 }
-export interface CallSolution {
-  sid?: string;
-}

--- a/examples/node/lib/rest/flexApi/v1/call.ts
+++ b/examples/node/lib/rest/flexApi/v1/call.ts
@@ -13,7 +13,7 @@
  */
 
 import { inspect, InspectOptions } from "util";
-import Page from "../../../base/Page";
+
 import Response from "../../../http/response";
 import V1 from "../V1";
 const deserialize = require("../../../base/deserialize");
@@ -123,7 +123,7 @@ export class CallContextImpl implements CallContext {
   }
 }
 
-interface CallPayload extends CallResource, Page.TwilioResponsePayload {}
+interface CallPayload extends CallResource {}
 
 interface CallResource {
   sid?: string | null;
@@ -177,35 +177,4 @@ export class CallInstance {
 }
 export interface CallSolution {
   sid?: string;
-}
-
-export class CallPage extends Page<
-  V1,
-  CallPayload,
-  CallResource,
-  CallInstance
-> {
-  /**
-   * Initialize the CallPage
-   *
-   * @param version - Version of the resource
-   * @param response - Response from the API
-   * @param solution - Path solution
-   */
-  constructor(version: V1, response: Response<string>, solution: CallSolution) {
-    super(version, response, solution);
-  }
-
-  /**
-   * Build an instance of CallInstance
-   *
-   * @param payload - Payload response from the API
-   */
-  getInstance(payload: CallPayload): CallInstance {
-    return new CallInstance(this._version, payload, this._solution.sid);
-  }
-
-  [inspect.custom](depth: any, options: InspectOptions) {
-    return inspect(this.toJSON(), options);
-  }
 }

--- a/examples/node/lib/rest/flexApi/v1/call.ts
+++ b/examples/node/lib/rest/flexApi/v1/call.ts
@@ -13,8 +13,6 @@
  */
 
 import { inspect, InspectOptions } from "util";
-
-import Response from "../../../http/response";
 import V1 from "../V1";
 const deserialize = require("../../../base/deserialize");
 const serialize = require("../../../base/serialize");

--- a/examples/node/lib/rest/flexApi/v1/credential.ts
+++ b/examples/node/lib/rest/flexApi/v1/credential.ts
@@ -13,7 +13,7 @@
  */
 
 import { inspect, InspectOptions } from "util";
-import Page from "../../../base/Page";
+
 import Response from "../../../http/response";
 import V1 from "../V1";
 const deserialize = require("../../../base/deserialize");

--- a/examples/node/lib/rest/flexApi/v1/credential.ts
+++ b/examples/node/lib/rest/flexApi/v1/credential.ts
@@ -13,8 +13,6 @@
  */
 
 import { inspect, InspectOptions } from "util";
-
-import Response from "../../../http/response";
 import V1 from "../V1";
 const deserialize = require("../../../base/deserialize");
 const serialize = require("../../../base/serialize");

--- a/examples/node/lib/rest/flexApi/v1/credential/aws.ts
+++ b/examples/node/lib/rest/flexApi/v1/credential/aws.ts
@@ -83,11 +83,11 @@ export interface AWSContext {
    *
    * @param { function } [callback] - Callback to handle processed record
    *
-   * @returns { Promise } Resolves to processed AWSInstance
+   * @returns { Promise } Resolves to processed boolean
    */
   remove(
-    callback?: (error: Error | null, item?: AWSInstance) => any
-  ): Promise<AWSInstance>;
+    callback?: (error: Error | null, item?: boolean) => any
+  ): Promise<boolean>;
 
   /**
    * Fetch a AWSInstance
@@ -144,17 +144,12 @@ export class AWSContextImpl implements AWSContext {
     this._uri = `/Credentials/AWS/${sid}`;
   }
 
-  remove(callback?: any): Promise<AWSInstance> {
+  remove(callback?: any): Promise<boolean> {
     let operationVersion = this._version,
       operationPromise = operationVersion.remove({
         uri: this._uri,
         method: "delete",
       });
-
-    operationPromise = operationPromise.then(
-      (payload) =>
-        new AWSInstance(operationVersion, payload, this._solution.sid)
-    );
 
     operationPromise = this._version.setPromiseCallback(
       operationPromise,
@@ -271,11 +266,11 @@ export class AWSInstance {
    *
    * @param { function } [callback] - Callback to handle processed record
    *
-   * @returns { Promise } Resolves to processed AWSInstance
+   * @returns { Promise } Resolves to processed boolean
    */
   remove(
-    callback?: (error: Error | null, item?: AWSInstance) => any
-  ): Promise<AWSInstance> {
+    callback?: (error: Error | null, item?: boolean) => any
+  ): Promise<boolean> {
     return this._proxy.remove(callback);
   }
 
@@ -335,9 +330,6 @@ export class AWSInstance {
   [inspect.custom](_depth: any, options: InspectOptions) {
     return inspect(this.toJSON(), options);
   }
-}
-export interface AWSSolution {
-  sid?: string;
 }
 
 export interface AWSListInstance {

--- a/examples/node/lib/rest/flexApi/v1/credential/newCredentials.ts
+++ b/examples/node/lib/rest/flexApi/v1/credential/newCredentials.ts
@@ -13,8 +13,6 @@
  */
 
 import { inspect, InspectOptions } from "util";
-
-import Response from "../../../../http/response";
 import V1 from "../../V1";
 const deserialize = require("../../../../base/deserialize");
 const serialize = require("../../../../base/serialize");

--- a/examples/node/lib/rest/flexApi/v1/credential/newCredentials.ts
+++ b/examples/node/lib/rest/flexApi/v1/credential/newCredentials.ts
@@ -212,4 +212,3 @@ export class NewCredentialsInstance {
     return inspect(this.toJSON(), options);
   }
 }
-export interface NewCredentialsSolution {}

--- a/examples/node/lib/rest/flexApi/v1/credential/newCredentials.ts
+++ b/examples/node/lib/rest/flexApi/v1/credential/newCredentials.ts
@@ -13,7 +13,7 @@
  */
 
 import { inspect, InspectOptions } from "util";
-import Page from "../../../../base/Page";
+
 import Response from "../../../../http/response";
 import V1 from "../../V1";
 const deserialize = require("../../../../base/deserialize");
@@ -172,9 +172,7 @@ export function NewCredentialsListInstance(
   return instance;
 }
 
-interface NewCredentialsPayload
-  extends NewCredentialsResource,
-    Page.TwilioResponsePayload {}
+interface NewCredentialsPayload extends NewCredentialsResource {}
 
 interface NewCredentialsResource {
   account_sid?: string | null;
@@ -220,38 +218,3 @@ export class NewCredentialsInstance {
   }
 }
 export interface NewCredentialsSolution {}
-
-export class NewCredentialsPage extends Page<
-  V1,
-  NewCredentialsPayload,
-  NewCredentialsResource,
-  NewCredentialsInstance
-> {
-  /**
-   * Initialize the NewCredentialsPage
-   *
-   * @param version - Version of the resource
-   * @param response - Response from the API
-   * @param solution - Path solution
-   */
-  constructor(
-    version: V1,
-    response: Response<string>,
-    solution: NewCredentialsSolution
-  ) {
-    super(version, response, solution);
-  }
-
-  /**
-   * Build an instance of NewCredentialsInstance
-   *
-   * @param payload - Payload response from the API
-   */
-  getInstance(payload: NewCredentialsPayload): NewCredentialsInstance {
-    return new NewCredentialsInstance(this._version, payload);
-  }
-
-  [inspect.custom](depth: any, options: InspectOptions) {
-    return inspect(this.toJSON(), options);
-  }
-}

--- a/examples/node/lib/rest/versionless/deployed_devices/fleet.ts
+++ b/examples/node/lib/rest/versionless/deployed_devices/fleet.ts
@@ -13,7 +13,7 @@
  */
 
 import { inspect, InspectOptions } from "util";
-import Page from "../../../base/Page";
+
 import Response from "../../../http/response";
 import DeployedDevices from "../DeployedDevices";
 const deserialize = require("../../../base/deserialize");
@@ -89,7 +89,7 @@ export class FleetContextImpl implements FleetContext {
   }
 }
 
-interface FleetPayload extends FleetResource, Page.TwilioResponsePayload {}
+interface FleetPayload extends FleetResource {}
 
 interface FleetResource {
   account_sid?: string | null;
@@ -164,41 +164,6 @@ export class FleetInstance {
 }
 export interface FleetSolution {
   sid?: string;
-}
-
-export class FleetPage extends Page<
-  DeployedDevices,
-  FleetPayload,
-  FleetResource,
-  FleetInstance
-> {
-  /**
-   * Initialize the FleetPage
-   *
-   * @param version - Version of the resource
-   * @param response - Response from the API
-   * @param solution - Path solution
-   */
-  constructor(
-    version: DeployedDevices,
-    response: Response<string>,
-    solution: FleetSolution
-  ) {
-    super(version, response, solution);
-  }
-
-  /**
-   * Build an instance of FleetInstance
-   *
-   * @param payload - Payload response from the API
-   */
-  getInstance(payload: FleetPayload): FleetInstance {
-    return new FleetInstance(this._version, payload, this._solution.sid);
-  }
-
-  [inspect.custom](depth: any, options: InspectOptions) {
-    return inspect(this.toJSON(), options);
-  }
 }
 
 export interface FleetListInstance {

--- a/examples/node/lib/rest/versionless/deployed_devices/fleet.ts
+++ b/examples/node/lib/rest/versionless/deployed_devices/fleet.ts
@@ -164,9 +164,6 @@ export class FleetInstance {
     return inspect(this.toJSON(), options);
   }
 }
-export interface FleetSolution {
-  sid?: string;
-}
 
 export interface FleetListInstance {
   (sid: string): FleetContext;

--- a/examples/node/lib/rest/versionless/deployed_devices/fleet.ts
+++ b/examples/node/lib/rest/versionless/deployed_devices/fleet.ts
@@ -13,8 +13,6 @@
  */
 
 import { inspect, InspectOptions } from "util";
-
-import Response from "../../../http/response";
 import DeployedDevices from "../DeployedDevices";
 const deserialize = require("../../../base/deserialize");
 const serialize = require("../../../base/serialize");

--- a/examples/node/lib/rest/versionless/understand/assistant.ts
+++ b/examples/node/lib/rest/versionless/understand/assistant.ts
@@ -173,4 +173,3 @@ export class AssistantInstance {
     return inspect(this.toJSON(), options);
   }
 }
-export interface AssistantSolution {}

--- a/examples/node/lib/rest/versionless/understand/assistant.ts
+++ b/examples/node/lib/rest/versionless/understand/assistant.ts
@@ -13,7 +13,7 @@
  */
 
 import { inspect, InspectOptions } from "util";
-import Page from "../../../base/Page";
+
 import Response from "../../../http/response";
 import Understand from "../Understand";
 const deserialize = require("../../../base/deserialize");
@@ -128,9 +128,7 @@ export function AssistantListInstance(
   return instance;
 }
 
-interface AssistantPayload
-  extends AssistantResource,
-    Page.TwilioResponsePayload {}
+interface AssistantPayload extends AssistantResource {}
 
 interface AssistantResource {
   account_sid?: string | null;
@@ -181,38 +179,3 @@ export class AssistantInstance {
   }
 }
 export interface AssistantSolution {}
-
-export class AssistantPage extends Page<
-  Understand,
-  AssistantPayload,
-  AssistantResource,
-  AssistantInstance
-> {
-  /**
-   * Initialize the AssistantPage
-   *
-   * @param version - Version of the resource
-   * @param response - Response from the API
-   * @param solution - Path solution
-   */
-  constructor(
-    version: Understand,
-    response: Response<string>,
-    solution: AssistantSolution
-  ) {
-    super(version, response, solution);
-  }
-
-  /**
-   * Build an instance of AssistantInstance
-   *
-   * @param payload - Payload response from the API
-   */
-  getInstance(payload: AssistantPayload): AssistantInstance {
-    return new AssistantInstance(this._version, payload);
-  }
-
-  [inspect.custom](depth: any, options: InspectOptions) {
-    return inspect(this.toJSON(), options);
-  }
-}

--- a/examples/node/lib/rest/versionless/understand/assistant.ts
+++ b/examples/node/lib/rest/versionless/understand/assistant.ts
@@ -13,8 +13,6 @@
  */
 
 import { inspect, InspectOptions } from "util";
-
-import Response from "../../../http/response";
 import Understand from "../Understand";
 const deserialize = require("../../../base/deserialize");
 const serialize = require("../../../base/serialize");

--- a/src/main/java/com/twilio/oai/TwilioNodeGenerator.java
+++ b/src/main/java/com/twilio/oai/TwilioNodeGenerator.java
@@ -139,6 +139,8 @@ public class TwilioNodeGenerator extends TypeScriptNodeClientCodegen {
                 addOperationName(co, "Update");
             } else if (co.nickname.startsWith("delete")) {
                 addOperationName(co, "Remove");
+                co.returnType = "boolean";
+                co.vendorExtensions.put("x-is-delete-operation", true);
             } else if (co.nickname.startsWith("create")) {
                 addOperationName(co, "Create");
             } else if (co.nickname.startsWith("fetch")) {

--- a/src/main/java/com/twilio/oai/TwilioNodeGenerator.java
+++ b/src/main/java/com/twilio/oai/TwilioNodeGenerator.java
@@ -129,6 +129,7 @@ public class TwilioNodeGenerator extends TypeScriptNodeClientCodegen {
 
             co.returnType = instanceName;
 
+            // Anything that ends with {sid} -> account/sid for example
             if (isInstanceOperation) {
                 resourceName = itemName + "Context";
                 parentResourceName = itemName + "ListInstance";
@@ -191,7 +192,7 @@ public class TwilioNodeGenerator extends TypeScriptNodeClientCodegen {
                                                                                  dependent.getName(),
                                                                                  operation)));
 
-            if (isInstanceOperation || (!hasInstanceOperations && httpMethod == HttpMethod.POST)) {
+            if (isInstanceOperation || (!hasInstanceOperations )) {
                 co.responses
                     .stream()
                     .map(response -> response.dataType)

--- a/src/main/java/com/twilio/oai/TwilioNodeGenerator.java
+++ b/src/main/java/com/twilio/oai/TwilioNodeGenerator.java
@@ -119,12 +119,10 @@ public class TwilioNodeGenerator extends TypeScriptNodeClientCodegen {
         for (final CodegenOperation co : opList) {
             // Group operations by resource.
             final String[] filePathArray = co.baseName.split(PATH_SEPARATOR_PLACEHOLDER);
-
             final String itemName = filePathArray[filePathArray.length - 1];
             final String instanceName = itemName + "Instance";
             co.returnType = instanceName;
             final boolean isInstanceOperation = PathUtils.isInstanceOperation(co);
-            final HttpMethod httpMethod = HttpMethod.fromString(co.httpMethod);
 
             String resourceName;
             String parentResourceName = null;
@@ -226,7 +224,6 @@ public class TwilioNodeGenerator extends TypeScriptNodeClientCodegen {
 
         results.put("resources", resources.values());
         results.put("hasPaginationOperation", hasPaginationOperation);
-
 
         return results;
     }

--- a/src/main/resources/twilio-node/api-single.mustache
+++ b/src/main/resources/twilio-node/api-single.mustache
@@ -1,7 +1,7 @@
 {{>licenseInfo}}
 
 import { inspect, InspectOptions } from "util";
-import Page from "{{apiVersionPath}}/../../base/Page";
+{{#hasPaginationOperation}}import Page from "{{apiVersionPath}}/../../base/Page";{{/hasPaginationOperation}}
 import Response from "{{apiVersionPath}}/../../http/response";
 import {{apiVersionClass}} from "{{apiVersionPath}}/{{apiVersionClass}}";
 const deserialize = require("{{apiVersionPath}}/../../base/deserialize");
@@ -158,5 +158,5 @@ export function {{resourceName}}(version: {{apiVersionClass}}{{#resourcePathPara
 }
 {{/parentResourceName}}
 {{>responseModel}}
-{{>pagination}}
+{{#hasPaginationOperation}}{{>pagination}}{{/hasPaginationOperation}}
 {{/resources}}

--- a/src/main/resources/twilio-node/api-single.mustache
+++ b/src/main/resources/twilio-node/api-single.mustache
@@ -1,8 +1,10 @@
 {{>licenseInfo}}
 
 import { inspect, InspectOptions } from "util";
-{{#hasPaginationOperation}}import Page from "{{apiVersionPath}}/../../base/Page";{{/hasPaginationOperation}}
+{{#hasPaginationOperation}}
+import Page from "{{apiVersionPath}}/../../base/Page";
 import Response from "{{apiVersionPath}}/../../http/response";
+{{/hasPaginationOperation}}
 import {{apiVersionClass}} from "{{apiVersionPath}}/{{apiVersionClass}}";
 const deserialize = require("{{apiVersionPath}}/../../base/deserialize");
 const serialize = require("{{apiVersionPath}}/../../base/serialize");

--- a/src/main/resources/twilio-node/api-single.mustache
+++ b/src/main/resources/twilio-node/api-single.mustache
@@ -172,5 +172,7 @@ export function {{resourceName}}(version: {{apiVersionClass}}{{#resourcePathPara
 }
 {{/parentResourceName}}
 {{>responseModel}}
+{{/resources}}
+{{#resources}}
 {{#hasPaginationOperation}}{{>pagination}}{{/hasPaginationOperation}}
 {{/resources}}

--- a/src/main/resources/twilio-node/api-single.mustache
+++ b/src/main/resources/twilio-node/api-single.mustache
@@ -158,4 +158,5 @@ export function {{resourceName}}(version: {{apiVersionClass}}{{#resourcePathPara
 }
 {{/parentResourceName}}
 {{>responseModel}}
+{{>pagination}}
 {{/resources}}

--- a/src/main/resources/twilio-node/pagination.mustache
+++ b/src/main/resources/twilio-node/pagination.mustache
@@ -1,0 +1,35 @@
+{{#operations}}
+{{#vendorExtensions.x-is-list-operation}}
+export class {{name}}Page extends Page<{{apiVersionClass}}, {{name}}Payload, {{name}}Resource, {{name}}Instance> {
+/**
+* Initialize the {{name}}Page
+*
+* @param version - Version of the resource
+* @param response - Response from the API
+* @param solution - Path solution
+*/
+constructor(version: {{apiVersionClass}}, response: Response<string>, solution: {{name}}Solution) {
+    super(version, response, solution);
+    }
+
+    /**
+    * Build an instance of {{name}}Instance
+    *
+    * @param payload - Payload response from the API
+    */
+    getInstance(payload: {{name}}Payload): {{name}}Instance {
+    return new {{name}}Instance(
+    this._version,
+    payload,
+{{#resourcePathParams}}
+        this._solution.{{paramName}},
+{{/resourcePathParams}}
+    );
+    }
+
+    [inspect.custom](depth: any, options: InspectOptions) {
+    return inspect(this.toJSON(), options);
+    }
+    }
+{{/vendorExtensions.x-is-list-operation}}
+{{/operations}}

--- a/src/main/resources/twilio-node/responseModel.mustache
+++ b/src/main/resources/twilio-node/responseModel.mustache
@@ -90,9 +90,4 @@ export class {{name}}Instance {
     return inspect(this.toJSON(), options);
   }
 }
-export interface {{name}}Solution {
-  {{#resourcePathParams}}
-  {{paramName}}?: {{{dataType}}};
-  {{/resourcePathParams}}
-}
 {{/responseModel}}

--- a/src/main/resources/twilio-node/responseModel.mustache
+++ b/src/main/resources/twilio-node/responseModel.mustache
@@ -91,36 +91,4 @@ export interface {{name}}Solution {
   {{paramName}}?: {{{dataType}}};
   {{/resourcePathParams}}
 }
-
-export class {{name}}Page extends Page<{{apiVersionClass}}, {{name}}Payload, {{name}}Resource, {{name}}Instance> {
-  /**
-   * Initialize the {{name}}Page
-   *
-   * @param version - Version of the resource
-   * @param response - Response from the API
-   * @param solution - Path solution
-   */
-  constructor(version: {{apiVersionClass}}, response: Response<string>, solution: {{name}}Solution) {
-    super(version, response, solution);
-  }
-
-  /**
-   * Build an instance of {{name}}Instance
-   *
-   * @param payload - Payload response from the API
-   */
-  getInstance(payload: {{name}}Payload): {{name}}Instance {
-    return new {{name}}Instance(
-      this._version,
-      payload,
-      {{#resourcePathParams}}
-      this._solution.{{paramName}},
-      {{/resourcePathParams}}
-    );
-  }
-
-  [inspect.custom](depth: any, options: InspectOptions) {
-    return inspect(this.toJSON(), options);
-  }
-}
 {{/responseModel}}

--- a/src/main/resources/twilio-node/responseModel.mustache
+++ b/src/main/resources/twilio-node/responseModel.mustache
@@ -7,7 +7,7 @@ export type {{vendorExtensions.x-name}} = {{#allowableValues}}{{#enumVars}}{{{va
 {{/vars}}
 {{/hasEnums}}
 
-interface {{name}}Payload extends {{name}}Resource, Page.TwilioResponsePayload {
+interface {{name}}Payload extends {{name}}Resource{{#hasPaginationOperation}}, Page.TwilioResponsePayload {{/hasPaginationOperation}}{
 }
 
 interface {{name}}Resource {


### PR DESCRIPTION
Two main changes here:

1. Pagination now only gets generated when the resource has a list operation
2. *Instance and *Solution are now generated for all api files

[Internal Link](https://issues.corp.twilio.com/browse/DI-2368)