### PR TITLE
fix: use the model name for python instance path variables

### DIFF
--- a/src/main/java/com/twilio/oai/api/FluentApiResourceBuilder.java
+++ b/src/main/java/com/twilio/oai/api/FluentApiResourceBuilder.java
@@ -183,6 +183,8 @@ public abstract class FluentApiResourceBuilder extends ApiResourceBuilder {
                                 final CodegenParameter param) {
         super.resolveParam(codegenParameterIResolver, param);
 
+        param.contentType = getModelName(param.dataType);
+
         updateDataType(param.baseType, param.dataType, (dataTypeWithEnum, dataType) -> {
             param.datatypeWithEnum = dataTypeWithEnum;
             param.dataType = dataType;

--- a/src/main/resources/twilio-python/instance.handlebars
+++ b/src/main/resources/twilio-python/instance.handlebars
@@ -1,6 +1,6 @@
 class {{instanceName}}(InstanceResource):
 {{>model}}
-    def __init__(self, version, payload{{#instancePathParams}}, {{paramName}}: {{{dataType}}}{{#if vendorExtensions.x-is-parent-param}}{{else}}=None{{/if}}{{/instancePathParams}}):
+    def __init__(self, version, payload{{#instancePathParams}}, {{paramName}}: {{{contentType}}}{{#if vendorExtensions.x-is-parent-param}}{{else}}=None{{/if}}{{/instancePathParams}}):
         """
         Initialize the {{instanceName}}
         :returns: twilio.rest.{{domainPackage}}.{{apiVersion}}.{{namespaceSubPart}}.{{instanceName}}


### PR DESCRIPTION
https://github.com/twilio/twilio-python/pull/673