### PR TITLE
fix: add stringify extension for non-string path param response properties

### DIFF
--- a/examples/csharp/src/Twilio/Rest/FlexApi/V1/CallResource.cs
+++ b/examples/csharp/src/Twilio/Rest/FlexApi/V1/CallResource.cs
@@ -117,9 +117,9 @@ namespace Twilio.Rest.FlexApi.V1
         }
 
     
-        ///<summary> The sid </summary> 
+        ///<summary> Non-string path parameter in the response. </summary> 
         [JsonProperty("sid")]
-        public string Sid { get; private set; }
+        public int? Sid { get; private set; }
 
 
 

--- a/examples/go/go-client/helper/rest/flex/v1/model_update_call_200_response.go
+++ b/examples/go/go-client/helper/rest/flex/v1/model_update_call_200_response.go
@@ -16,5 +16,6 @@ package openapi
 
 // UpdateCall200Response struct for UpdateCall200Response
 type UpdateCall200Response struct {
-	Sid *string `json:"sid,omitempty"`
+	// Non-string path parameter in the response.
+	Sid *int `json:"sid,omitempty"`
 }

--- a/examples/java/src/main/java/com/twilio/rest/flexapi/v1/Call.java
+++ b/examples/java/src/main/java/com/twilio/rest/flexapi/v1/Call.java
@@ -72,7 +72,7 @@ import com.twilio.type.SubscribeRule;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @ToString
 public class Call extends Resource {
-    private static final long serialVersionUID = 145080881849338L;
+    private static final long serialVersionUID = 9929770204306L;
 
     public static CallUpdater updater(final String pathSid){
         return new CallUpdater(pathSid);
@@ -115,17 +115,17 @@ public class Call extends Resource {
         }
     }
 
-    private final String sid;
+    private final Integer sid;
 
     @JsonCreator
     private Call(
         @JsonProperty("sid")
-        final String sid
+        final Integer sid
     ) {
         this.sid = sid;
     }
 
-        public final String getSid() {
+        public final Integer getSid() {
             return this.sid;
         }
 

--- a/examples/java/unit-test/rest/TwilioRestTest.java
+++ b/examples/java/unit-test/rest/TwilioRestTest.java
@@ -1126,7 +1126,7 @@ public class TwilioRestTest {
             .updater("sidUpdated")
             .update(twilioRestClient);
 
-        assertEquals("123", updatedCall.getSid());
+        assertEquals(new Integer(123), updatedCall.getSid());
     }
 
     @Test

--- a/examples/node/lib/rest/flexApi/v1/call.ts
+++ b/examples/node/lib/rest/flexApi/v1/call.ts
@@ -90,7 +90,7 @@ export class CallContextImpl implements CallContext {
 interface CallPayload extends CallResource {}
 
 interface CallResource {
-  sid?: string | null;
+  sid?: number | null;
 }
 
 export class CallInstance {
@@ -98,12 +98,15 @@ export class CallInstance {
   protected _context?: CallContext;
 
   constructor(protected _version: V1, payload: CallResource, sid?: string) {
-    this.sid = payload.sid;
+    this.sid = deserialize.integer(payload.sid);
 
-    this._solution = { sid: sid || this.sid };
+    this._solution = { sid: sid || this.sid.toString() };
   }
 
-  sid?: string | null;
+  /**
+   * Non-string path parameter in the response.
+   */
+  sid?: number | null;
 
   private get _proxy(): CallContext {
     this._context =

--- a/examples/php/src/Twilio/Rest/FlexApi/V1/CallInstance.php
+++ b/examples/php/src/Twilio/Rest/FlexApi/V1/CallInstance.php
@@ -30,7 +30,7 @@ use Twilio\Serialize;
 
 
 /**
- * @property string $sid
+ * @property int $sid
  */
 
 class CallInstance extends InstanceResource {

--- a/examples/spec/twilio_flex_v1.yaml
+++ b/examples/spec/twilio_flex_v1.yaml
@@ -164,7 +164,7 @@ paths:
                   type: array
                 TestAnyType: { }
                 TestAnyArray:
-                  items: {}
+                  items: { }
                   type: array
                 Permissions:
                   description: 'A comma-separated list of the permissions you will
@@ -329,8 +329,9 @@ paths:
               schema:
                 properties:
                   sid:
+                    description: Non-string path parameter in the response.
                     nullable: true
-                    type: string
+                    type: integer
                 type: object
           description: OK
       security:

--- a/src/main/java/com/twilio/oai/TwilioGoGenerator.java
+++ b/src/main/java/com/twilio/oai/TwilioGoGenerator.java
@@ -2,7 +2,6 @@ package com.twilio.oai;
 
 import com.twilio.oai.common.Utility;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -22,6 +21,8 @@ import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
 import org.openapitools.codegen.model.OperationsMap;
+
+import static com.twilio.oai.common.ApplicationConstants.STRING;
 
 public class TwilioGoGenerator extends AbstractTwilioGoGenerator {
 
@@ -73,13 +74,13 @@ public class TwilioGoGenerator extends AbstractTwilioGoGenerator {
         if (property.dataType.startsWith("[]") && property.dataType.contains("Enum")) {
             property._enum = (List<String>) property.items.allowableValues.get("values");
             property.allowableValues = property.items.allowableValues;
-            property.dataType = "[]string";
+            property.dataType = "[]" + STRING;
             property.isEnum = property.dataFormat == null;
             property.isNullable = true;
         } else if (property.dataType.contains("Enum")) {
             String[] value = property.dataType.split("Enum");
             property.datatypeWithEnum = value[value.length-1];
-            property.dataType = "string";
+            property.dataType = STRING;
             property.isEnum = property.dataFormat == null;
             property.isNullable = true;
         }
@@ -89,13 +90,13 @@ public class TwilioGoGenerator extends AbstractTwilioGoGenerator {
         if (parameter.dataType.startsWith("[]") && parameter.dataType.contains("Enum")) {
             parameter._enum = (List<String>) parameter.items.allowableValues.get("values");
             parameter.allowableValues = parameter.items.allowableValues;
-            parameter.dataType = "[]string";
+            parameter.dataType = "[]" + STRING;
             parameter.isEnum = parameter.dataFormat == null;
             parameter.isNullable = true;
         } else if (parameter.dataType.contains("Enum")) {
             String[] value = parameter.dataType.split("Enum");
             parameter.datatypeWithEnum = value[value.length-1];
-            parameter.dataType = "string";
+            parameter.dataType = STRING;
             parameter.isEnum = parameter.dataFormat == null;
             parameter.isNullable = true;
         }

--- a/src/main/java/com/twilio/oai/TwilioTerraformGenerator.java
+++ b/src/main/java/com/twilio/oai/TwilioTerraformGenerator.java
@@ -32,6 +32,7 @@ import org.openapitools.codegen.model.OperationMap;
 import org.openapitools.codegen.model.OperationsMap;
 import org.openapitools.codegen.utils.ModelUtils;
 
+import static com.twilio.oai.common.ApplicationConstants.STRING;
 import static com.twilio.oai.common.EnumConstants.Operation;
 
 public class TwilioTerraformGenerator extends AbstractTwilioGoGenerator {
@@ -79,7 +80,7 @@ public class TwilioTerraformGenerator extends AbstractTwilioGoGenerator {
     public TwilioTerraformGenerator() {
         super();
 
-        typeMapping.put("object", "string");
+        typeMapping.put("object", STRING);
     }
 
     @Override
@@ -334,13 +335,12 @@ public class TwilioTerraformGenerator extends AbstractTwilioGoGenerator {
                 // some properties of type "object" can be an array or a map. (Eg: errors and links in the studio flows)
                 // Letting the type objects be as Strings in the terraform provider and then json encoding in the
                 // provider is the current workaround.
-                return new TerraformSchema("string", schemaOptions, null);
+                return new TerraformSchema(STRING, schemaOptions, null);
         }
     }
 
     private void addParamVendorExtensions(final List<CodegenParameter> params) {
         params.forEach(p -> p.vendorExtensions.put("x-name-in-snake-case", StringHelper.toSnakeCase(p.paramName)));
-        params.forEach(p -> p.vendorExtensions.put("x-util-name", p.isFreeFormObject ? "Object" : "String"));
         params.forEach(p -> p.vendorExtensions.put("x-index", params.indexOf(p)));
     }
 

--- a/src/main/java/com/twilio/oai/api/FluentApiResourceBuilder.java
+++ b/src/main/java/com/twilio/oai/api/FluentApiResourceBuilder.java
@@ -17,6 +17,7 @@ import org.openapitools.codegen.CodegenOperation;
 import org.openapitools.codegen.CodegenParameter;
 import org.openapitools.codegen.CodegenProperty;
 
+import static com.twilio.oai.common.ApplicationConstants.STRING;
 import static com.twilio.oai.template.AbstractApiActionTemplate.API_TEMPLATE;
 
 public abstract class FluentApiResourceBuilder extends ApiResourceBuilder {
@@ -144,6 +145,13 @@ public abstract class FluentApiResourceBuilder extends ApiResourceBuilder {
                 model.getVars().forEach(variable -> {
                     codegenPropertyResolver.resolve(variable);
                     variable.vendorExtensions.put("x-name", resourceName + variable.getNameInCamelCase());
+
+                    instancePathParams
+                        .stream()
+                        .filter(param -> param.paramName.equals(variable.name))
+                        .filter(param -> param.dataType.equals(STRING))
+                        .filter(param -> !param.dataType.equals(variable.dataType))
+                        .forEach(param -> param.vendorExtensions.put("x-stringify", true));
                 });
 
                 if (model != responseModel) {

--- a/src/main/java/com/twilio/oai/api/JavaApiResourceBuilder.java
+++ b/src/main/java/com/twilio/oai/api/JavaApiResourceBuilder.java
@@ -288,7 +288,7 @@ public class JavaApiResourceBuilder extends ApiResourceBuilder{
 
             if(!specialTypes.contains(cp.dataType) && !cp.vendorExtensions.containsKey("x-prefixed-collapsible-map") && !cp.isArray){
                 cp.vendorExtensions.put("x-is-other-data-type", true);
-            } else if (cp.isArray && cp.baseType.equalsIgnoreCase("String")) {
+            } else if (cp.isArray && cp.baseType.equalsIgnoreCase(STRING)) {
                 cp.vendorExtensions.put("x-is-string-array", true);
             }
 
@@ -306,6 +306,7 @@ public class JavaApiResourceBuilder extends ApiResourceBuilder{
        return allParams.stream().filter(param -> !param.isPathParam).collect(Collectors.toList());
     }
 
+    @SuppressWarnings("unchecked")
     private ArrayList<List<CodegenParameter>> generateSignatureList(final CodegenOperation co) {
         CodegenParameter accountSidParam = null;
         List<List<CodegenParameter>> conditionalCodegenParam = new ArrayList<>();

--- a/src/main/java/com/twilio/oai/common/ApplicationConstants.java
+++ b/src/main/java/com/twilio/oai/common/ApplicationConstants.java
@@ -23,11 +23,11 @@ public class ApplicationConstants {
     public static final String LIST_END = ">";
 
     public static final String OBJECT = "Object";
+    public static final String STRING = "string";
     public static final String ARRAY = "array";
     public static final String ENUM_VARS = "enumVars";
 
     public static final String LIST_INSTANCE = "ListInstance";
-    public static final String DEPENDENTS = "dependents";
 
     public static final String TWILIO_EXTENSION_NAME = "x-twilio";
     public static final String PATH_TYPE_EXTENSION_NAME = "x-path-type";

--- a/src/main/java/com/twilio/oai/resolver/php/PhpParameterResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/php/PhpParameterResolver.java
@@ -3,16 +3,19 @@ package com.twilio.oai.resolver.php;
 import com.twilio.oai.resolver.IConventionMapper;
 import com.twilio.oai.resolver.LanguageConventionResolver;
 import com.twilio.oai.resolver.LanguageParamResolver;
+
 import org.openapitools.codegen.CodegenParameter;
 
 import static com.twilio.oai.common.ApplicationConstants.OBJECT;
 import static com.twilio.oai.common.ApplicationConstants.SERIALIZE_VEND_EXT;
+import static com.twilio.oai.common.ApplicationConstants.STRING;
 import static com.twilio.oai.resolver.php.PhpPropertyResolver.MAP_STRING;
 
 public class PhpParameterResolver extends LanguageParamResolver {
-    public final static String SERALIZE_ARRAY_MAP = "Serialize::map";
-    public final static String SERALIZE_ARRAY_JSON_OBJECT = "Serialize::jsonObject";
-    public final static String ARRAY_OF_ARRAY_STRING = "array-of-array";
+    public static final String SERIALIZE_ARRAY_MAP = "Serialize::map";
+    public static final String SERIALIZE_ARRAY_JSON_OBJECT = "Serialize::jsonObject";
+    public static final String ARRAY_OF_ARRAY_STRING = "array-of-array";
+
     public PhpParameterResolver(IConventionMapper mapper) {
         super(mapper);
     }
@@ -27,11 +30,11 @@ public class PhpParameterResolver extends LanguageParamResolver {
             codegenParameter.dataType = "array[]";
         }
         if (codegenParameter.dataType.equalsIgnoreCase(OBJECT) ||
-                codegenParameter.dataType.equals(LanguageConventionResolver.LIST_OBJECT)) {
+            codegenParameter.dataType.equals(LanguageConventionResolver.LIST_OBJECT)) {
             codegenParameter.dataType = "array";
         }
         if (codegenParameter.dataType.contains("Enum")) {
-            codegenParameter.dataType = "string";
+            codegenParameter.dataType = STRING;
         }
     }
 
@@ -39,14 +42,14 @@ public class PhpParameterResolver extends LanguageParamResolver {
     public void resolveSerialize(CodegenParameter codegenParameter) {
         super.resolveSerialize(codegenParameter);
         if (codegenParameter.dataType != null && codegenParameter.dataType.contains("[]")) {
-            codegenParameter.vendorExtensions.put(SERIALIZE_VEND_EXT, SERALIZE_ARRAY_MAP);
+            codegenParameter.vendorExtensions.put(SERIALIZE_VEND_EXT, SERIALIZE_ARRAY_MAP);
             codegenParameter.vendorExtensions.put(SERIALIZE_VEND_EXT + LanguageConventionResolver.HYPHEN + MAP_STRING, true);
             if(codegenParameter.dataType.contains("array")) {
-                codegenParameter.vendorExtensions.put(SERIALIZE_VEND_EXT + LanguageConventionResolver.HYPHEN + ARRAY_OF_ARRAY_STRING, SERALIZE_ARRAY_JSON_OBJECT);
+                codegenParameter.vendorExtensions.put(SERIALIZE_VEND_EXT + LanguageConventionResolver.HYPHEN + ARRAY_OF_ARRAY_STRING, SERIALIZE_ARRAY_JSON_OBJECT);
             }
         }
         if (codegenParameter.dataType != null && codegenParameter.dataType.equals("array")) {
-            codegenParameter.vendorExtensions.put(SERIALIZE_VEND_EXT, SERALIZE_ARRAY_JSON_OBJECT);
+            codegenParameter.vendorExtensions.put(SERIALIZE_VEND_EXT, SERIALIZE_ARRAY_JSON_OBJECT);
         }
     }
 }

--- a/src/main/java/com/twilio/oai/resolver/php/PhpParameterResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/php/PhpParameterResolver.java
@@ -6,6 +6,7 @@ import com.twilio.oai.resolver.LanguageParamResolver;
 
 import org.openapitools.codegen.CodegenParameter;
 
+import static com.twilio.oai.common.ApplicationConstants.ARRAY;
 import static com.twilio.oai.common.ApplicationConstants.OBJECT;
 import static com.twilio.oai.common.ApplicationConstants.SERIALIZE_VEND_EXT;
 import static com.twilio.oai.common.ApplicationConstants.STRING;
@@ -24,14 +25,14 @@ public class PhpParameterResolver extends LanguageParamResolver {
     public void resolveProperties(CodegenParameter codegenParameter) {
         super.resolveProperties(codegenParameter);
         if (codegenParameter.dataType.equalsIgnoreCase(LanguageConventionResolver.MIXED)) {
-            codegenParameter.dataType = "array";
+            codegenParameter.dataType = ARRAY;
         }
         if (codegenParameter.dataType.equalsIgnoreCase(LanguageConventionResolver.MIXED_ARRAY)) {
-            codegenParameter.dataType = "array[]";
+            codegenParameter.dataType = ARRAY + "[]";
         }
         if (codegenParameter.dataType.equalsIgnoreCase(OBJECT) ||
             codegenParameter.dataType.equals(LanguageConventionResolver.LIST_OBJECT)) {
-            codegenParameter.dataType = "array";
+            codegenParameter.dataType = ARRAY;
         }
         if (codegenParameter.dataType.contains("Enum")) {
             codegenParameter.dataType = STRING;
@@ -44,11 +45,11 @@ public class PhpParameterResolver extends LanguageParamResolver {
         if (codegenParameter.dataType != null && codegenParameter.dataType.contains("[]")) {
             codegenParameter.vendorExtensions.put(SERIALIZE_VEND_EXT, SERIALIZE_ARRAY_MAP);
             codegenParameter.vendorExtensions.put(SERIALIZE_VEND_EXT + LanguageConventionResolver.HYPHEN + MAP_STRING, true);
-            if(codegenParameter.dataType.contains("array")) {
+            if (codegenParameter.dataType.contains(ARRAY)) {
                 codegenParameter.vendorExtensions.put(SERIALIZE_VEND_EXT + LanguageConventionResolver.HYPHEN + ARRAY_OF_ARRAY_STRING, SERIALIZE_ARRAY_JSON_OBJECT);
             }
         }
-        if (codegenParameter.dataType != null && codegenParameter.dataType.equals("array")) {
+        if (codegenParameter.dataType != null && codegenParameter.dataType.equals(ARRAY)) {
             codegenParameter.vendorExtensions.put(SERIALIZE_VEND_EXT, SERIALIZE_ARRAY_JSON_OBJECT);
         }
     }

--- a/src/main/java/com/twilio/oai/resolver/php/PhpPropertyResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/php/PhpPropertyResolver.java
@@ -7,6 +7,8 @@ import com.twilio.oai.resolver.LanguagePropertyResolver;
 
 import org.openapitools.codegen.CodegenProperty;
 
+import static com.twilio.oai.common.ApplicationConstants.STRING;
+
 public class PhpPropertyResolver extends LanguagePropertyResolver {
     public static final String MAP_STRING = "map";
 
@@ -24,25 +26,25 @@ public class PhpPropertyResolver extends LanguagePropertyResolver {
     }
 
     @Override
-    public  void resolveProperties(CodegenProperty codegenProperty) {
+    public void resolveProperties(CodegenProperty codegenProperty) {
         super.resolveProperties(codegenProperty);
-        if(codegenProperty.dataType.equals(LanguageConventionResolver.MIXED)) {
+        if (codegenProperty.dataType.equals(LanguageConventionResolver.MIXED)) {
             codegenProperty.dataType = "array";
         }
         if (codegenProperty.dataType.equalsIgnoreCase(LanguageConventionResolver.MIXED_ARRAY)) {
             codegenProperty.dataType = "array[]";
         }
         if (codegenProperty.dataType.equals("float")) {
-            codegenProperty.dataType = "string";
+            codegenProperty.dataType = STRING;
         }
-        if(codegenProperty.dataType.equals(LanguageConventionResolver.LIST_OBJECT)) {
+        if (codegenProperty.dataType.equals(LanguageConventionResolver.LIST_OBJECT)) {
             codegenProperty.dataType = "array";
         }
         if (codegenProperty.dataType.contains("Enum") || codegenProperty.complexType != null) {
-            if(codegenProperty.openApiType.equals("array")) {
-                codegenProperty.dataType = "string[]";
+            if (codegenProperty.openApiType.equals("array")) {
+                codegenProperty.dataType = STRING + "[]";
             } else {
-                codegenProperty.dataType = "string";
+                codegenProperty.dataType = STRING;
             }
         }
     }

--- a/src/main/java/com/twilio/oai/resolver/php/PhpPropertyResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/php/PhpPropertyResolver.java
@@ -7,6 +7,7 @@ import com.twilio.oai.resolver.LanguagePropertyResolver;
 
 import org.openapitools.codegen.CodegenProperty;
 
+import static com.twilio.oai.common.ApplicationConstants.ARRAY;
 import static com.twilio.oai.common.ApplicationConstants.STRING;
 
 public class PhpPropertyResolver extends LanguagePropertyResolver {
@@ -29,19 +30,19 @@ public class PhpPropertyResolver extends LanguagePropertyResolver {
     public void resolveProperties(CodegenProperty codegenProperty) {
         super.resolveProperties(codegenProperty);
         if (codegenProperty.dataType.equals(LanguageConventionResolver.MIXED)) {
-            codegenProperty.dataType = "array";
+            codegenProperty.dataType = ARRAY;
         }
         if (codegenProperty.dataType.equalsIgnoreCase(LanguageConventionResolver.MIXED_ARRAY)) {
-            codegenProperty.dataType = "array[]";
+            codegenProperty.dataType = ARRAY + "[]";
         }
         if (codegenProperty.dataType.equals("float")) {
             codegenProperty.dataType = STRING;
         }
         if (codegenProperty.dataType.equals(LanguageConventionResolver.LIST_OBJECT)) {
-            codegenProperty.dataType = "array";
+            codegenProperty.dataType = ARRAY;
         }
         if (codegenProperty.dataType.contains("Enum") || codegenProperty.complexType != null) {
-            if (codegenProperty.openApiType.equals("array")) {
+            if (codegenProperty.openApiType.equals(ARRAY)) {
                 codegenProperty.dataType = STRING + "[]";
             } else {
                 codegenProperty.dataType = STRING;

--- a/src/main/resources/twilio-node/responseModel.mustache
+++ b/src/main/resources/twilio-node/responseModel.mustache
@@ -28,16 +28,11 @@ export class {{instanceName}} {
 
   constructor(protected _version: {{apiVersionClass}}, payload: {{apiName}}Resource{{#instancePathParams}}, {{paramName}}{{^vendorExtensions.x-is-parent-param}}?{{/vendorExtensions.x-is-parent-param}}: {{{dataType}}}{{/instancePathParams}}) {
     {{#vars}}
-    {{#vendorExtensions.x-deserialize}}
     this.{{name}} = {{vendorExtensions.x-deserialize}}(payload.{{baseName}});
-    {{/vendorExtensions.x-deserialize}}
-    {{^vendorExtensions.x-deserialize}}
-    this.{{name}} = payload.{{baseName}};
-    {{/vendorExtensions.x-deserialize}}
     {{/vars}}
 
     {{#instancePath}}
-    this._solution = { {{#instancePathParams}}{{paramName}}{{^vendorExtensions.x-is-parent-param}}: {{paramName}} || this.{{paramName}}{{/vendorExtensions.x-is-parent-param}}, {{/instancePathParams}} };
+    this._solution = { {{#instancePathParams}}{{paramName}}{{^vendorExtensions.x-is-parent-param}}: {{paramName}} || this.{{paramName}}{{#vendorExtensions.x-stringify}}.toString(){{/vendorExtensions.x-stringify}}{{/vendorExtensions.x-is-parent-param}}, {{/instancePathParams}} };
     {{/instancePath}}
   }
 


### PR DESCRIPTION
This removes TypeScript errors for non-matching types.

https://github.com/twilio/twilio-node/pull/854