### PR TITLE
fix: only include list operations if a path is present in python

### DIFF
--- a/src/main/resources/twilio-python/api-single.mustache
+++ b/src/main/resources/twilio-python/api-single.mustache
@@ -31,7 +31,7 @@ class {{apiName}}List(ListResource):
         {{#listPath}}self._uri = '{{listPath}}'.format(**self._solution){{/listPath}}
         {{#dependents}}{{^instanceDependent}}
         self._{{mountName}} = None{{/instanceDependent}}{{/dependents}}
-        {{>listOperations}}{{#dependents}}{{^instanceDependent}}
+        {{#listPath}}{{>listOperations}}{{/listPath}}{{#dependents}}{{^instanceDependent}}
     @property
     def {{mountName}}(self):
         """


### PR DESCRIPTION
https://github.com/twilio/twilio-python/pull/682