### PR TITLE
chore: prep for multi-threaded/batch execution

### DIFF
--- a/src/main/java/com/twilio/oai/AbstractTwilioGoGenerator.java
+++ b/src/main/java/com/twilio/oai/AbstractTwilioGoGenerator.java
@@ -48,12 +48,6 @@ public abstract class AbstractTwilioGoGenerator extends GoClientCodegen {
 
         twilioCodegen.processOpts();
 
-        if (additionalProperties().get("apiVersion").equals("")) {
-            // Exit gracefully if given an OpenAPI document that doesn't contain a versioned API. The Go clients do
-            // not currently support this.
-            System.exit(0);
-        }
-
         additionalProperties.put(CodegenConstants.IS_GO_SUBMODULE, true);
         additionalProperties.put(CodegenConstants.ENUM_CLASS_PREFIX, true);
     }
@@ -86,8 +80,22 @@ public abstract class AbstractTwilioGoGenerator extends GoClientCodegen {
 
         directoryStructureService.configure(openAPI);
 
+        if (directoryStructureService.isVersionLess()) {
+            // Clear the template files if given an OpenAPI document that doesn't contain a versioned API. The Go
+            // clients do not currently support this.
+            clearTemplateFiles();
+        }
+
         // Clear out any tags present. We want all operations in a single API file.
         getOperationStream(openAPI).forEach(operation -> operation.setTags(null));
+    }
+
+    protected void clearTemplateFiles() {
+        apiTemplateFiles.clear();
+        apiDocTemplateFiles.clear();
+        modelTemplateFiles.clear();
+        modelDocTemplateFiles.clear();
+        supportingFiles.clear();
     }
 
     private Stream<Operation> getOperationStream(final OpenAPI openAPI) {

--- a/src/main/java/com/twilio/oai/TwilioTerraformGenerator.java
+++ b/src/main/java/com/twilio/oai/TwilioTerraformGenerator.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import lombok.AllArgsConstructor;
@@ -32,6 +33,7 @@ import org.openapitools.codegen.model.OperationMap;
 import org.openapitools.codegen.model.OperationsMap;
 import org.openapitools.codegen.utils.ModelUtils;
 
+import static com.twilio.oai.DirectoryStructureService.API_VERSION;
 import static com.twilio.oai.common.ApplicationConstants.STRING;
 import static com.twilio.oai.common.EnumConstants.Operation;
 
@@ -87,12 +89,17 @@ public class TwilioTerraformGenerator extends AbstractTwilioGoGenerator {
     public void processOpts() {
         super.processOpts();
 
-        if (additionalProperties.get("apiVersion").equals("v2010")) {
-            additionalProperties.remove("apiVersion");
-            additionalProperties.remove("apiVersionClass");
-        }
-
         supportingFiles.add(new SupportingFile("README.mustache", "README.md"));
+    }
+
+    @Override
+    public void processOpenAPI(final OpenAPI openAPI) {
+        super.processOpenAPI(openAPI);
+
+        if (additionalProperties.get(API_VERSION).equals("v2010")) {
+            additionalProperties.remove(API_VERSION);
+            additionalProperties.remove(API_VERSION + "Class");
+        }
     }
 
     @Override
@@ -208,9 +215,9 @@ public class TwilioTerraformGenerator extends AbstractTwilioGoGenerator {
             });
         }
 
-        // Exit if there are no resources to generate.
+        // Clear the template files if there are no resources to generate.
         if (resources.isEmpty()) {
-            System.exit(0);
+            clearTemplateFiles();
         }
 
         results.put("resources", resources.values());

--- a/src/main/java/com/twilio/oai/resolver/csharp/OperationStore.java
+++ b/src/main/java/com/twilio/oai/resolver/csharp/OperationStore.java
@@ -9,13 +9,10 @@ import java.util.HashMap;
 public final class OperationStore {
 
     private OperationStore() { }
-    private static OperationStore instance;
-    public static OperationStore getInstance()
-    {
-        if (instance == null)
-            instance = new OperationStore();
+    private static final ThreadLocal<OperationStore> instance = ThreadLocal.withInitial(OperationStore::new);
 
-        return instance;
+    public static OperationStore getInstance() {
+        return instance.get();
     }
 
     public void clear() {


### PR DESCRIPTION
When multi-threading, we can no longer exit mid-generation or rely on writable global statics.