### PR TITLE
chore: move list implementations to the bottom for python

### DIFF
--- a/examples/python/twilio/rest/api/v2010/account/__init__.py
+++ b/examples/python/twilio/rest/api/v2010/account/__init__.py
@@ -14,424 +14,13 @@ r"""
 
 
 from typing import Optional
-from twilio.base import deserialize
-from twilio.base import serialize
-from twilio.base import values
+from twilio.base import deserialize, serialize, values
 from twilio.base.instance_context import InstanceContext
 from twilio.base.instance_resource import InstanceResource
 from twilio.base.list_resource import ListResource
 from twilio.base.version import Version
 from twilio.base.page import Page
 from twilio.rest.api.v2010.account.call import CallList
-
-
-class AccountList(ListResource):
-    def __init__(self, version: Version):
-        """
-        Initialize the AccountList
-
-        :param Version version: Version that contains the resource
-
-        :returns: twilio.rest.api.v2010.account.AccountList
-        :rtype: twilio.rest.api.v2010.account.AccountList
-        """
-        super().__init__(version)
-
-        self._uri = "/Accounts.json"
-
-    def create(
-        self,
-        x_twilio_webhook_enabled=values.unset,
-        recording_status_callback=values.unset,
-        recording_status_callback_event=values.unset,
-        twiml=values.unset,
-    ):
-        """
-        Create the AccountInstance
-
-        :param str x_twilio_webhook_enabled:
-        :param str recording_status_callback:
-        :param list[str] recording_status_callback_event:
-        :param str twiml:
-
-        :returns: The created AccountInstance
-        :rtype: twilio.rest.api.v2010.account.AccountInstance
-        """
-        data = values.of(
-            {
-                "RecordingStatusCallback": recording_status_callback,
-                "RecordingStatusCallbackEvent": serialize.map(
-                    recording_status_callback_event, lambda e: e
-                ),
-                "Twiml": twiml,
-            }
-        )
-        headers = values.of(
-            {
-                "X-Twilio-Webhook-Enabled": x_twilio_webhook_enabled,
-            }
-        )
-        payload = self._version.create(
-            method="POST", uri=self._uri, data=data, headers=headers
-        )
-
-        return AccountInstance(self._version, payload)
-
-    async def create_async(
-        self,
-        x_twilio_webhook_enabled=values.unset,
-        recording_status_callback=values.unset,
-        recording_status_callback_event=values.unset,
-        twiml=values.unset,
-    ):
-        """
-        Asynchronously create the AccountInstance
-
-        :param str x_twilio_webhook_enabled:
-        :param str recording_status_callback:
-        :param list[str] recording_status_callback_event:
-        :param str twiml:
-
-        :returns: The created AccountInstance
-        :rtype: twilio.rest.api.v2010.account.AccountInstance
-        """
-        data = values.of(
-            {
-                "RecordingStatusCallback": recording_status_callback,
-                "RecordingStatusCallbackEvent": serialize.map(
-                    recording_status_callback_event, lambda e: e
-                ),
-                "Twiml": twiml,
-            }
-        )
-        headers = values.of(
-            {
-                "X-Twilio-Webhook-Enabled": x_twilio_webhook_enabled,
-            }
-        )
-        payload = await self._version.create_async(
-            method="POST", uri=self._uri, data=data, headers=headers
-        )
-
-        return AccountInstance(self._version, payload)
-
-    def stream(
-        self,
-        date_created=values.unset,
-        date_test=values.unset,
-        date_created_before=values.unset,
-        date_created_after=values.unset,
-        limit=None,
-        page_size=None,
-    ):
-        """
-        Streams AccountInstance records from the API as a generator stream.
-        This operation lazily loads records as efficiently as possible until the limit
-        is reached.
-        The results are returned as a generator, so this operation is memory efficient.
-
-        :param datetime date_created:
-        :param date date_test:
-        :param datetime date_created_before:
-        :param datetime date_created_after:
-        :param int limit: Upper limit for the number of records to return. stream()
-                          guarantees to never return more than limit.  Default is no limit
-        :param int page_size: Number of records to fetch per request, when not set will use
-                              the default value of 50 records.  If no page_size is defined
-                              but a limit is defined, stream() will attempt to read the
-                              limit with the most efficient page size, i.e. min(limit, 1000)
-
-        :returns: Generator that will yield up to limit results
-        :rtype: list[twilio.rest.api.v2010.account.AccountInstance]
-        """
-        limits = self._version.read_limits(limit, page_size)
-        page = self.page(
-            date_created=date_created,
-            date_test=date_test,
-            date_created_before=date_created_before,
-            date_created_after=date_created_after,
-            page_size=limits["page_size"],
-        )
-
-        return self._version.stream(page, limits["limit"])
-
-    async def stream_async(
-        self,
-        date_created=values.unset,
-        date_test=values.unset,
-        date_created_before=values.unset,
-        date_created_after=values.unset,
-        limit=None,
-        page_size=None,
-    ):
-        """
-        Asynchronously streams AccountInstance records from the API as a generator stream.
-        This operation lazily loads records as efficiently as possible until the limit
-        is reached.
-        The results are returned as a generator, so this operation is memory efficient.
-
-        :param datetime date_created:
-        :param date date_test:
-        :param datetime date_created_before:
-        :param datetime date_created_after:
-        :param int limit: Upper limit for the number of records to return. stream()
-                          guarantees to never return more than limit.  Default is no limit
-        :param int page_size: Number of records to fetch per request, when not set will use
-                              the default value of 50 records.  If no page_size is defined
-                              but a limit is defined, stream() will attempt to read the
-                              limit with the most efficient page size, i.e. min(limit, 1000)
-
-        :returns: Generator that will yield up to limit results
-        :rtype: list[twilio.rest.api.v2010.account.AccountInstance]
-        """
-        limits = self._version.read_limits(limit, page_size)
-        page = await self.page_async(
-            date_created=date_created,
-            date_test=date_test,
-            date_created_before=date_created_before,
-            date_created_after=date_created_after,
-            page_size=limits["page_size"],
-        )
-
-        return await self._version.stream_async(page, limits["limit"])
-
-    def list(
-        self,
-        date_created=values.unset,
-        date_test=values.unset,
-        date_created_before=values.unset,
-        date_created_after=values.unset,
-        limit=None,
-        page_size=None,
-    ):
-        """
-        Lists AccountInstance records from the API as a list.
-        Unlike stream(), this operation is eager and will load `limit` records into
-        memory before returning.
-
-        :param datetime date_created:
-        :param date date_test:
-        :param datetime date_created_before:
-        :param datetime date_created_after:
-        :param int limit: Upper limit for the number of records to return. list() guarantees
-                          never to return more than limit.  Default is no limit
-        :param int page_size: Number of records to fetch per request, when not set will use
-                              the default value of 50 records.  If no page_size is defined
-                              but a limit is defined, list() will attempt to read the limit
-                              with the most efficient page size, i.e. min(limit, 1000)
-
-        :returns: Generator that will yield up to limit results
-        :rtype: list[twilio.rest.api.v2010.account.AccountInstance]
-        """
-        return list(
-            self.stream(
-                date_created=date_created,
-                date_test=date_test,
-                date_created_before=date_created_before,
-                date_created_after=date_created_after,
-                limit=limit,
-                page_size=page_size,
-            )
-        )
-
-    async def list_async(
-        self,
-        date_created=values.unset,
-        date_test=values.unset,
-        date_created_before=values.unset,
-        date_created_after=values.unset,
-        limit=None,
-        page_size=None,
-    ):
-        """
-        Asynchronously lists AccountInstance records from the API as a list.
-        Unlike stream(), this operation is eager and will load `limit` records into
-        memory before returning.
-
-        :param datetime date_created:
-        :param date date_test:
-        :param datetime date_created_before:
-        :param datetime date_created_after:
-        :param int limit: Upper limit for the number of records to return. list() guarantees
-                          never to return more than limit.  Default is no limit
-        :param int page_size: Number of records to fetch per request, when not set will use
-                              the default value of 50 records.  If no page_size is defined
-                              but a limit is defined, list() will attempt to read the limit
-                              with the most efficient page size, i.e. min(limit, 1000)
-
-        :returns: Generator that will yield up to limit results
-        :rtype: list[twilio.rest.api.v2010.account.AccountInstance]
-        """
-        return list(
-            await self.stream_async(
-                date_created=date_created,
-                date_test=date_test,
-                date_created_before=date_created_before,
-                date_created_after=date_created_after,
-                limit=limit,
-                page_size=page_size,
-            )
-        )
-
-    def page(
-        self,
-        date_created=values.unset,
-        date_test=values.unset,
-        date_created_before=values.unset,
-        date_created_after=values.unset,
-        page_token=values.unset,
-        page_number=values.unset,
-        page_size=values.unset,
-    ):
-        """
-        Retrieve a single page of AccountInstance records from the API.
-        Request is executed immediately
-
-        :param datetime date_created:
-        :param date date_test:
-        :param datetime date_created_before:
-        :param datetime date_created_after:
-        :param str page_token: PageToken provided by the API
-        :param int page_number: Page Number, this value is simply for client state
-        :param int page_size: Number of records to return, defaults to 50
-
-        :returns: Page of AccountInstance
-        :rtype: twilio.rest.api.v2010.account.AccountPage
-        """
-        data = values.of(
-            {
-                "DateCreated": serialize.iso8601_datetime(date_created),
-                "Date.Test": serialize.iso8601_date(date_test),
-                "DateCreated<": serialize.iso8601_datetime(date_created_before),
-                "DateCreated>": serialize.iso8601_datetime(date_created_after),
-                "PageToken": page_token,
-                "Page": page_number,
-                "PageSize": page_size,
-            }
-        )
-
-        response = self._version.page(method="GET", uri=self._uri, params=data)
-        return AccountPage(self._version, response)
-
-    async def page_async(
-        self,
-        date_created=values.unset,
-        date_test=values.unset,
-        date_created_before=values.unset,
-        date_created_after=values.unset,
-        page_token=values.unset,
-        page_number=values.unset,
-        page_size=values.unset,
-    ):
-        """
-        Asynchronously retrieve a single page of AccountInstance records from the API.
-        Request is executed immediately
-
-        :param datetime date_created:
-        :param date date_test:
-        :param datetime date_created_before:
-        :param datetime date_created_after:
-        :param str page_token: PageToken provided by the API
-        :param int page_number: Page Number, this value is simply for client state
-        :param int page_size: Number of records to return, defaults to 50
-
-        :returns: Page of AccountInstance
-        :rtype: twilio.rest.api.v2010.account.AccountPage
-        """
-        data = values.of(
-            {
-                "DateCreated": serialize.iso8601_datetime(date_created),
-                "Date.Test": serialize.iso8601_date(date_test),
-                "DateCreated<": serialize.iso8601_datetime(date_created_before),
-                "DateCreated>": serialize.iso8601_datetime(date_created_after),
-                "PageToken": page_token,
-                "Page": page_number,
-                "PageSize": page_size,
-            }
-        )
-
-        response = await self._version.page_async(
-            method="GET", uri=self._uri, params=data
-        )
-        return AccountPage(self._version, response)
-
-    def get_page(self, target_url):
-        """
-        Retrieve a specific page of AccountInstance records from the API.
-        Request is executed immediately
-
-        :param str target_url: API-generated URL for the requested results page
-
-        :returns: Page of AccountInstance
-        :rtype: twilio.rest.api.v2010.account.AccountPage
-        """
-        response = self._version.domain.twilio.request("GET", target_url)
-        return AccountPage(self._version, response)
-
-    async def get_page_async(self, target_url):
-        """
-        Asynchronously retrieve a specific page of AccountInstance records from the API.
-        Request is executed immediately
-
-        :param str target_url: API-generated URL for the requested results page
-
-        :returns: Page of AccountInstance
-        :rtype: twilio.rest.api.v2010.account.AccountPage
-        """
-        response = await self._version.domain.twilio.request_async("GET", target_url)
-        return AccountPage(self._version, response)
-
-    def get(self, sid):
-        """
-        Constructs a AccountContext
-
-        :param sid:
-
-        :returns: twilio.rest.api.v2010.account.AccountContext
-        :rtype: twilio.rest.api.v2010.account.AccountContext
-        """
-        return AccountContext(self._version, sid=sid)
-
-    def __call__(self, sid):
-        """
-        Constructs a AccountContext
-
-        :param sid:
-
-        :returns: twilio.rest.api.v2010.account.AccountContext
-        :rtype: twilio.rest.api.v2010.account.AccountContext
-        """
-        return AccountContext(self._version, sid=sid)
-
-    def __repr__(self):
-        """
-        Provide a friendly representation
-
-        :returns: Machine friendly representation
-        :rtype: str
-        """
-        return "<Twilio.Api.V2010.AccountList>"
-
-
-class AccountPage(Page):
-    def get_instance(self, payload):
-        """
-        Build an instance of AccountInstance
-
-        :param dict payload: Payload response from the API
-
-        :returns: twilio.rest.api.v2010.account.AccountInstance
-        :rtype: twilio.rest.api.v2010.account.AccountInstance
-        """
-        return AccountInstance(self._version, payload)
-
-    def __repr__(self) -> str:
-        """
-        Provide a friendly representation
-
-        :returns: Machine friendly representation
-        """
-        return "<Twilio.Api.V2010.AccountPage>"
 
 
 class AccountInstance(InstanceResource):
@@ -876,3 +465,412 @@ class AccountContext(InstanceContext):
         """
         context = " ".join("{}={}".format(k, v) for k, v in self._solution.items())
         return "<Twilio.Api.V2010.AccountContext {}>".format(context)
+
+
+class AccountList(ListResource):
+    def __init__(self, version: Version):
+        """
+        Initialize the AccountList
+
+        :param Version version: Version that contains the resource
+
+        :returns: twilio.rest.api.v2010.account.AccountList
+        :rtype: twilio.rest.api.v2010.account.AccountList
+        """
+        super().__init__(version)
+
+        self._uri = "/Accounts.json"
+
+    def create(
+        self,
+        x_twilio_webhook_enabled=values.unset,
+        recording_status_callback=values.unset,
+        recording_status_callback_event=values.unset,
+        twiml=values.unset,
+    ):
+        """
+        Create the AccountInstance
+
+        :param str x_twilio_webhook_enabled:
+        :param str recording_status_callback:
+        :param list[str] recording_status_callback_event:
+        :param str twiml:
+
+        :returns: The created AccountInstance
+        :rtype: twilio.rest.api.v2010.account.AccountInstance
+        """
+        data = values.of(
+            {
+                "RecordingStatusCallback": recording_status_callback,
+                "RecordingStatusCallbackEvent": serialize.map(
+                    recording_status_callback_event, lambda e: e
+                ),
+                "Twiml": twiml,
+            }
+        )
+        headers = values.of(
+            {
+                "X-Twilio-Webhook-Enabled": x_twilio_webhook_enabled,
+            }
+        )
+        payload = self._version.create(
+            method="POST", uri=self._uri, data=data, headers=headers
+        )
+
+        return AccountInstance(self._version, payload)
+
+    async def create_async(
+        self,
+        x_twilio_webhook_enabled=values.unset,
+        recording_status_callback=values.unset,
+        recording_status_callback_event=values.unset,
+        twiml=values.unset,
+    ):
+        """
+        Asynchronously create the AccountInstance
+
+        :param str x_twilio_webhook_enabled:
+        :param str recording_status_callback:
+        :param list[str] recording_status_callback_event:
+        :param str twiml:
+
+        :returns: The created AccountInstance
+        :rtype: twilio.rest.api.v2010.account.AccountInstance
+        """
+        data = values.of(
+            {
+                "RecordingStatusCallback": recording_status_callback,
+                "RecordingStatusCallbackEvent": serialize.map(
+                    recording_status_callback_event, lambda e: e
+                ),
+                "Twiml": twiml,
+            }
+        )
+        headers = values.of(
+            {
+                "X-Twilio-Webhook-Enabled": x_twilio_webhook_enabled,
+            }
+        )
+        payload = await self._version.create_async(
+            method="POST", uri=self._uri, data=data, headers=headers
+        )
+
+        return AccountInstance(self._version, payload)
+
+    def stream(
+        self,
+        date_created=values.unset,
+        date_test=values.unset,
+        date_created_before=values.unset,
+        date_created_after=values.unset,
+        limit=None,
+        page_size=None,
+    ):
+        """
+        Streams AccountInstance records from the API as a generator stream.
+        This operation lazily loads records as efficiently as possible until the limit
+        is reached.
+        The results are returned as a generator, so this operation is memory efficient.
+
+        :param datetime date_created:
+        :param date date_test:
+        :param datetime date_created_before:
+        :param datetime date_created_after:
+        :param int limit: Upper limit for the number of records to return. stream()
+                          guarantees to never return more than limit.  Default is no limit
+        :param int page_size: Number of records to fetch per request, when not set will use
+                              the default value of 50 records.  If no page_size is defined
+                              but a limit is defined, stream() will attempt to read the
+                              limit with the most efficient page size, i.e. min(limit, 1000)
+
+        :returns: Generator that will yield up to limit results
+        :rtype: list[twilio.rest.api.v2010.account.AccountInstance]
+        """
+        limits = self._version.read_limits(limit, page_size)
+        page = self.page(
+            date_created=date_created,
+            date_test=date_test,
+            date_created_before=date_created_before,
+            date_created_after=date_created_after,
+            page_size=limits["page_size"],
+        )
+
+        return self._version.stream(page, limits["limit"])
+
+    async def stream_async(
+        self,
+        date_created=values.unset,
+        date_test=values.unset,
+        date_created_before=values.unset,
+        date_created_after=values.unset,
+        limit=None,
+        page_size=None,
+    ):
+        """
+        Asynchronously streams AccountInstance records from the API as a generator stream.
+        This operation lazily loads records as efficiently as possible until the limit
+        is reached.
+        The results are returned as a generator, so this operation is memory efficient.
+
+        :param datetime date_created:
+        :param date date_test:
+        :param datetime date_created_before:
+        :param datetime date_created_after:
+        :param int limit: Upper limit for the number of records to return. stream()
+                          guarantees to never return more than limit.  Default is no limit
+        :param int page_size: Number of records to fetch per request, when not set will use
+                              the default value of 50 records.  If no page_size is defined
+                              but a limit is defined, stream() will attempt to read the
+                              limit with the most efficient page size, i.e. min(limit, 1000)
+
+        :returns: Generator that will yield up to limit results
+        :rtype: list[twilio.rest.api.v2010.account.AccountInstance]
+        """
+        limits = self._version.read_limits(limit, page_size)
+        page = await self.page_async(
+            date_created=date_created,
+            date_test=date_test,
+            date_created_before=date_created_before,
+            date_created_after=date_created_after,
+            page_size=limits["page_size"],
+        )
+
+        return await self._version.stream_async(page, limits["limit"])
+
+    def list(
+        self,
+        date_created=values.unset,
+        date_test=values.unset,
+        date_created_before=values.unset,
+        date_created_after=values.unset,
+        limit=None,
+        page_size=None,
+    ):
+        """
+        Lists AccountInstance records from the API as a list.
+        Unlike stream(), this operation is eager and will load `limit` records into
+        memory before returning.
+
+        :param datetime date_created:
+        :param date date_test:
+        :param datetime date_created_before:
+        :param datetime date_created_after:
+        :param int limit: Upper limit for the number of records to return. list() guarantees
+                          never to return more than limit.  Default is no limit
+        :param int page_size: Number of records to fetch per request, when not set will use
+                              the default value of 50 records.  If no page_size is defined
+                              but a limit is defined, list() will attempt to read the limit
+                              with the most efficient page size, i.e. min(limit, 1000)
+
+        :returns: Generator that will yield up to limit results
+        :rtype: list[twilio.rest.api.v2010.account.AccountInstance]
+        """
+        return list(
+            self.stream(
+                date_created=date_created,
+                date_test=date_test,
+                date_created_before=date_created_before,
+                date_created_after=date_created_after,
+                limit=limit,
+                page_size=page_size,
+            )
+        )
+
+    async def list_async(
+        self,
+        date_created=values.unset,
+        date_test=values.unset,
+        date_created_before=values.unset,
+        date_created_after=values.unset,
+        limit=None,
+        page_size=None,
+    ):
+        """
+        Asynchronously lists AccountInstance records from the API as a list.
+        Unlike stream(), this operation is eager and will load `limit` records into
+        memory before returning.
+
+        :param datetime date_created:
+        :param date date_test:
+        :param datetime date_created_before:
+        :param datetime date_created_after:
+        :param int limit: Upper limit for the number of records to return. list() guarantees
+                          never to return more than limit.  Default is no limit
+        :param int page_size: Number of records to fetch per request, when not set will use
+                              the default value of 50 records.  If no page_size is defined
+                              but a limit is defined, list() will attempt to read the limit
+                              with the most efficient page size, i.e. min(limit, 1000)
+
+        :returns: Generator that will yield up to limit results
+        :rtype: list[twilio.rest.api.v2010.account.AccountInstance]
+        """
+        return list(
+            await self.stream_async(
+                date_created=date_created,
+                date_test=date_test,
+                date_created_before=date_created_before,
+                date_created_after=date_created_after,
+                limit=limit,
+                page_size=page_size,
+            )
+        )
+
+    def page(
+        self,
+        date_created=values.unset,
+        date_test=values.unset,
+        date_created_before=values.unset,
+        date_created_after=values.unset,
+        page_token=values.unset,
+        page_number=values.unset,
+        page_size=values.unset,
+    ):
+        """
+        Retrieve a single page of AccountInstance records from the API.
+        Request is executed immediately
+
+        :param datetime date_created:
+        :param date date_test:
+        :param datetime date_created_before:
+        :param datetime date_created_after:
+        :param str page_token: PageToken provided by the API
+        :param int page_number: Page Number, this value is simply for client state
+        :param int page_size: Number of records to return, defaults to 50
+
+        :returns: Page of AccountInstance
+        :rtype: twilio.rest.api.v2010.account.AccountPage
+        """
+        data = values.of(
+            {
+                "DateCreated": serialize.iso8601_datetime(date_created),
+                "Date.Test": serialize.iso8601_date(date_test),
+                "DateCreated<": serialize.iso8601_datetime(date_created_before),
+                "DateCreated>": serialize.iso8601_datetime(date_created_after),
+                "PageToken": page_token,
+                "Page": page_number,
+                "PageSize": page_size,
+            }
+        )
+
+        response = self._version.page(method="GET", uri=self._uri, params=data)
+        return AccountPage(self._version, response)
+
+    async def page_async(
+        self,
+        date_created=values.unset,
+        date_test=values.unset,
+        date_created_before=values.unset,
+        date_created_after=values.unset,
+        page_token=values.unset,
+        page_number=values.unset,
+        page_size=values.unset,
+    ):
+        """
+        Asynchronously retrieve a single page of AccountInstance records from the API.
+        Request is executed immediately
+
+        :param datetime date_created:
+        :param date date_test:
+        :param datetime date_created_before:
+        :param datetime date_created_after:
+        :param str page_token: PageToken provided by the API
+        :param int page_number: Page Number, this value is simply for client state
+        :param int page_size: Number of records to return, defaults to 50
+
+        :returns: Page of AccountInstance
+        :rtype: twilio.rest.api.v2010.account.AccountPage
+        """
+        data = values.of(
+            {
+                "DateCreated": serialize.iso8601_datetime(date_created),
+                "Date.Test": serialize.iso8601_date(date_test),
+                "DateCreated<": serialize.iso8601_datetime(date_created_before),
+                "DateCreated>": serialize.iso8601_datetime(date_created_after),
+                "PageToken": page_token,
+                "Page": page_number,
+                "PageSize": page_size,
+            }
+        )
+
+        response = await self._version.page_async(
+            method="GET", uri=self._uri, params=data
+        )
+        return AccountPage(self._version, response)
+
+    def get_page(self, target_url):
+        """
+        Retrieve a specific page of AccountInstance records from the API.
+        Request is executed immediately
+
+        :param str target_url: API-generated URL for the requested results page
+
+        :returns: Page of AccountInstance
+        :rtype: twilio.rest.api.v2010.account.AccountPage
+        """
+        response = self._version.domain.twilio.request("GET", target_url)
+        return AccountPage(self._version, response)
+
+    async def get_page_async(self, target_url):
+        """
+        Asynchronously retrieve a specific page of AccountInstance records from the API.
+        Request is executed immediately
+
+        :param str target_url: API-generated URL for the requested results page
+
+        :returns: Page of AccountInstance
+        :rtype: twilio.rest.api.v2010.account.AccountPage
+        """
+        response = await self._version.domain.twilio.request_async("GET", target_url)
+        return AccountPage(self._version, response)
+
+    def get(self, sid):
+        """
+        Constructs a AccountContext
+
+        :param sid:
+
+        :returns: twilio.rest.api.v2010.account.AccountContext
+        :rtype: twilio.rest.api.v2010.account.AccountContext
+        """
+        return AccountContext(self._version, sid=sid)
+
+    def __call__(self, sid):
+        """
+        Constructs a AccountContext
+
+        :param sid:
+
+        :returns: twilio.rest.api.v2010.account.AccountContext
+        :rtype: twilio.rest.api.v2010.account.AccountContext
+        """
+        return AccountContext(self._version, sid=sid)
+
+    def __repr__(self):
+        """
+        Provide a friendly representation
+
+        :returns: Machine friendly representation
+        :rtype: str
+        """
+        return "<Twilio.Api.V2010.AccountList>"
+
+
+class AccountPage(Page):
+    def get_instance(self, payload):
+        """
+        Build an instance of AccountInstance
+
+        :param dict payload: Payload response from the API
+
+        :returns: twilio.rest.api.v2010.account.AccountInstance
+        :rtype: twilio.rest.api.v2010.account.AccountInstance
+        """
+        return AccountInstance(self._version, payload)
+
+    def __repr__(self) -> str:
+        """
+        Provide a friendly representation
+
+        :returns: Machine friendly representation
+        """
+        return "<Twilio.Api.V2010.AccountPage>"

--- a/examples/python/twilio/rest/api/v2010/account/__init__.py
+++ b/examples/python/twilio/rest/api/v2010/account/__init__.py
@@ -467,6 +467,27 @@ class AccountContext(InstanceContext):
         return "<Twilio.Api.V2010.AccountContext {}>".format(context)
 
 
+class AccountPage(Page):
+    def get_instance(self, payload):
+        """
+        Build an instance of AccountInstance
+
+        :param dict payload: Payload response from the API
+
+        :returns: twilio.rest.api.v2010.account.AccountInstance
+        :rtype: twilio.rest.api.v2010.account.AccountInstance
+        """
+        return AccountInstance(self._version, payload)
+
+    def __repr__(self) -> str:
+        """
+        Provide a friendly representation
+
+        :returns: Machine friendly representation
+        """
+        return "<Twilio.Api.V2010.AccountPage>"
+
+
 class AccountList(ListResource):
     def __init__(self, version: Version):
         """
@@ -853,24 +874,3 @@ class AccountList(ListResource):
         :rtype: str
         """
         return "<Twilio.Api.V2010.AccountList>"
-
-
-class AccountPage(Page):
-    def get_instance(self, payload):
-        """
-        Build an instance of AccountInstance
-
-        :param dict payload: Payload response from the API
-
-        :returns: twilio.rest.api.v2010.account.AccountInstance
-        :rtype: twilio.rest.api.v2010.account.AccountInstance
-        """
-        return AccountInstance(self._version, payload)
-
-    def __repr__(self) -> str:
-        """
-        Provide a friendly representation
-
-        :returns: Machine friendly representation
-        """
-        return "<Twilio.Api.V2010.AccountPage>"

--- a/examples/python/twilio/rest/api/v2010/account/call/__init__.py
+++ b/examples/python/twilio/rest/api/v2010/account/call/__init__.py
@@ -14,9 +14,7 @@ r"""
 
 
 from typing import Optional
-from twilio.base import deserialize
-from twilio.base import serialize
-from twilio.base import values
+from twilio.base import deserialize, serialize, values
 from twilio.base.instance_context import InstanceContext
 from twilio.base.instance_resource import InstanceResource
 from twilio.base.list_resource import ListResource
@@ -25,155 +23,6 @@ from twilio.base.version import Version
 from twilio.rest.api.v2010.account.call.feedback_call_summary import (
     FeedbackCallSummaryList,
 )
-
-
-class CallList(ListResource):
-    def __init__(self, version: Version, account_sid: str):
-        """
-        Initialize the CallList
-
-        :param Version version: Version that contains the resource
-        :param account_sid:
-
-        :returns: twilio.rest.api.v2010.account.call.CallList
-        :rtype: twilio.rest.api.v2010.account.call.CallList
-        """
-        super().__init__(version)
-
-        # Path Solution
-        self._solution = {
-            "account_sid": account_sid,
-        }
-        self._uri = "/Accounts/{account_sid}/Calls.json".format(**self._solution)
-
-        self._feedback_call_summary: Optional[FeedbackCallSummaryList] = None
-
-    def create(
-        self,
-        required_string_property,
-        test_method,
-        test_array_of_strings=values.unset,
-        test_array_of_uri=values.unset,
-    ):
-        """
-        Create the CallInstance
-
-        :param str required_string_property:
-        :param str test_method: The HTTP method that we should use to request the `TestArrayOfUri`.
-        :param list[str] test_array_of_strings:
-        :param list[str] test_array_of_uri:
-
-        :returns: The created CallInstance
-        :rtype: twilio.rest.api.v2010.account.call.CallInstance
-        """
-        data = values.of(
-            {
-                "RequiredStringProperty": required_string_property,
-                "TestMethod": test_method,
-                "TestArrayOfStrings": serialize.map(test_array_of_strings, lambda e: e),
-                "TestArrayOfUri": serialize.map(test_array_of_uri, lambda e: e),
-            }
-        )
-
-        payload = self._version.create(
-            method="POST",
-            uri=self._uri,
-            data=data,
-        )
-
-        return CallInstance(
-            self._version, payload, account_sid=self._solution["account_sid"]
-        )
-
-    async def create_async(
-        self,
-        required_string_property,
-        test_method,
-        test_array_of_strings=values.unset,
-        test_array_of_uri=values.unset,
-    ):
-        """
-        Asynchronously create the CallInstance
-
-        :param str required_string_property:
-        :param str test_method: The HTTP method that we should use to request the `TestArrayOfUri`.
-        :param list[str] test_array_of_strings:
-        :param list[str] test_array_of_uri:
-
-        :returns: The created CallInstance
-        :rtype: twilio.rest.api.v2010.account.call.CallInstance
-        """
-        data = values.of(
-            {
-                "RequiredStringProperty": required_string_property,
-                "TestMethod": test_method,
-                "TestArrayOfStrings": serialize.map(test_array_of_strings, lambda e: e),
-                "TestArrayOfUri": serialize.map(test_array_of_uri, lambda e: e),
-            }
-        )
-
-        payload = await self._version.create_async(
-            method="POST",
-            uri=self._uri,
-            data=data,
-        )
-
-        return CallInstance(
-            self._version, payload, account_sid=self._solution["account_sid"]
-        )
-
-    @property
-    def feedback_call_summary(self):
-        """
-        Access the feedback_call_summary
-
-        :returns: twilio.rest.api.v2010.account.call.FeedbackCallSummaryList
-        :rtype: twilio.rest.api.v2010.account.call.FeedbackCallSummaryList
-        """
-        if self._feedback_call_summary is None:
-            self._feedback_call_summary = FeedbackCallSummaryList(
-                self._version, account_sid=self._solution["account_sid"]
-            )
-        return self._feedback_call_summary
-
-    def get(self, test_integer):
-        """
-        Constructs a CallContext
-
-        :param test_integer: INTEGER ID param!!!
-
-        :returns: twilio.rest.api.v2010.account.call.CallContext
-        :rtype: twilio.rest.api.v2010.account.call.CallContext
-        """
-        return CallContext(
-            self._version,
-            account_sid=self._solution["account_sid"],
-            test_integer=test_integer,
-        )
-
-    def __call__(self, test_integer):
-        """
-        Constructs a CallContext
-
-        :param test_integer: INTEGER ID param!!!
-
-        :returns: twilio.rest.api.v2010.account.call.CallContext
-        :rtype: twilio.rest.api.v2010.account.call.CallContext
-        """
-        return CallContext(
-            self._version,
-            account_sid=self._solution["account_sid"],
-            test_integer=test_integer,
-        )
-
-    def __repr__(self):
-        """
-        Provide a friendly representation
-
-        :returns: Machine friendly representation
-        :rtype: str
-        """
-        return "<Twilio.Api.V2010.CallList>"
 
 
 class CallInstance(InstanceResource):
@@ -521,3 +370,152 @@ class CallContext(InstanceContext):
         """
         context = " ".join("{}={}".format(k, v) for k, v in self._solution.items())
         return "<Twilio.Api.V2010.CallContext {}>".format(context)
+
+
+class CallList(ListResource):
+    def __init__(self, version: Version, account_sid: str):
+        """
+        Initialize the CallList
+
+        :param Version version: Version that contains the resource
+        :param account_sid:
+
+        :returns: twilio.rest.api.v2010.account.call.CallList
+        :rtype: twilio.rest.api.v2010.account.call.CallList
+        """
+        super().__init__(version)
+
+        # Path Solution
+        self._solution = {
+            "account_sid": account_sid,
+        }
+        self._uri = "/Accounts/{account_sid}/Calls.json".format(**self._solution)
+
+        self._feedback_call_summary: Optional[FeedbackCallSummaryList] = None
+
+    def create(
+        self,
+        required_string_property,
+        test_method,
+        test_array_of_strings=values.unset,
+        test_array_of_uri=values.unset,
+    ):
+        """
+        Create the CallInstance
+
+        :param str required_string_property:
+        :param str test_method: The HTTP method that we should use to request the `TestArrayOfUri`.
+        :param list[str] test_array_of_strings:
+        :param list[str] test_array_of_uri:
+
+        :returns: The created CallInstance
+        :rtype: twilio.rest.api.v2010.account.call.CallInstance
+        """
+        data = values.of(
+            {
+                "RequiredStringProperty": required_string_property,
+                "TestMethod": test_method,
+                "TestArrayOfStrings": serialize.map(test_array_of_strings, lambda e: e),
+                "TestArrayOfUri": serialize.map(test_array_of_uri, lambda e: e),
+            }
+        )
+
+        payload = self._version.create(
+            method="POST",
+            uri=self._uri,
+            data=data,
+        )
+
+        return CallInstance(
+            self._version, payload, account_sid=self._solution["account_sid"]
+        )
+
+    async def create_async(
+        self,
+        required_string_property,
+        test_method,
+        test_array_of_strings=values.unset,
+        test_array_of_uri=values.unset,
+    ):
+        """
+        Asynchronously create the CallInstance
+
+        :param str required_string_property:
+        :param str test_method: The HTTP method that we should use to request the `TestArrayOfUri`.
+        :param list[str] test_array_of_strings:
+        :param list[str] test_array_of_uri:
+
+        :returns: The created CallInstance
+        :rtype: twilio.rest.api.v2010.account.call.CallInstance
+        """
+        data = values.of(
+            {
+                "RequiredStringProperty": required_string_property,
+                "TestMethod": test_method,
+                "TestArrayOfStrings": serialize.map(test_array_of_strings, lambda e: e),
+                "TestArrayOfUri": serialize.map(test_array_of_uri, lambda e: e),
+            }
+        )
+
+        payload = await self._version.create_async(
+            method="POST",
+            uri=self._uri,
+            data=data,
+        )
+
+        return CallInstance(
+            self._version, payload, account_sid=self._solution["account_sid"]
+        )
+
+    @property
+    def feedback_call_summary(self):
+        """
+        Access the feedback_call_summary
+
+        :returns: twilio.rest.api.v2010.account.call.FeedbackCallSummaryList
+        :rtype: twilio.rest.api.v2010.account.call.FeedbackCallSummaryList
+        """
+        if self._feedback_call_summary is None:
+            self._feedback_call_summary = FeedbackCallSummaryList(
+                self._version, account_sid=self._solution["account_sid"]
+            )
+        return self._feedback_call_summary
+
+    def get(self, test_integer):
+        """
+        Constructs a CallContext
+
+        :param test_integer: INTEGER ID param!!!
+
+        :returns: twilio.rest.api.v2010.account.call.CallContext
+        :rtype: twilio.rest.api.v2010.account.call.CallContext
+        """
+        return CallContext(
+            self._version,
+            account_sid=self._solution["account_sid"],
+            test_integer=test_integer,
+        )
+
+    def __call__(self, test_integer):
+        """
+        Constructs a CallContext
+
+        :param test_integer: INTEGER ID param!!!
+
+        :returns: twilio.rest.api.v2010.account.call.CallContext
+        :rtype: twilio.rest.api.v2010.account.call.CallContext
+        """
+        return CallContext(
+            self._version,
+            account_sid=self._solution["account_sid"],
+            test_integer=test_integer,
+        )
+
+    def __repr__(self):
+        """
+        Provide a friendly representation
+
+        :returns: Machine friendly representation
+        :rtype: str
+        """
+        return "<Twilio.Api.V2010.CallList>"

--- a/examples/python/twilio/rest/api/v2010/account/call/feedback_call_summary.py
+++ b/examples/python/twilio/rest/api/v2010/account/call/feedback_call_summary.py
@@ -14,67 +14,11 @@ r"""
 
 
 from typing import Optional
-from twilio.base import deserialize
-from twilio.base import serialize
-from twilio.base import values
+from twilio.base import deserialize, serialize, values
 from twilio.base.instance_context import InstanceContext
 from twilio.base.instance_resource import InstanceResource
 from twilio.base.list_resource import ListResource
 from twilio.base.version import Version
-
-
-class FeedbackCallSummaryList(ListResource):
-    def __init__(self, version: Version, account_sid: str):
-        """
-        Initialize the FeedbackCallSummaryList
-
-        :param Version version: Version that contains the resource
-        :param account_sid:
-
-        :returns: twilio.rest.api.v2010.account.call.feedback_call_summary.FeedbackCallSummaryList
-        :rtype: twilio.rest.api.v2010.account.call.feedback_call_summary.FeedbackCallSummaryList
-        """
-        super().__init__(version)
-
-        # Path Solution
-        self._solution = {
-            "account_sid": account_sid,
-        }
-
-    def get(self, sid):
-        """
-        Constructs a FeedbackCallSummaryContext
-
-        :param sid:
-
-        :returns: twilio.rest.api.v2010.account.call.feedback_call_summary.FeedbackCallSummaryContext
-        :rtype: twilio.rest.api.v2010.account.call.feedback_call_summary.FeedbackCallSummaryContext
-        """
-        return FeedbackCallSummaryContext(
-            self._version, account_sid=self._solution["account_sid"], sid=sid
-        )
-
-    def __call__(self, sid):
-        """
-        Constructs a FeedbackCallSummaryContext
-
-        :param sid:
-
-        :returns: twilio.rest.api.v2010.account.call.feedback_call_summary.FeedbackCallSummaryContext
-        :rtype: twilio.rest.api.v2010.account.call.feedback_call_summary.FeedbackCallSummaryContext
-        """
-        return FeedbackCallSummaryContext(
-            self._version, account_sid=self._solution["account_sid"], sid=sid
-        )
-
-    def __repr__(self):
-        """
-        Provide a friendly representation
-
-        :returns: Machine friendly representation
-        :rtype: str
-        """
-        return "<Twilio.Api.V2010.FeedbackCallSummaryList>"
 
 
 class FeedbackCallSummaryInstance(InstanceResource):
@@ -410,3 +354,57 @@ class FeedbackCallSummaryContext(InstanceContext):
         """
         context = " ".join("{}={}".format(k, v) for k, v in self._solution.items())
         return "<Twilio.Api.V2010.FeedbackCallSummaryContext {}>".format(context)
+
+
+class FeedbackCallSummaryList(ListResource):
+    def __init__(self, version: Version, account_sid: str):
+        """
+        Initialize the FeedbackCallSummaryList
+
+        :param Version version: Version that contains the resource
+        :param account_sid:
+
+        :returns: twilio.rest.api.v2010.account.call.feedback_call_summary.FeedbackCallSummaryList
+        :rtype: twilio.rest.api.v2010.account.call.feedback_call_summary.FeedbackCallSummaryList
+        """
+        super().__init__(version)
+
+        # Path Solution
+        self._solution = {
+            "account_sid": account_sid,
+        }
+
+    def get(self, sid):
+        """
+        Constructs a FeedbackCallSummaryContext
+
+        :param sid:
+
+        :returns: twilio.rest.api.v2010.account.call.feedback_call_summary.FeedbackCallSummaryContext
+        :rtype: twilio.rest.api.v2010.account.call.feedback_call_summary.FeedbackCallSummaryContext
+        """
+        return FeedbackCallSummaryContext(
+            self._version, account_sid=self._solution["account_sid"], sid=sid
+        )
+
+    def __call__(self, sid):
+        """
+        Constructs a FeedbackCallSummaryContext
+
+        :param sid:
+
+        :returns: twilio.rest.api.v2010.account.call.feedback_call_summary.FeedbackCallSummaryContext
+        :rtype: twilio.rest.api.v2010.account.call.feedback_call_summary.FeedbackCallSummaryContext
+        """
+        return FeedbackCallSummaryContext(
+            self._version, account_sid=self._solution["account_sid"], sid=sid
+        )
+
+    def __repr__(self):
+        """
+        Provide a friendly representation
+
+        :returns: Machine friendly representation
+        :rtype: str
+        """
+        return "<Twilio.Api.V2010.FeedbackCallSummaryList>"

--- a/examples/python/twilio/rest/flex_api/v1/call.py
+++ b/examples/python/twilio/rest/flex_api/v1/call.py
@@ -14,56 +14,11 @@ r"""
 
 
 from typing import Optional
-from twilio.base import deserialize
-from twilio.base import values
+from twilio.base import deserialize, values
 from twilio.base.instance_context import InstanceContext
 from twilio.base.instance_resource import InstanceResource
 from twilio.base.list_resource import ListResource
 from twilio.base.version import Version
-
-
-class CallList(ListResource):
-    def __init__(self, version: Version):
-        """
-        Initialize the CallList
-
-        :param Version version: Version that contains the resource
-
-        :returns: twilio.rest.flex_api.v1.call.CallList
-        :rtype: twilio.rest.flex_api.v1.call.CallList
-        """
-        super().__init__(version)
-
-    def get(self, sid):
-        """
-        Constructs a CallContext
-
-        :param sid:
-
-        :returns: twilio.rest.flex_api.v1.call.CallContext
-        :rtype: twilio.rest.flex_api.v1.call.CallContext
-        """
-        return CallContext(self._version, sid=sid)
-
-    def __call__(self, sid):
-        """
-        Constructs a CallContext
-
-        :param sid:
-
-        :returns: twilio.rest.flex_api.v1.call.CallContext
-        :rtype: twilio.rest.flex_api.v1.call.CallContext
-        """
-        return CallContext(self._version, sid=sid)
-
-    def __repr__(self):
-        """
-        Provide a friendly representation
-
-        :returns: Machine friendly representation
-        :rtype: str
-        """
-        return "<Twilio.FlexApi.V1.CallList>"
 
 
 class CallInstance(InstanceResource):
@@ -204,3 +159,47 @@ class CallContext(InstanceContext):
         """
         context = " ".join("{}={}".format(k, v) for k, v in self._solution.items())
         return "<Twilio.FlexApi.V1.CallContext {}>".format(context)
+
+
+class CallList(ListResource):
+    def __init__(self, version: Version):
+        """
+        Initialize the CallList
+
+        :param Version version: Version that contains the resource
+
+        :returns: twilio.rest.flex_api.v1.call.CallList
+        :rtype: twilio.rest.flex_api.v1.call.CallList
+        """
+        super().__init__(version)
+
+    def get(self, sid):
+        """
+        Constructs a CallContext
+
+        :param sid:
+
+        :returns: twilio.rest.flex_api.v1.call.CallContext
+        :rtype: twilio.rest.flex_api.v1.call.CallContext
+        """
+        return CallContext(self._version, sid=sid)
+
+    def __call__(self, sid):
+        """
+        Constructs a CallContext
+
+        :param sid:
+
+        :returns: twilio.rest.flex_api.v1.call.CallContext
+        :rtype: twilio.rest.flex_api.v1.call.CallContext
+        """
+        return CallContext(self._version, sid=sid)
+
+    def __repr__(self):
+        """
+        Provide a friendly representation
+
+        :returns: Machine friendly representation
+        :rtype: str
+        """
+        return "<Twilio.FlexApi.V1.CallList>"

--- a/examples/python/twilio/rest/flex_api/v1/credential/aws/__init__.py
+++ b/examples/python/twilio/rest/flex_api/v1/credential/aws/__init__.py
@@ -14,249 +14,13 @@ r"""
 
 
 from typing import Optional
-from twilio.base import deserialize
-from twilio.base import values
+from twilio.base import deserialize, values
 from twilio.base.instance_context import InstanceContext
 from twilio.base.instance_resource import InstanceResource
 from twilio.base.list_resource import ListResource
 from twilio.base.version import Version
 from twilio.base.page import Page
 from twilio.rest.flex_api.v1.credential.aws.history import HistoryList
-
-
-class AwsList(ListResource):
-    def __init__(self, version: Version):
-        """
-        Initialize the AwsList
-
-        :param Version version: Version that contains the resource
-
-        :returns: twilio.rest.flex_api.v1.credential.aws.AwsList
-        :rtype: twilio.rest.flex_api.v1.credential.aws.AwsList
-        """
-        super().__init__(version)
-
-        self._uri = "/Credentials/AWS"
-
-    def stream(self, limit=None, page_size=None):
-        """
-        Streams AwsInstance records from the API as a generator stream.
-        This operation lazily loads records as efficiently as possible until the limit
-        is reached.
-        The results are returned as a generator, so this operation is memory efficient.
-
-        :param int limit: Upper limit for the number of records to return. stream()
-                          guarantees to never return more than limit.  Default is no limit
-        :param int page_size: Number of records to fetch per request, when not set will use
-                              the default value of 50 records.  If no page_size is defined
-                              but a limit is defined, stream() will attempt to read the
-                              limit with the most efficient page size, i.e. min(limit, 1000)
-
-        :returns: Generator that will yield up to limit results
-        :rtype: list[twilio.rest.flex_api.v1.credential.aws.AwsInstance]
-        """
-        limits = self._version.read_limits(limit, page_size)
-        page = self.page(page_size=limits["page_size"])
-
-        return self._version.stream(page, limits["limit"])
-
-    async def stream_async(self, limit=None, page_size=None):
-        """
-        Asynchronously streams AwsInstance records from the API as a generator stream.
-        This operation lazily loads records as efficiently as possible until the limit
-        is reached.
-        The results are returned as a generator, so this operation is memory efficient.
-
-        :param int limit: Upper limit for the number of records to return. stream()
-                          guarantees to never return more than limit.  Default is no limit
-        :param int page_size: Number of records to fetch per request, when not set will use
-                              the default value of 50 records.  If no page_size is defined
-                              but a limit is defined, stream() will attempt to read the
-                              limit with the most efficient page size, i.e. min(limit, 1000)
-
-        :returns: Generator that will yield up to limit results
-        :rtype: list[twilio.rest.flex_api.v1.credential.aws.AwsInstance]
-        """
-        limits = self._version.read_limits(limit, page_size)
-        page = await self.page_async(page_size=limits["page_size"])
-
-        return await self._version.stream_async(page, limits["limit"])
-
-    def list(self, limit=None, page_size=None):
-        """
-        Lists AwsInstance records from the API as a list.
-        Unlike stream(), this operation is eager and will load `limit` records into
-        memory before returning.
-
-        :param int limit: Upper limit for the number of records to return. list() guarantees
-                          never to return more than limit.  Default is no limit
-        :param int page_size: Number of records to fetch per request, when not set will use
-                              the default value of 50 records.  If no page_size is defined
-                              but a limit is defined, list() will attempt to read the limit
-                              with the most efficient page size, i.e. min(limit, 1000)
-
-        :returns: Generator that will yield up to limit results
-        :rtype: list[twilio.rest.flex_api.v1.credential.aws.AwsInstance]
-        """
-        return list(
-            self.stream(
-                limit=limit,
-                page_size=page_size,
-            )
-        )
-
-    async def list_async(self, limit=None, page_size=None):
-        """
-        Asynchronously lists AwsInstance records from the API as a list.
-        Unlike stream(), this operation is eager and will load `limit` records into
-        memory before returning.
-
-        :param int limit: Upper limit for the number of records to return. list() guarantees
-                          never to return more than limit.  Default is no limit
-        :param int page_size: Number of records to fetch per request, when not set will use
-                              the default value of 50 records.  If no page_size is defined
-                              but a limit is defined, list() will attempt to read the limit
-                              with the most efficient page size, i.e. min(limit, 1000)
-
-        :returns: Generator that will yield up to limit results
-        :rtype: list[twilio.rest.flex_api.v1.credential.aws.AwsInstance]
-        """
-        return list(
-            await self.stream_async(
-                limit=limit,
-                page_size=page_size,
-            )
-        )
-
-    def page(
-        self, page_token=values.unset, page_number=values.unset, page_size=values.unset
-    ):
-        """
-        Retrieve a single page of AwsInstance records from the API.
-        Request is executed immediately
-
-        :param str page_token: PageToken provided by the API
-        :param int page_number: Page Number, this value is simply for client state
-        :param int page_size: Number of records to return, defaults to 50
-
-        :returns: Page of AwsInstance
-        :rtype: twilio.rest.flex_api.v1.credential.aws.AwsPage
-        """
-        data = values.of(
-            {
-                "PageToken": page_token,
-                "Page": page_number,
-                "PageSize": page_size,
-            }
-        )
-
-        response = self._version.page(method="GET", uri=self._uri, params=data)
-        return AwsPage(self._version, response)
-
-    async def page_async(
-        self, page_token=values.unset, page_number=values.unset, page_size=values.unset
-    ):
-        """
-        Asynchronously retrieve a single page of AwsInstance records from the API.
-        Request is executed immediately
-
-        :param str page_token: PageToken provided by the API
-        :param int page_number: Page Number, this value is simply for client state
-        :param int page_size: Number of records to return, defaults to 50
-
-        :returns: Page of AwsInstance
-        :rtype: twilio.rest.flex_api.v1.credential.aws.AwsPage
-        """
-        data = values.of(
-            {
-                "PageToken": page_token,
-                "Page": page_number,
-                "PageSize": page_size,
-            }
-        )
-
-        response = await self._version.page_async(
-            method="GET", uri=self._uri, params=data
-        )
-        return AwsPage(self._version, response)
-
-    def get_page(self, target_url):
-        """
-        Retrieve a specific page of AwsInstance records from the API.
-        Request is executed immediately
-
-        :param str target_url: API-generated URL for the requested results page
-
-        :returns: Page of AwsInstance
-        :rtype: twilio.rest.flex_api.v1.credential.aws.AwsPage
-        """
-        response = self._version.domain.twilio.request("GET", target_url)
-        return AwsPage(self._version, response)
-
-    async def get_page_async(self, target_url):
-        """
-        Asynchronously retrieve a specific page of AwsInstance records from the API.
-        Request is executed immediately
-
-        :param str target_url: API-generated URL for the requested results page
-
-        :returns: Page of AwsInstance
-        :rtype: twilio.rest.flex_api.v1.credential.aws.AwsPage
-        """
-        response = await self._version.domain.twilio.request_async("GET", target_url)
-        return AwsPage(self._version, response)
-
-    def get(self, sid):
-        """
-        Constructs a AwsContext
-
-        :param sid:
-
-        :returns: twilio.rest.flex_api.v1.credential.aws.AwsContext
-        :rtype: twilio.rest.flex_api.v1.credential.aws.AwsContext
-        """
-        return AwsContext(self._version, sid=sid)
-
-    def __call__(self, sid):
-        """
-        Constructs a AwsContext
-
-        :param sid:
-
-        :returns: twilio.rest.flex_api.v1.credential.aws.AwsContext
-        :rtype: twilio.rest.flex_api.v1.credential.aws.AwsContext
-        """
-        return AwsContext(self._version, sid=sid)
-
-    def __repr__(self):
-        """
-        Provide a friendly representation
-
-        :returns: Machine friendly representation
-        :rtype: str
-        """
-        return "<Twilio.FlexApi.V1.AwsList>"
-
-
-class AwsPage(Page):
-    def get_instance(self, payload):
-        """
-        Build an instance of AwsInstance
-
-        :param dict payload: Payload response from the API
-
-        :returns: twilio.rest.flex_api.v1.credential.aws.AwsInstance
-        :rtype: twilio.rest.flex_api.v1.credential.aws.AwsInstance
-        """
-        return AwsInstance(self._version, payload)
-
-    def __repr__(self) -> str:
-        """
-        Provide a friendly representation
-
-        :returns: Machine friendly representation
-        """
-        return "<Twilio.FlexApi.V1.AwsPage>"
 
 
 class AwsInstance(InstanceResource):
@@ -581,3 +345,238 @@ class AwsContext(InstanceContext):
         """
         context = " ".join("{}={}".format(k, v) for k, v in self._solution.items())
         return "<Twilio.FlexApi.V1.AwsContext {}>".format(context)
+
+
+class AwsList(ListResource):
+    def __init__(self, version: Version):
+        """
+        Initialize the AwsList
+
+        :param Version version: Version that contains the resource
+
+        :returns: twilio.rest.flex_api.v1.credential.aws.AwsList
+        :rtype: twilio.rest.flex_api.v1.credential.aws.AwsList
+        """
+        super().__init__(version)
+
+        self._uri = "/Credentials/AWS"
+
+    def stream(self, limit=None, page_size=None):
+        """
+        Streams AwsInstance records from the API as a generator stream.
+        This operation lazily loads records as efficiently as possible until the limit
+        is reached.
+        The results are returned as a generator, so this operation is memory efficient.
+
+        :param int limit: Upper limit for the number of records to return. stream()
+                          guarantees to never return more than limit.  Default is no limit
+        :param int page_size: Number of records to fetch per request, when not set will use
+                              the default value of 50 records.  If no page_size is defined
+                              but a limit is defined, stream() will attempt to read the
+                              limit with the most efficient page size, i.e. min(limit, 1000)
+
+        :returns: Generator that will yield up to limit results
+        :rtype: list[twilio.rest.flex_api.v1.credential.aws.AwsInstance]
+        """
+        limits = self._version.read_limits(limit, page_size)
+        page = self.page(page_size=limits["page_size"])
+
+        return self._version.stream(page, limits["limit"])
+
+    async def stream_async(self, limit=None, page_size=None):
+        """
+        Asynchronously streams AwsInstance records from the API as a generator stream.
+        This operation lazily loads records as efficiently as possible until the limit
+        is reached.
+        The results are returned as a generator, so this operation is memory efficient.
+
+        :param int limit: Upper limit for the number of records to return. stream()
+                          guarantees to never return more than limit.  Default is no limit
+        :param int page_size: Number of records to fetch per request, when not set will use
+                              the default value of 50 records.  If no page_size is defined
+                              but a limit is defined, stream() will attempt to read the
+                              limit with the most efficient page size, i.e. min(limit, 1000)
+
+        :returns: Generator that will yield up to limit results
+        :rtype: list[twilio.rest.flex_api.v1.credential.aws.AwsInstance]
+        """
+        limits = self._version.read_limits(limit, page_size)
+        page = await self.page_async(page_size=limits["page_size"])
+
+        return await self._version.stream_async(page, limits["limit"])
+
+    def list(self, limit=None, page_size=None):
+        """
+        Lists AwsInstance records from the API as a list.
+        Unlike stream(), this operation is eager and will load `limit` records into
+        memory before returning.
+
+        :param int limit: Upper limit for the number of records to return. list() guarantees
+                          never to return more than limit.  Default is no limit
+        :param int page_size: Number of records to fetch per request, when not set will use
+                              the default value of 50 records.  If no page_size is defined
+                              but a limit is defined, list() will attempt to read the limit
+                              with the most efficient page size, i.e. min(limit, 1000)
+
+        :returns: Generator that will yield up to limit results
+        :rtype: list[twilio.rest.flex_api.v1.credential.aws.AwsInstance]
+        """
+        return list(
+            self.stream(
+                limit=limit,
+                page_size=page_size,
+            )
+        )
+
+    async def list_async(self, limit=None, page_size=None):
+        """
+        Asynchronously lists AwsInstance records from the API as a list.
+        Unlike stream(), this operation is eager and will load `limit` records into
+        memory before returning.
+
+        :param int limit: Upper limit for the number of records to return. list() guarantees
+                          never to return more than limit.  Default is no limit
+        :param int page_size: Number of records to fetch per request, when not set will use
+                              the default value of 50 records.  If no page_size is defined
+                              but a limit is defined, list() will attempt to read the limit
+                              with the most efficient page size, i.e. min(limit, 1000)
+
+        :returns: Generator that will yield up to limit results
+        :rtype: list[twilio.rest.flex_api.v1.credential.aws.AwsInstance]
+        """
+        return list(
+            await self.stream_async(
+                limit=limit,
+                page_size=page_size,
+            )
+        )
+
+    def page(
+        self, page_token=values.unset, page_number=values.unset, page_size=values.unset
+    ):
+        """
+        Retrieve a single page of AwsInstance records from the API.
+        Request is executed immediately
+
+        :param str page_token: PageToken provided by the API
+        :param int page_number: Page Number, this value is simply for client state
+        :param int page_size: Number of records to return, defaults to 50
+
+        :returns: Page of AwsInstance
+        :rtype: twilio.rest.flex_api.v1.credential.aws.AwsPage
+        """
+        data = values.of(
+            {
+                "PageToken": page_token,
+                "Page": page_number,
+                "PageSize": page_size,
+            }
+        )
+
+        response = self._version.page(method="GET", uri=self._uri, params=data)
+        return AwsPage(self._version, response)
+
+    async def page_async(
+        self, page_token=values.unset, page_number=values.unset, page_size=values.unset
+    ):
+        """
+        Asynchronously retrieve a single page of AwsInstance records from the API.
+        Request is executed immediately
+
+        :param str page_token: PageToken provided by the API
+        :param int page_number: Page Number, this value is simply for client state
+        :param int page_size: Number of records to return, defaults to 50
+
+        :returns: Page of AwsInstance
+        :rtype: twilio.rest.flex_api.v1.credential.aws.AwsPage
+        """
+        data = values.of(
+            {
+                "PageToken": page_token,
+                "Page": page_number,
+                "PageSize": page_size,
+            }
+        )
+
+        response = await self._version.page_async(
+            method="GET", uri=self._uri, params=data
+        )
+        return AwsPage(self._version, response)
+
+    def get_page(self, target_url):
+        """
+        Retrieve a specific page of AwsInstance records from the API.
+        Request is executed immediately
+
+        :param str target_url: API-generated URL for the requested results page
+
+        :returns: Page of AwsInstance
+        :rtype: twilio.rest.flex_api.v1.credential.aws.AwsPage
+        """
+        response = self._version.domain.twilio.request("GET", target_url)
+        return AwsPage(self._version, response)
+
+    async def get_page_async(self, target_url):
+        """
+        Asynchronously retrieve a specific page of AwsInstance records from the API.
+        Request is executed immediately
+
+        :param str target_url: API-generated URL for the requested results page
+
+        :returns: Page of AwsInstance
+        :rtype: twilio.rest.flex_api.v1.credential.aws.AwsPage
+        """
+        response = await self._version.domain.twilio.request_async("GET", target_url)
+        return AwsPage(self._version, response)
+
+    def get(self, sid):
+        """
+        Constructs a AwsContext
+
+        :param sid:
+
+        :returns: twilio.rest.flex_api.v1.credential.aws.AwsContext
+        :rtype: twilio.rest.flex_api.v1.credential.aws.AwsContext
+        """
+        return AwsContext(self._version, sid=sid)
+
+    def __call__(self, sid):
+        """
+        Constructs a AwsContext
+
+        :param sid:
+
+        :returns: twilio.rest.flex_api.v1.credential.aws.AwsContext
+        :rtype: twilio.rest.flex_api.v1.credential.aws.AwsContext
+        """
+        return AwsContext(self._version, sid=sid)
+
+    def __repr__(self):
+        """
+        Provide a friendly representation
+
+        :returns: Machine friendly representation
+        :rtype: str
+        """
+        return "<Twilio.FlexApi.V1.AwsList>"
+
+
+class AwsPage(Page):
+    def get_instance(self, payload):
+        """
+        Build an instance of AwsInstance
+
+        :param dict payload: Payload response from the API
+
+        :returns: twilio.rest.flex_api.v1.credential.aws.AwsInstance
+        :rtype: twilio.rest.flex_api.v1.credential.aws.AwsInstance
+        """
+        return AwsInstance(self._version, payload)
+
+    def __repr__(self) -> str:
+        """
+        Provide a friendly representation
+
+        :returns: Machine friendly representation
+        """
+        return "<Twilio.FlexApi.V1.AwsPage>"

--- a/examples/python/twilio/rest/flex_api/v1/credential/aws/__init__.py
+++ b/examples/python/twilio/rest/flex_api/v1/credential/aws/__init__.py
@@ -347,6 +347,27 @@ class AwsContext(InstanceContext):
         return "<Twilio.FlexApi.V1.AwsContext {}>".format(context)
 
 
+class AwsPage(Page):
+    def get_instance(self, payload):
+        """
+        Build an instance of AwsInstance
+
+        :param dict payload: Payload response from the API
+
+        :returns: twilio.rest.flex_api.v1.credential.aws.AwsInstance
+        :rtype: twilio.rest.flex_api.v1.credential.aws.AwsInstance
+        """
+        return AwsInstance(self._version, payload)
+
+    def __repr__(self) -> str:
+        """
+        Provide a friendly representation
+
+        :returns: Machine friendly representation
+        """
+        return "<Twilio.FlexApi.V1.AwsPage>"
+
+
 class AwsList(ListResource):
     def __init__(self, version: Version):
         """
@@ -559,24 +580,3 @@ class AwsList(ListResource):
         :rtype: str
         """
         return "<Twilio.FlexApi.V1.AwsList>"
-
-
-class AwsPage(Page):
-    def get_instance(self, payload):
-        """
-        Build an instance of AwsInstance
-
-        :param dict payload: Payload response from the API
-
-        :returns: twilio.rest.flex_api.v1.credential.aws.AwsInstance
-        :rtype: twilio.rest.flex_api.v1.credential.aws.AwsInstance
-        """
-        return AwsInstance(self._version, payload)
-
-    def __repr__(self) -> str:
-        """
-        Provide a friendly representation
-
-        :returns: Machine friendly representation
-        """
-        return "<Twilio.FlexApi.V1.AwsPage>"

--- a/examples/python/twilio/rest/flex_api/v1/credential/aws/history.py
+++ b/examples/python/twilio/rest/flex_api/v1/credential/aws/history.py
@@ -14,61 +14,11 @@ r"""
 
 
 from typing import Optional
-from twilio.base import deserialize
-from twilio.base import serialize
-from twilio.base import values
+from twilio.base import deserialize, serialize, values
 from twilio.base.instance_context import InstanceContext
 from twilio.base.instance_resource import InstanceResource
 from twilio.base.list_resource import ListResource
 from twilio.base.version import Version
-
-
-class HistoryList(ListResource):
-    def __init__(self, version: Version, sid: str):
-        """
-        Initialize the HistoryList
-
-        :param Version version: Version that contains the resource
-        :param sid:
-
-        :returns: twilio.rest.flex_api.v1.credential.aws.history.HistoryList
-        :rtype: twilio.rest.flex_api.v1.credential.aws.history.HistoryList
-        """
-        super().__init__(version)
-
-        # Path Solution
-        self._solution = {
-            "sid": sid,
-        }
-
-    def get(self):
-        """
-        Constructs a HistoryContext
-
-
-        :returns: twilio.rest.flex_api.v1.credential.aws.history.HistoryContext
-        :rtype: twilio.rest.flex_api.v1.credential.aws.history.HistoryContext
-        """
-        return HistoryContext(self._version, sid=self._solution["sid"])
-
-    def __call__(self):
-        """
-        Constructs a HistoryContext
-
-
-        :returns: twilio.rest.flex_api.v1.credential.aws.history.HistoryContext
-        :rtype: twilio.rest.flex_api.v1.credential.aws.history.HistoryContext
-        """
-        return HistoryContext(self._version, sid=self._solution["sid"])
-
-    def __repr__(self):
-        """
-        Provide a friendly representation
-
-        :returns: Machine friendly representation
-        :rtype: str
-        """
-        return "<Twilio.FlexApi.V1.HistoryList>"
 
 
 class HistoryInstance(InstanceResource):
@@ -250,3 +200,51 @@ class HistoryContext(InstanceContext):
         """
         context = " ".join("{}={}".format(k, v) for k, v in self._solution.items())
         return "<Twilio.FlexApi.V1.HistoryContext {}>".format(context)
+
+
+class HistoryList(ListResource):
+    def __init__(self, version: Version, sid: str):
+        """
+        Initialize the HistoryList
+
+        :param Version version: Version that contains the resource
+        :param sid:
+
+        :returns: twilio.rest.flex_api.v1.credential.aws.history.HistoryList
+        :rtype: twilio.rest.flex_api.v1.credential.aws.history.HistoryList
+        """
+        super().__init__(version)
+
+        # Path Solution
+        self._solution = {
+            "sid": sid,
+        }
+
+    def get(self):
+        """
+        Constructs a HistoryContext
+
+
+        :returns: twilio.rest.flex_api.v1.credential.aws.history.HistoryContext
+        :rtype: twilio.rest.flex_api.v1.credential.aws.history.HistoryContext
+        """
+        return HistoryContext(self._version, sid=self._solution["sid"])
+
+    def __call__(self):
+        """
+        Constructs a HistoryContext
+
+
+        :returns: twilio.rest.flex_api.v1.credential.aws.history.HistoryContext
+        :rtype: twilio.rest.flex_api.v1.credential.aws.history.HistoryContext
+        """
+        return HistoryContext(self._version, sid=self._solution["sid"])
+
+    def __repr__(self):
+        """
+        Provide a friendly representation
+
+        :returns: Machine friendly representation
+        :rtype: str
+        """
+        return "<Twilio.FlexApi.V1.HistoryList>"

--- a/examples/python/twilio/rest/flex_api/v1/credential/new_credentials.py
+++ b/examples/python/twilio/rest/flex_api/v1/credential/new_credentials.py
@@ -13,13 +13,73 @@ r"""
 """
 
 
-from twilio.base import deserialize
-from twilio.base import serialize
-from twilio.base import values
+from twilio.base import deserialize, serialize, values
 
 from twilio.base.instance_resource import InstanceResource
 from twilio.base.list_resource import ListResource
 from twilio.base.version import Version
+
+
+class NewCredentialsInstance(InstanceResource):
+    def __init__(self, version, payload):
+        """
+        Initialize the NewCredentialsInstance
+
+        :returns: twilio.rest.flex_api.v1.credential.new_credentials.NewCredentialsInstance
+        :rtype: twilio.rest.flex_api.v1.credential.new_credentials.NewCredentialsInstance
+        """
+        super().__init__(version)
+
+        self._properties = {
+            "account_sid": payload.get("account_sid"),
+            "sid": payload.get("sid"),
+            "test_string": payload.get("test_string"),
+            "test_integer": deserialize.integer(payload.get("test_integer")),
+        }
+
+        self._solution = {}
+
+    @property
+    def account_sid(self):
+        """
+        :returns:
+        :rtype: str
+        """
+        return self._properties["account_sid"]
+
+    @property
+    def sid(self):
+        """
+        :returns:
+        :rtype: str
+        """
+        return self._properties["sid"]
+
+    @property
+    def test_string(self):
+        """
+        :returns:
+        :rtype: str
+        """
+        return self._properties["test_string"]
+
+    @property
+    def test_integer(self):
+        """
+        :returns:
+        :rtype: int
+        """
+        return self._properties["test_integer"]
+
+    def __repr__(self):
+        """
+        Provide a friendly representation
+
+        :returns: Machine friendly representation
+        :rtype: str
+        """
+        context = " ".join("{}={}".format(k, v) for k, v in self._solution.items())
+        return "<Twilio.FlexApi.V1.NewCredentialsInstance {}>".format(context)
 
 
 class NewCredentialsList(ListResource):
@@ -200,65 +260,3 @@ class NewCredentialsList(ListResource):
         :rtype: str
         """
         return "<Twilio.FlexApi.V1.NewCredentialsList>"
-
-
-class NewCredentialsInstance(InstanceResource):
-    def __init__(self, version, payload):
-        """
-        Initialize the NewCredentialsInstance
-
-        :returns: twilio.rest.flex_api.v1.credential.new_credentials.NewCredentialsInstance
-        :rtype: twilio.rest.flex_api.v1.credential.new_credentials.NewCredentialsInstance
-        """
-        super().__init__(version)
-
-        self._properties = {
-            "account_sid": payload.get("account_sid"),
-            "sid": payload.get("sid"),
-            "test_string": payload.get("test_string"),
-            "test_integer": deserialize.integer(payload.get("test_integer")),
-        }
-
-        self._solution = {}
-
-    @property
-    def account_sid(self):
-        """
-        :returns:
-        :rtype: str
-        """
-        return self._properties["account_sid"]
-
-    @property
-    def sid(self):
-        """
-        :returns:
-        :rtype: str
-        """
-        return self._properties["sid"]
-
-    @property
-    def test_string(self):
-        """
-        :returns:
-        :rtype: str
-        """
-        return self._properties["test_string"]
-
-    @property
-    def test_integer(self):
-        """
-        :returns:
-        :rtype: int
-        """
-        return self._properties["test_integer"]
-
-    def __repr__(self):
-        """
-        Provide a friendly representation
-
-        :returns: Machine friendly representation
-        :rtype: str
-        """
-        context = " ".join("{}={}".format(k, v) for k, v in self._solution.items())
-        return "<Twilio.FlexApi.V1.NewCredentialsInstance {}>".format(context)

--- a/examples/python/twilio/rest/versionless/deployed_devices/fleet.py
+++ b/examples/python/twilio/rest/versionless/deployed_devices/fleet.py
@@ -21,98 +21,6 @@ from twilio.base.list_resource import ListResource
 from twilio.base.version import Version
 
 
-class FleetList(ListResource):
-    def __init__(self, version: Version):
-        """
-        Initialize the FleetList
-
-        :param Version version: Version that contains the resource
-
-        :returns: twilio.rest.versionless.deployed_devices.fleet.FleetList
-        :rtype: twilio.rest.versionless.deployed_devices.fleet.FleetList
-        """
-        super().__init__(version)
-
-        self._uri = "/Fleets"
-
-    def create(self, name=values.unset):
-        """
-        Create the FleetInstance
-
-        :param str name:
-
-        :returns: The created FleetInstance
-        :rtype: twilio.rest.versionless.deployed_devices.fleet.FleetInstance
-        """
-        data = values.of(
-            {
-                "Name": name,
-            }
-        )
-
-        payload = self._version.create(
-            method="POST",
-            uri=self._uri,
-            data=data,
-        )
-
-        return FleetInstance(self._version, payload)
-
-    async def create_async(self, name=values.unset):
-        """
-        Asynchronously create the FleetInstance
-
-        :param str name:
-
-        :returns: The created FleetInstance
-        :rtype: twilio.rest.versionless.deployed_devices.fleet.FleetInstance
-        """
-        data = values.of(
-            {
-                "Name": name,
-            }
-        )
-
-        payload = await self._version.create_async(
-            method="POST",
-            uri=self._uri,
-            data=data,
-        )
-
-        return FleetInstance(self._version, payload)
-
-    def get(self, sid):
-        """
-        Constructs a FleetContext
-
-        :param sid:
-
-        :returns: twilio.rest.versionless.deployed_devices.fleet.FleetContext
-        :rtype: twilio.rest.versionless.deployed_devices.fleet.FleetContext
-        """
-        return FleetContext(self._version, sid=sid)
-
-    def __call__(self, sid):
-        """
-        Constructs a FleetContext
-
-        :param sid:
-
-        :returns: twilio.rest.versionless.deployed_devices.fleet.FleetContext
-        :rtype: twilio.rest.versionless.deployed_devices.fleet.FleetContext
-        """
-        return FleetContext(self._version, sid=sid)
-
-    def __repr__(self):
-        """
-        Provide a friendly representation
-
-        :returns: Machine friendly representation
-        :rtype: str
-        """
-        return "<Twilio.Versionless.DeployedDevices.FleetList>"
-
-
 class FleetInstance(InstanceResource):
     def __init__(self, version, payload, sid: Optional[str] = None):
         """
@@ -273,3 +181,95 @@ class FleetContext(InstanceContext):
         """
         context = " ".join("{}={}".format(k, v) for k, v in self._solution.items())
         return "<Twilio.Versionless.DeployedDevices.FleetContext {}>".format(context)
+
+
+class FleetList(ListResource):
+    def __init__(self, version: Version):
+        """
+        Initialize the FleetList
+
+        :param Version version: Version that contains the resource
+
+        :returns: twilio.rest.versionless.deployed_devices.fleet.FleetList
+        :rtype: twilio.rest.versionless.deployed_devices.fleet.FleetList
+        """
+        super().__init__(version)
+
+        self._uri = "/Fleets"
+
+    def create(self, name=values.unset):
+        """
+        Create the FleetInstance
+
+        :param str name:
+
+        :returns: The created FleetInstance
+        :rtype: twilio.rest.versionless.deployed_devices.fleet.FleetInstance
+        """
+        data = values.of(
+            {
+                "Name": name,
+            }
+        )
+
+        payload = self._version.create(
+            method="POST",
+            uri=self._uri,
+            data=data,
+        )
+
+        return FleetInstance(self._version, payload)
+
+    async def create_async(self, name=values.unset):
+        """
+        Asynchronously create the FleetInstance
+
+        :param str name:
+
+        :returns: The created FleetInstance
+        :rtype: twilio.rest.versionless.deployed_devices.fleet.FleetInstance
+        """
+        data = values.of(
+            {
+                "Name": name,
+            }
+        )
+
+        payload = await self._version.create_async(
+            method="POST",
+            uri=self._uri,
+            data=data,
+        )
+
+        return FleetInstance(self._version, payload)
+
+    def get(self, sid):
+        """
+        Constructs a FleetContext
+
+        :param sid:
+
+        :returns: twilio.rest.versionless.deployed_devices.fleet.FleetContext
+        :rtype: twilio.rest.versionless.deployed_devices.fleet.FleetContext
+        """
+        return FleetContext(self._version, sid=sid)
+
+    def __call__(self, sid):
+        """
+        Constructs a FleetContext
+
+        :param sid:
+
+        :returns: twilio.rest.versionless.deployed_devices.fleet.FleetContext
+        :rtype: twilio.rest.versionless.deployed_devices.fleet.FleetContext
+        """
+        return FleetContext(self._version, sid=sid)
+
+    def __repr__(self):
+        """
+        Provide a friendly representation
+
+        :returns: Machine friendly representation
+        :rtype: str
+        """
+        return "<Twilio.Versionless.DeployedDevices.FleetList>"

--- a/examples/python/twilio/rest/versionless/understand/assistant.py
+++ b/examples/python/twilio/rest/versionless/understand/assistant.py
@@ -21,6 +21,50 @@ from twilio.base.version import Version
 from twilio.base.page import Page
 
 
+class AssistantInstance(InstanceResource):
+    def __init__(self, version, payload):
+        """
+        Initialize the AssistantInstance
+
+        :returns: twilio.rest.versionless.understand.assistant.AssistantInstance
+        :rtype: twilio.rest.versionless.understand.assistant.AssistantInstance
+        """
+        super().__init__(version)
+
+        self._properties = {
+            "sid": payload.get("sid"),
+            "friendly_name": payload.get("friendly_name"),
+        }
+
+        self._solution = {}
+
+    @property
+    def sid(self):
+        """
+        :returns: A string that uniquely identifies this Fleet.
+        :rtype: str
+        """
+        return self._properties["sid"]
+
+    @property
+    def friendly_name(self):
+        """
+        :returns: A human readable description for this Fleet.
+        :rtype: str
+        """
+        return self._properties["friendly_name"]
+
+    def __repr__(self):
+        """
+        Provide a friendly representation
+
+        :returns: Machine friendly representation
+        :rtype: str
+        """
+        context = " ".join("{}={}".format(k, v) for k, v in self._solution.items())
+        return "<Twilio.Versionless.Understand.AssistantInstance {}>".format(context)
+
+
 class AssistantList(ListResource):
     def __init__(self, version: Version):
         """
@@ -232,47 +276,3 @@ class AssistantPage(Page):
         :returns: Machine friendly representation
         """
         return "<Twilio.Versionless.Understand.AssistantPage>"
-
-
-class AssistantInstance(InstanceResource):
-    def __init__(self, version, payload):
-        """
-        Initialize the AssistantInstance
-
-        :returns: twilio.rest.versionless.understand.assistant.AssistantInstance
-        :rtype: twilio.rest.versionless.understand.assistant.AssistantInstance
-        """
-        super().__init__(version)
-
-        self._properties = {
-            "sid": payload.get("sid"),
-            "friendly_name": payload.get("friendly_name"),
-        }
-
-        self._solution = {}
-
-    @property
-    def sid(self):
-        """
-        :returns: A string that uniquely identifies this Fleet.
-        :rtype: str
-        """
-        return self._properties["sid"]
-
-    @property
-    def friendly_name(self):
-        """
-        :returns: A human readable description for this Fleet.
-        :rtype: str
-        """
-        return self._properties["friendly_name"]
-
-    def __repr__(self):
-        """
-        Provide a friendly representation
-
-        :returns: Machine friendly representation
-        :rtype: str
-        """
-        context = " ".join("{}={}".format(k, v) for k, v in self._solution.items())
-        return "<Twilio.Versionless.Understand.AssistantInstance {}>".format(context)

--- a/examples/python/twilio/rest/versionless/understand/assistant.py
+++ b/examples/python/twilio/rest/versionless/understand/assistant.py
@@ -65,6 +65,27 @@ class AssistantInstance(InstanceResource):
         return "<Twilio.Versionless.Understand.AssistantInstance {}>".format(context)
 
 
+class AssistantPage(Page):
+    def get_instance(self, payload):
+        """
+        Build an instance of AssistantInstance
+
+        :param dict payload: Payload response from the API
+
+        :returns: twilio.rest.versionless.understand.assistant.AssistantInstance
+        :rtype: twilio.rest.versionless.understand.assistant.AssistantInstance
+        """
+        return AssistantInstance(self._version, payload)
+
+    def __repr__(self) -> str:
+        """
+        Provide a friendly representation
+
+        :returns: Machine friendly representation
+        """
+        return "<Twilio.Versionless.Understand.AssistantPage>"
+
+
 class AssistantList(ListResource):
     def __init__(self, version: Version):
         """
@@ -255,24 +276,3 @@ class AssistantList(ListResource):
         :rtype: str
         """
         return "<Twilio.Versionless.Understand.AssistantList>"
-
-
-class AssistantPage(Page):
-    def get_instance(self, payload):
-        """
-        Build an instance of AssistantInstance
-
-        :param dict payload: Payload response from the API
-
-        :returns: twilio.rest.versionless.understand.assistant.AssistantInstance
-        :rtype: twilio.rest.versionless.understand.assistant.AssistantInstance
-        """
-        return AssistantInstance(self._version, payload)
-
-    def __repr__(self) -> str:
-        """
-        Provide a friendly representation
-
-        :returns: Machine friendly representation
-        """
-        return "<Twilio.Versionless.Understand.AssistantPage>"

--- a/src/main/resources/twilio-python/api-single.mustache
+++ b/src/main/resources/twilio-python/api-single.mustache
@@ -13,6 +13,7 @@ from twilio.base.version import Version
 
 {{#responseModel}}{{>instance}}{{/responseModel}}
 {{#instancePath}}{{>context}}{{/instancePath}}
+{{#hasPaginationOperation}}{{>pagination}}{{/hasPaginationOperation}}
 
 class {{apiName}}List(ListResource):
 
@@ -59,5 +60,4 @@ class {{apiName}}List(ListResource):
         :rtype: str
         """
         return '<Twilio.{{domainName}}.{{apiVersionClass}}.{{apiName}}List>'
-{{#hasPaginationOperation}}{{>pagination}}{{/hasPaginationOperation}}
 {{/resources}}

--- a/src/main/resources/twilio-python/api-single.mustache
+++ b/src/main/resources/twilio-python/api-single.mustache
@@ -1,10 +1,8 @@
 {{>licenseInfo}}
 {{#resources}}
-from datetime import date
+from datetime import date, datetime
 from typing import Optional
-from twilio.base import deserialize
-from twilio.base import serialize
-from twilio.base import values
+from twilio.base import deserialize, serialize, values
 {{#instancePath}}from twilio.base.instance_context import InstanceContext{{/instancePath}}
 {{#responseModel}}from twilio.base.instance_resource import InstanceResource{{/responseModel}}
 from twilio.base.list_resource import ListResource
@@ -12,6 +10,9 @@ from twilio.base.version import Version
 {{#hasPaginationOperation}}from twilio.base.page import Page{{/hasPaginationOperation}}
 {{#dependents}}from twilio.rest.{{domainPackage}}.{{apiVersion}}.{{namespaceSubPart}}.{{filename}} import {{resourceName}}List
 {{/dependents}}
+
+{{#responseModel}}{{>instance}}{{/responseModel}}
+{{#instancePath}}{{>context}}{{/instancePath}}
 
 class {{apiName}}List(ListResource):
 
@@ -59,6 +60,4 @@ class {{apiName}}List(ListResource):
         """
         return '<Twilio.{{domainName}}.{{apiVersionClass}}.{{apiName}}List>'
 {{#hasPaginationOperation}}{{>pagination}}{{/hasPaginationOperation}}
-{{#responseModel}}{{>instance}}{{/responseModel}}
-{{#instancePath}}{{>context}}{{/instancePath}}
 {{/resources}}


### PR DESCRIPTION
Needed for future work where list methods are typed with instance and context types which must already be defined.

https://github.com/twilio/twilio-python/pull/689