### PR TITLE
fix: use ‘str’ for non-enum complex response properties in python

### DIFF
--- a/examples/python/twilio/rest/api/v2010/account/__init__.py
+++ b/examples/python/twilio/rest/api/v2010/account/__init__.py
@@ -121,7 +121,7 @@ class AccountInstance(InstanceResource):
     def test_object(self):
         """
         :returns:
-        :rtype: TestResponseObjectTestObject
+        :rtype: str
         """
         return self._properties["test_object"]
 
@@ -185,7 +185,7 @@ class AccountInstance(InstanceResource):
     def test_array_of_integers(self):
         """
         :returns:
-        :rtype: list[int]
+        :rtype: List[int]
         """
         return self._properties["test_array_of_integers"]
 
@@ -193,7 +193,7 @@ class AccountInstance(InstanceResource):
     def test_array_of_array_of_integers(self):
         """
         :returns:
-        :rtype: list[list[int]]
+        :rtype: List[List[int]]
         """
         return self._properties["test_array_of_array_of_integers"]
 
@@ -201,7 +201,7 @@ class AccountInstance(InstanceResource):
     def test_array_of_objects(self):
         """
         :returns:
-        :rtype: list[TestResponseObjectTestArrayOfObjects]
+        :rtype: List[str]
         """
         return self._properties["test_array_of_objects"]
 
@@ -209,7 +209,7 @@ class AccountInstance(InstanceResource):
     def test_array_of_enum(self):
         """
         :returns: Permissions authorized to the app
-        :rtype: list[AccountInstance.Status]
+        :rtype: List[AccountInstance.Status]
         """
         return self._properties["test_array_of_enum"]
 
@@ -514,7 +514,7 @@ class AccountList(ListResource):
 
         :param str x_twilio_webhook_enabled:
         :param str recording_status_callback:
-        :param list[str] recording_status_callback_event:
+        :param List[str] recording_status_callback_event:
         :param str twiml:
 
         :returns: The created AccountInstance
@@ -552,7 +552,7 @@ class AccountList(ListResource):
 
         :param str x_twilio_webhook_enabled:
         :param str recording_status_callback:
-        :param list[str] recording_status_callback_event:
+        :param List[str] recording_status_callback_event:
         :param str twiml:
 
         :returns: The created AccountInstance

--- a/examples/python/twilio/rest/api/v2010/account/call/__init__.py
+++ b/examples/python/twilio/rest/api/v2010/account/call/__init__.py
@@ -127,7 +127,7 @@ class CallInstance(InstanceResource):
     def test_object(self):
         """
         :returns:
-        :rtype: TestResponseObjectTestObject
+        :rtype: str
         """
         return self._properties["test_object"]
 
@@ -191,7 +191,7 @@ class CallInstance(InstanceResource):
     def test_array_of_integers(self):
         """
         :returns:
-        :rtype: list[int]
+        :rtype: List[int]
         """
         return self._properties["test_array_of_integers"]
 
@@ -199,7 +199,7 @@ class CallInstance(InstanceResource):
     def test_array_of_array_of_integers(self):
         """
         :returns:
-        :rtype: list[list[int]]
+        :rtype: List[List[int]]
         """
         return self._properties["test_array_of_array_of_integers"]
 
@@ -207,7 +207,7 @@ class CallInstance(InstanceResource):
     def test_array_of_objects(self):
         """
         :returns:
-        :rtype: list[TestResponseObjectTestArrayOfObjects]
+        :rtype: List[str]
         """
         return self._properties["test_array_of_objects"]
 
@@ -215,7 +215,7 @@ class CallInstance(InstanceResource):
     def test_array_of_enum(self):
         """
         :returns: Permissions authorized to the app
-        :rtype: list[CallInstance.Status]
+        :rtype: List[CallInstance.Status]
         """
         return self._properties["test_array_of_enum"]
 
@@ -405,8 +405,8 @@ class CallList(ListResource):
 
         :param str required_string_property:
         :param str test_method: The HTTP method that we should use to request the `TestArrayOfUri`.
-        :param list[str] test_array_of_strings:
-        :param list[str] test_array_of_uri:
+        :param List[str] test_array_of_strings:
+        :param List[str] test_array_of_uri:
 
         :returns: The created CallInstance
         :rtype: twilio.rest.api.v2010.account.call.CallInstance
@@ -442,8 +442,8 @@ class CallList(ListResource):
 
         :param str required_string_property:
         :param str test_method: The HTTP method that we should use to request the `TestArrayOfUri`.
-        :param list[str] test_array_of_strings:
-        :param list[str] test_array_of_uri:
+        :param List[str] test_array_of_strings:
+        :param List[str] test_array_of_uri:
 
         :returns: The created CallInstance
         :rtype: twilio.rest.api.v2010.account.call.CallInstance

--- a/examples/python/twilio/rest/api/v2010/account/call/feedback_call_summary.py
+++ b/examples/python/twilio/rest/api/v2010/account/call/feedback_call_summary.py
@@ -121,7 +121,7 @@ class FeedbackCallSummaryInstance(InstanceResource):
     def test_object(self):
         """
         :returns:
-        :rtype: TestResponseObjectTestObject
+        :rtype: str
         """
         return self._properties["test_object"]
 
@@ -185,7 +185,7 @@ class FeedbackCallSummaryInstance(InstanceResource):
     def test_array_of_integers(self):
         """
         :returns:
-        :rtype: list[int]
+        :rtype: List[int]
         """
         return self._properties["test_array_of_integers"]
 
@@ -193,7 +193,7 @@ class FeedbackCallSummaryInstance(InstanceResource):
     def test_array_of_array_of_integers(self):
         """
         :returns:
-        :rtype: list[list[int]]
+        :rtype: List[List[int]]
         """
         return self._properties["test_array_of_array_of_integers"]
 
@@ -201,7 +201,7 @@ class FeedbackCallSummaryInstance(InstanceResource):
     def test_array_of_objects(self):
         """
         :returns:
-        :rtype: list[TestResponseObjectTestArrayOfObjects]
+        :rtype: List[str]
         """
         return self._properties["test_array_of_objects"]
 
@@ -209,7 +209,7 @@ class FeedbackCallSummaryInstance(InstanceResource):
     def test_array_of_enum(self):
         """
         :returns: Permissions authorized to the app
-        :rtype: list[FeedbackCallSummaryInstance.Status]
+        :rtype: List[FeedbackCallSummaryInstance.Status]
         """
         return self._properties["test_array_of_enum"]
 

--- a/examples/python/twilio/rest/flex_api/v1/credential/new_credentials.py
+++ b/examples/python/twilio/rest/flex_api/v1/credential/new_credentials.py
@@ -131,10 +131,10 @@ class NewCredentialsList(ListResource):
         :param datetime test_date_time:
         :param date test_date:
         :param NewCredentialsInstance.Status test_enum:
-        :param list[object] test_object_array:
+        :param List[object] test_object_array:
         :param object test_any_type:
-        :param list[object] test_any_array:
-        :param list[str] permissions: A comma-separated list of the permissions you will request from the users of this ConnectApp.  Can include: `get-all` and `post-all`.
+        :param List[object] test_any_array:
+        :param List[str] permissions: A comma-separated list of the permissions you will request from the users of this ConnectApp.  Can include: `get-all` and `post-all`.
         :param str some_a2p_thing:
 
         :returns: The created NewCredentialsInstance
@@ -209,10 +209,10 @@ class NewCredentialsList(ListResource):
         :param datetime test_date_time:
         :param date test_date:
         :param NewCredentialsInstance.Status test_enum:
-        :param list[object] test_object_array:
+        :param List[object] test_object_array:
         :param object test_any_type:
-        :param list[object] test_any_array:
-        :param list[str] permissions: A comma-separated list of the permissions you will request from the users of this ConnectApp.  Can include: `get-all` and `post-all`.
+        :param List[object] test_any_array:
+        :param List[str] permissions: A comma-separated list of the permissions you will request from the users of this ConnectApp.  Can include: `get-all` and `post-all`.
         :param str some_a2p_thing:
 
         :returns: The created NewCredentialsInstance

--- a/src/main/java/com/twilio/oai/TwilioPythonGenerator.java
+++ b/src/main/java/com/twilio/oai/TwilioPythonGenerator.java
@@ -46,6 +46,8 @@ public class TwilioPythonGenerator extends AbstractPythonCodegen {
         super();
         twilioCodegen = new TwilioCodegenAdapter(this, getName());
         packageName = "";
+
+        typeMapping.put("array", "List");
     }
 
     @Override

--- a/src/main/java/com/twilio/oai/api/PythonApiResourceBuilder.java
+++ b/src/main/java/com/twilio/oai/api/PythonApiResourceBuilder.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenOperation;
 import org.openapitools.codegen.CodegenParameter;
+import org.openapitools.codegen.CodegenProperty;
 
 import static com.twilio.oai.common.ApplicationConstants.PATH_SEPARATOR_PLACEHOLDER;
 
@@ -42,6 +43,25 @@ public class PythonApiResourceBuilder extends FluentApiResourceBuilder {
                 }
             }
         }
+        return this;
+    }
+
+    @Override
+    public PythonApiResourceBuilder updateResponseModel(final Resolver<CodegenProperty> codegenPropertyResolver,
+                                                        final Resolver<CodegenModel> codegenModelResolver) {
+        super.updateResponseModel(codegenPropertyResolver, codegenModelResolver);
+
+        if (responseModel != null) {
+            responseModel.getVars().forEach(variable -> {
+                if (variable.complexType != null && !variable.complexType.contains(ApplicationConstants.ENUM)) {
+                    getModelByClassname(variable.complexType).ifPresent(model -> {
+                        variable.baseType = variable.baseType.replace(variable.datatypeWithEnum, "str");
+                        variable.datatypeWithEnum = "str";
+                    });
+                }
+            });
+        }
+
         return this;
     }
 

--- a/src/main/resources/twilio-python/api-single.mustache
+++ b/src/main/resources/twilio-python/api-single.mustache
@@ -1,7 +1,7 @@
 {{>licenseInfo}}
 {{#resources}}
 from datetime import date, datetime
-from typing import Optional
+from typing import List, Optional
 from twilio.base import deserialize, serialize, values
 {{#instancePath}}from twilio.base.instance_context import InstanceContext{{/instancePath}}
 {{#responseModel}}from twilio.base.instance_resource import InstanceResource{{/responseModel}}


### PR DESCRIPTION
This is to match existing behavior since we don’t deserialize into the complex types.

Also fix the List typing.

https://github.com/twilio/twilio-python/pull/691