### PR TITLE
chore: consolidate snake_case logic

### DIFF
--- a/examples/go/go-client/terraform/resources/flex/v1/README.md
+++ b/examples/go/go-client/terraform/resources/flex/v1/README.md
@@ -21,6 +21,6 @@ Name | Type | Requirement | Description
 **test_any_type** | string | Optional | 
 **test_any_array** | list(string) | Optional | 
 **permissions** | list(string) | Optional | A comma-separated list of the permissions you will request from the users of this ConnectApp.  Can include: &#x60;get-all&#x60; and &#x60;post-all&#x60;.
-**some_a2_pthing** | string | Optional | 
+**some_a2p_thing** | string | Optional | 
 **sid** | string | *Computed* | 
 

--- a/examples/go/go-client/terraform/resources/flex/v1/api_default.go
+++ b/examples/go/go-client/terraform/resources/flex/v1/api_default.go
@@ -49,7 +49,7 @@ func ResourceCredentialsAWS() *schema.Resource {
 			"test_any_type":      AsString(SchemaForceNewOptional),
 			"test_any_array":     AsList(AsString(SchemaForceNewOptional), SchemaForceNewOptional),
 			"permissions":        AsList(AsString(SchemaForceNewOptional), SchemaForceNewOptional),
-			"some_a2_pthing":     AsString(SchemaForceNewOptional),
+			"some_a2p_thing":     AsString(SchemaForceNewOptional),
 			"sid":                AsString(SchemaComputed),
 		},
 		Importer: &schema.ResourceImporter{

--- a/src/main/java/com/twilio/oai/StringHelper.java
+++ b/src/main/java/com/twilio/oai/StringHelper.java
@@ -11,18 +11,25 @@ import org.apache.commons.lang3.StringUtils;
 @UtilityClass
 public class StringHelper {
 
+    private static final String SNAKE_SEPARATOR = "_";
+    private static final String SNAKE_REPLACER = "$1" + SNAKE_SEPARATOR + "$2";
+
+    public String toSnakeCase(final String inputWord) {
+        return inputWord
+            .replaceAll("[^a-zA-Z\\d]+", SNAKE_SEPARATOR)
+            .replaceAll("([a-z])([A-Z])", SNAKE_REPLACER)
+            .replaceAll("(\\d[A-Z]*)([A-Z])", SNAKE_REPLACER)
+            .replaceAll("([A-Z])([A-Z][a-z])", SNAKE_REPLACER)
+            .toLowerCase();
+    }
+
     public String camelize(final String inputWord) {
         return StringHelper.camelize(inputWord, false);
     }
 
     public String camelize(final String inputWord, final boolean lowercaseFirstLetter) {
         final String camelized = Arrays
-            .stream(inputWord
-                        .replaceAll("([a-z])([A-Z])", "$1_$2")
-                        .replaceAll("(\\d)([A-Za-z])", "$1_$2")
-                        .replaceAll("([A-Z])([A-Z][a-z])", "$1_$2")
-                        .split("[_.-]"))
-            .map(String::toLowerCase)
+            .stream(toSnakeCase(inputWord).replaceAll("(\\d)([a-z])", SNAKE_REPLACER).split(SNAKE_SEPARATOR))
             .map(StringHelper::toFirstLetterCaps)
             .collect(Collectors.joining());
 

--- a/src/main/java/com/twilio/oai/TwilioTerraformGenerator.java
+++ b/src/main/java/com/twilio/oai/TwilioTerraformGenerator.java
@@ -124,7 +124,7 @@ public class TwilioTerraformGenerator extends AbstractTwilioGoGenerator {
                 k -> new ArrayList<>());
 
             resource.put("name", resourceName);
-            resource.put("nameInSnakeCase", toSnakeCase(resourceName));
+            resource.put("nameInSnakeCase", StringHelper.toSnakeCase(resourceName));
             resourceOperationList.add(co);
 
             twilioCodegen.populateCrudOperations(resource, co);
@@ -179,7 +179,7 @@ public class TwilioTerraformGenerator extends AbstractTwilioGoGenerator {
                     // 'sid'). We assume it's the last path parameter for the fetch/update/delete operation.
                     final CodegenParameter idParameter = fetchOperation.pathParams.get(
                             fetchOperation.pathParams.size() - 1);
-                    final String idParameterSnakeCase = toSnakeCase(idParameter.paramName);
+                    final String idParameterSnakeCase = StringHelper.toSnakeCase(idParameter.paramName);
 
                     // If the resource ID parameter is not part of the operation response body, remove the resource.
                     if (!properties.containsKey(idParameterSnakeCase)) {
@@ -277,7 +277,7 @@ public class TwilioTerraformGenerator extends AbstractTwilioGoGenerator {
         final TerraformSchema terraformSchema = buildTerraformSchema(codegenParameter, schemaOptions);
 
         codegenParameter.vendorExtensions.put("x-terraform-schema", terraformSchema);
-        codegenParameter.vendorExtensions.put("x-name-in-snake-case", this.toSnakeCase(codegenParameter.baseName));
+        codegenParameter.vendorExtensions.put("x-name-in-snake-case", StringHelper.toSnakeCase(codegenParameter.baseName));
     }
 
     private Set<String> getParamNames(final List<CodegenParameter> parameters) {
@@ -317,13 +317,9 @@ public class TwilioTerraformGenerator extends AbstractTwilioGoGenerator {
     }
 
     private void addParamVendorExtensions(final List<CodegenParameter> params) {
-        params.forEach(p -> p.vendorExtensions.put("x-name-in-snake-case", this.toSnakeCase(p.paramName)));
+        params.forEach(p -> p.vendorExtensions.put("x-name-in-snake-case", StringHelper.toSnakeCase(p.paramName)));
         params.forEach(p -> p.vendorExtensions.put("x-util-name", p.isFreeFormObject ? "Object" : "String"));
         params.forEach(p -> p.vendorExtensions.put("x-index", params.indexOf(p)));
-    }
-
-    private String toSnakeCase(final String string) {
-        return string.replaceAll("[^a-zA-Z\\d]+", "_").replaceAll("([a-z\\d])([A-Z])", "$1_$2").toLowerCase();
     }
 
     /**

--- a/src/main/java/com/twilio/oai/resolver/java/JavaConventionResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/java/JavaConventionResolver.java
@@ -52,8 +52,7 @@ public class JavaConventionResolver {
                 }
             }
 
-            // Converts property.nameInSnakeCase to all lowercase
-            property.nameInSnakeCase = property.nameInSnakeCase.toLowerCase(Locale.ROOT);
+            property.nameInSnakeCase = StringHelper.toSnakeCase(property.name);
 
             // Merges the vendorExtensions map with the existing property's vendor extensions
             vendorExtensions.forEach(

--- a/src/test/java/com/twilio/oai/StringHelperTest.java
+++ b/src/test/java/com/twilio/oai/StringHelperTest.java
@@ -1,0 +1,24 @@
+package com.twilio.oai;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StringHelperTest {
+
+    @Test
+    public void testToSnakeCase() {
+        assertEquals("some_a2p_thing", StringHelper.toSnakeCase("SomeA2PThing"));
+        assertEquals("psd2_enabled", StringHelper.toSnakeCase("Psd2Enabled"));
+        assertEquals("aws_s3_url", StringHelper.toSnakeCase("AwsS3Url"));
+        assertEquals("callback_url", StringHelper.toSnakeCase("callbackURL"));
+    }
+
+    @Test
+    public void testCamelize() {
+        assertEquals("SomeA2PThing", StringHelper.camelize("some_a2p_thing"));
+        assertEquals("Psd2Enabled", StringHelper.camelize("psd2_enabled"));
+        assertEquals("AwsS3Url", StringHelper.camelize("aws_s3_url"));
+        assertEquals("CallbackUrl", StringHelper.camelize("callback_url"));
+    }
+}


### PR DESCRIPTION
Also fixes issue where things like `callbackURL` were turning to `callback_u_r_l` in underlying DefaultCodegen.