### PR TITLE
test: Add regex tests

### DIFF
--- a/src/main/java/com/twilio/oai/PathUtils.java
+++ b/src/main/java/com/twilio/oai/PathUtils.java
@@ -1,11 +1,9 @@
 package com.twilio.oai;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
 
-import com.google.common.collect.Streams;
 import io.swagger.v3.oas.models.PathItem;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -47,7 +45,7 @@ public class PathUtils {
     }
 
     public static String fetchLastElement(final String path, final String delimiter) {
-        return Streams.findLast(Arrays.stream(path.split(delimiter))).get();
+        return path.substring(path.lastIndexOf(delimiter)+1);
     }
 
     public static Optional<String> getTwilioExtension(final PathItem pathItem, final String extensionKey) {
@@ -64,7 +62,7 @@ public class PathUtils {
     }
 
     public static boolean isInstanceOperation(final CodegenOperation operation) {
-        return operation.vendorExtensions.get(PATH_TYPE_EXTENSION_NAME).equals(PathType.INSTANCE.getValue());
+        return operation.vendorExtensions.getOrDefault(PATH_TYPE_EXTENSION_NAME, "").equals(PathType.INSTANCE.getValue());
     }
 
     public static boolean isInstancePath(final String path) {

--- a/src/test/java/com/twilio/oai/PathUtilsTest.java
+++ b/src/test/java/com/twilio/oai/PathUtilsTest.java
@@ -101,14 +101,4 @@ public class PathUtilsTest {
         CodegenOperation nonInstanceCo = new CodegenOperation();
         assertFalse(PathUtils.isInstanceOperation(nonInstanceCo));
     }
-
-    @Test
-    public void testIsInstancePath(){
-        final String instancePath = "some/instance/path/{param}.json";
-        assertTrue(PathUtils.isInstancePath(instancePath));
-
-        final String nonInstancePath = "some/non/instance/path.json";
-        assertFalse(PathUtils.isInstancePath(nonInstancePath));
-
-    }
 }

--- a/src/test/java/com/twilio/oai/PathUtilsTest.java
+++ b/src/test/java/com/twilio/oai/PathUtilsTest.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import io.swagger.v3.oas.models.PathItem;
 import org.junit.Test;
+import org.openapitools.codegen.CodegenOperation;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -27,5 +28,87 @@ public class PathUtilsTest {
         pathItem.addExtension("x-twilio", Map.of("that-one", "that-value"));
         assertTrue(PathUtils.getTwilioExtension(pathItem, extensionKey).isPresent());
         assertEquals("that-value", PathUtils.getTwilioExtension(pathItem, extensionKey).orElseThrow());
+    }
+
+    @Test
+    public void testGetFirstPathPart(){
+        final String path = "/version-v1";
+        assertEquals("version-v1", PathUtils.getFirstPathPart(path));
+
+        final String pathWithParts = "first/second/{pathVar}";
+        assertEquals("first", PathUtils.getFirstPathPart(pathWithParts));
+
+        final String emptyPath = "";
+        assertEquals("", PathUtils.getFirstPathPart(emptyPath));
+    }
+
+    @Test
+    public void testCleanPath(){
+        final String pathWithParams = "some/path/{pathParam1}/withPathParams/{pathParam2}.json";
+        assertEquals("some/path/withPathParams.json", PathUtils.cleanPath(pathWithParams));
+
+        final String pathWithoutParams = "some/other/path/noParams";
+        assertEquals("some/other/path/noParams", PathUtils.cleanPath(pathWithoutParams));
+    }
+
+    @Test
+    public void testRemoveExtension(){
+        final String pathWithExtension = "some/path/{param1}/with/extension.ext";
+        assertEquals("some/path/{param1}/with/extension", PathUtils.removeExtension(pathWithExtension));
+
+        final String pathWithoutExtension = "some/path";
+        assertEquals("some/path", PathUtils.removeExtension(pathWithoutExtension));
+    }
+    @Test
+    public void testRemoveFirstPart(){
+        final String path = "/some/path/{param}";
+        assertEquals("/path/{param}", PathUtils.removeFirstPart(path));
+    }
+
+    @Test
+    public void testCleanPathAndRemoveFirstElement(){
+        final String path = "/some/path/with/{params}/and/extension.ext";
+        assertEquals("/path/with/and/extension", PathUtils.cleanPathAndRemoveFirstElement(path));
+    }
+
+    @Test
+    public void testRemoveBraces(){
+        final String path = "path/with/{braces}/{braces2}/";
+        assertEquals("path/with/braces/braces2/", PathUtils.removeBraces(path));
+    }
+
+    @Test
+    public void testRemoveTrailingPathParam(){
+        final String pathWithTrailingParam = "some/path/with/{multiple}/trailing/{param}";
+        assertEquals("some/path/with/{multiple}/trailing", PathUtils.removeTrailingPathParam(pathWithTrailingParam));
+    }
+
+    @Test
+    public void testFetchLastElement(){
+        final String pathWithDelimiter = "this:is:a:path:wow";
+        assertEquals("wow", PathUtils.fetchLastElement(pathWithDelimiter, ":"));
+
+        final String pathWithoutDelimiter = "something";
+        assertEquals("something", PathUtils.fetchLastElement(pathWithoutDelimiter, ";"));
+    }
+
+    @Test
+    public void testIsInstanceOperation(){
+        CodegenOperation instanceCo = new CodegenOperation();
+        instanceCo.vendorExtensions.put("x-path-type", "instance");
+        assertTrue(PathUtils.isInstanceOperation(instanceCo));
+
+        CodegenOperation nonInstanceCo = new CodegenOperation();
+        assertFalse(PathUtils.isInstanceOperation(nonInstanceCo));
+    }
+
+    @Test
+    public void testIsInstancePath(){
+        final String instancePath = "some/instance/path/{param}.json";
+        assertTrue(PathUtils.isInstancePath(instancePath));
+
+        final String nonInstancePath = "some/non/instance/path.json";
+        assertFalse(PathUtils.isInstancePath(nonInstancePath));
+
     }
 }


### PR DESCRIPTION
Some pre-work to DI-2348.

Adding these tests for two main reasons:
1. These methods get used a lot and can easily cause issues on edge cases
2. It makes it easier to decipher what a regex is doing by having examples