### PR TITLE
fix!: refactor internal resource property storage for python

### DIFF
--- a/examples/python/tests/integration/api_integration_test.py
+++ b/examples/python/tests/integration/api_integration_test.py
@@ -17,19 +17,18 @@ class IntegrationTest(unittest.TestCase):
 
     def test_create_account(self):
         result = self.client.api.v2010.accounts.create()
-        print(result._properties)
-        self.assertEqual(result._properties["sid"], self.auth)
-        self.assertEqual(result._properties["test_string"], "Ahoy")
+        self.assertEqual(result.sid, self.auth)
+        self.assertEqual(result.test_string, "Ahoy")
 
     def test_create_call(self):
         result = self.client.api.v2010.accounts(self.sid).calls.create("str", "POST")
-        self.assertEqual(result._properties["sid"], self.auth)
-        self.assertEqual(result._properties["test_string"], "Ahoy")
+        self.assertEqual(result.sid, self.auth)
+        self.assertEqual(result.test_string, "Ahoy")
 
     def test_fetch_call(self):
         result = self.client.api.v2010.accounts(self.sid).calls(123).fetch()
-        self.assertEqual(result._properties["sid"], self.auth)
-        self.assertEqual(result._properties["test_string"], "Ahoy")
+        self.assertEqual(result.sid, self.auth)
+        self.assertEqual(result.test_string, "Ahoy")
 
     def test_update_call_feedback_summary(self):
         result = (
@@ -38,10 +37,10 @@ class IntegrationTest(unittest.TestCase):
             .update(end_date="2020-12-31", start_date="2020-01-01")
         )
         self.assertEqual(
-            result._properties["test_array_of_objects"][0]["description"],
+            result.test_array_of_objects[0]["description"],
             "issue description",
         )
-        self.assertEqual(result._properties["test_array_of_objects"][0]["count"], 4)
+        self.assertEqual(result.test_array_of_objects[0]["count"], 4)
 
 
 class AsyncIntegrationTests(unittest.IsolatedAsyncioTestCase):
@@ -61,21 +60,20 @@ class AsyncIntegrationTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_create_account(self):
         result = await self.client.api.v2010.accounts.create_async()
-        print(result._properties)
-        self.assertEqual(result._properties["sid"], self.auth)
-        self.assertEqual(result._properties["test_string"], "Ahoy")
+        self.assertEqual(result.sid, self.auth)
+        self.assertEqual(result.test_string, "Ahoy")
 
     async def test_create_call(self):
         result = await self.client.api.v2010.accounts(self.sid).calls.create_async(
             "str", "POST"
         )
-        self.assertEqual(result._properties["sid"], self.auth)
-        self.assertEqual(result._properties["test_string"], "Ahoy")
+        self.assertEqual(result.sid, self.auth)
+        self.assertEqual(result.test_string, "Ahoy")
 
     async def test_fetch_call(self):
         result = await self.client.api.v2010.accounts(self.sid).calls(123).fetch_async()
-        self.assertEqual(result._properties["sid"], self.auth)
-        self.assertEqual(result._properties["test_string"], "Ahoy")
+        self.assertEqual(result.sid, self.auth)
+        self.assertEqual(result.test_string, "Ahoy")
 
     async def test_update_call_feedback_summary(self):
         result = (
@@ -84,7 +82,7 @@ class AsyncIntegrationTests(unittest.IsolatedAsyncioTestCase):
             .update_async(end_date="2020-12-31", start_date="2020-01-01")
         )
         self.assertEqual(
-            result._properties["test_array_of_objects"][0]["description"],
+            result.test_array_of_objects[0]["description"],
             "issue description",
         )
-        self.assertEqual(result._properties["test_array_of_objects"][0]["count"], 4)
+        self.assertEqual(result.test_array_of_objects[0]["count"], 4)

--- a/examples/python/twilio/rest/api/v2010/account/__init__.py
+++ b/examples/python/twilio/rest/api/v2010/account/__init__.py
@@ -40,31 +40,43 @@ class AccountInstance(InstanceResource):
         """
         super().__init__(version)
 
-        self._properties = {
-            "account_sid": payload.get("account_sid"),
-            "sid": payload.get("sid"),
-            "test_string": payload.get("test_string"),
-            "test_integer": deserialize.integer(payload.get("test_integer")),
-            "test_object": payload.get("test_object"),
-            "test_date_time": deserialize.rfc2822_datetime(
-                payload.get("test_date_time")
-            ),
-            "test_number": deserialize.decimal(payload.get("test_number")),
-            "price_unit": payload.get("price_unit"),
-            "test_number_float": payload.get("test_number_float"),
-            "test_number_decimal": payload.get("test_number_decimal"),
-            "test_enum": payload.get("test_enum"),
-            "a2p_profile_bundle_sid": payload.get("a2p_profile_bundle_sid"),
-            "test_array_of_integers": payload.get("test_array_of_integers"),
-            "test_array_of_array_of_integers": payload.get(
-                "test_array_of_array_of_integers"
-            ),
-            "test_array_of_objects": payload.get("test_array_of_objects"),
-            "test_array_of_enum": payload.get("test_array_of_enum"),
-        }
+        self._account_sid: Optional[str] = payload.get("account_sid")
+        self._sid: Optional[str] = payload.get("sid")
+        self._test_string: Optional[str] = payload.get("test_string")
+        self._test_integer: Optional[int] = deserialize.integer(
+            payload.get("test_integer")
+        )
+        self._test_object: Optional[str] = payload.get("test_object")
+        self._test_date_time: Optional[datetime] = deserialize.rfc2822_datetime(
+            payload.get("test_date_time")
+        )
+        self._test_number: Optional[float] = deserialize.decimal(
+            payload.get("test_number")
+        )
+        self._price_unit: Optional[str] = payload.get("price_unit")
+        self._test_number_float: Optional[float] = payload.get("test_number_float")
+        self._test_number_decimal: Optional[Decimal] = payload.get(
+            "test_number_decimal"
+        )
+        self._test_enum: Optional["AccountInstance.Status"] = payload.get("test_enum")
+        self._a2p_profile_bundle_sid: Optional[str] = payload.get(
+            "a2p_profile_bundle_sid"
+        )
+        self._test_array_of_integers: Optional[List[int]] = payload.get(
+            "test_array_of_integers"
+        )
+        self._test_array_of_array_of_integers: Optional[List[List[int]]] = payload.get(
+            "test_array_of_array_of_integers"
+        )
+        self._test_array_of_objects: Optional[List[str]] = payload.get(
+            "test_array_of_objects"
+        )
+        self._test_array_of_enum: Optional[
+            List["AccountInstance.Status"]
+        ] = payload.get("test_array_of_enum")
 
         self._solution = {
-            "sid": sid or self._properties["sid"],
+            "sid": sid or self._sid,
         }
         self._context: Optional[AccountContext] = None
 
@@ -84,116 +96,74 @@ class AccountInstance(InstanceResource):
         return self._context
 
     @property
-    def account_sid(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["account_sid"]
+    def account_sid(self) -> Optional[str]:
+        return self._account_sid
 
     @property
-    def sid(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["sid"]
+    def sid(self) -> Optional[str]:
+        return self._sid
 
     @property
-    def test_string(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["test_string"]
+    def test_string(self) -> Optional[str]:
+        return self._test_string
 
     @property
-    def test_integer(self) -> int:
-        """
-        :returns:
-        """
-        return self._properties["test_integer"]
+    def test_integer(self) -> Optional[int]:
+        return self._test_integer
 
     @property
-    def test_object(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["test_object"]
+    def test_object(self) -> Optional[str]:
+        return self._test_object
 
     @property
-    def test_date_time(self) -> datetime:
-        """
-        :returns:
-        """
-        return self._properties["test_date_time"]
+    def test_date_time(self) -> Optional[datetime]:
+        return self._test_date_time
 
     @property
-    def test_number(self) -> float:
-        """
-        :returns:
-        """
-        return self._properties["test_number"]
+    def test_number(self) -> Optional[float]:
+        return self._test_number
 
     @property
-    def price_unit(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["price_unit"]
+    def price_unit(self) -> Optional[str]:
+        return self._price_unit
 
     @property
-    def test_number_float(self) -> float:
-        """
-        :returns:
-        """
-        return self._properties["test_number_float"]
+    def test_number_float(self) -> Optional[float]:
+        return self._test_number_float
 
     @property
-    def test_number_decimal(self) -> Decimal:
-        """
-        :returns:
-        """
-        return self._properties["test_number_decimal"]
+    def test_number_decimal(self) -> Optional[Decimal]:
+        return self._test_number_decimal
 
     @property
-    def test_enum(self) -> "AccountInstance.Status":
-        """
-        :returns:
-        """
-        return self._properties["test_enum"]
+    def test_enum(self) -> Optional["AccountInstance.Status"]:
+        return self._test_enum
 
     @property
-    def a2p_profile_bundle_sid(self) -> str:
+    def a2p_profile_bundle_sid(self) -> Optional[str]:
         """
         :returns: A2P Messaging Profile Bundle BundleSid
         """
-        return self._properties["a2p_profile_bundle_sid"]
+        return self._a2p_profile_bundle_sid
 
     @property
-    def test_array_of_integers(self) -> List[int]:
-        """
-        :returns:
-        """
-        return self._properties["test_array_of_integers"]
+    def test_array_of_integers(self) -> Optional[List[int]]:
+        return self._test_array_of_integers
 
     @property
-    def test_array_of_array_of_integers(self) -> List[List[int]]:
-        """
-        :returns:
-        """
-        return self._properties["test_array_of_array_of_integers"]
+    def test_array_of_array_of_integers(self) -> Optional[List[List[int]]]:
+        return self._test_array_of_array_of_integers
 
     @property
-    def test_array_of_objects(self) -> List[str]:
-        """
-        :returns:
-        """
-        return self._properties["test_array_of_objects"]
+    def test_array_of_objects(self) -> Optional[List[str]]:
+        return self._test_array_of_objects
 
     @property
-    def test_array_of_enum(self) -> List["AccountInstance.Status"]:
+    def test_array_of_enum(self) -> Optional[List["AccountInstance.Status"]]:
         """
         :returns: Permissions authorized to the app
         """
-        return self._properties["test_array_of_enum"]
+        return self._test_array_of_enum
 
     def delete(self) -> bool:
         """

--- a/examples/python/twilio/rest/api/v2010/account/call/__init__.py
+++ b/examples/python/twilio/rest/api/v2010/account/call/__init__.py
@@ -44,32 +44,44 @@ class CallInstance(InstanceResource):
         """
         super().__init__(version)
 
-        self._properties = {
-            "account_sid": payload.get("account_sid"),
-            "sid": payload.get("sid"),
-            "test_string": payload.get("test_string"),
-            "test_integer": deserialize.integer(payload.get("test_integer")),
-            "test_object": payload.get("test_object"),
-            "test_date_time": deserialize.rfc2822_datetime(
-                payload.get("test_date_time")
-            ),
-            "test_number": deserialize.decimal(payload.get("test_number")),
-            "price_unit": payload.get("price_unit"),
-            "test_number_float": payload.get("test_number_float"),
-            "test_number_decimal": payload.get("test_number_decimal"),
-            "test_enum": payload.get("test_enum"),
-            "a2p_profile_bundle_sid": payload.get("a2p_profile_bundle_sid"),
-            "test_array_of_integers": payload.get("test_array_of_integers"),
-            "test_array_of_array_of_integers": payload.get(
-                "test_array_of_array_of_integers"
-            ),
-            "test_array_of_objects": payload.get("test_array_of_objects"),
-            "test_array_of_enum": payload.get("test_array_of_enum"),
-        }
+        self._account_sid: Optional[str] = payload.get("account_sid")
+        self._sid: Optional[str] = payload.get("sid")
+        self._test_string: Optional[str] = payload.get("test_string")
+        self._test_integer: Optional[int] = deserialize.integer(
+            payload.get("test_integer")
+        )
+        self._test_object: Optional[str] = payload.get("test_object")
+        self._test_date_time: Optional[datetime] = deserialize.rfc2822_datetime(
+            payload.get("test_date_time")
+        )
+        self._test_number: Optional[float] = deserialize.decimal(
+            payload.get("test_number")
+        )
+        self._price_unit: Optional[str] = payload.get("price_unit")
+        self._test_number_float: Optional[float] = payload.get("test_number_float")
+        self._test_number_decimal: Optional[Decimal] = payload.get(
+            "test_number_decimal"
+        )
+        self._test_enum: Optional["CallInstance.Status"] = payload.get("test_enum")
+        self._a2p_profile_bundle_sid: Optional[str] = payload.get(
+            "a2p_profile_bundle_sid"
+        )
+        self._test_array_of_integers: Optional[List[int]] = payload.get(
+            "test_array_of_integers"
+        )
+        self._test_array_of_array_of_integers: Optional[List[List[int]]] = payload.get(
+            "test_array_of_array_of_integers"
+        )
+        self._test_array_of_objects: Optional[List[str]] = payload.get(
+            "test_array_of_objects"
+        )
+        self._test_array_of_enum: Optional[List["CallInstance.Status"]] = payload.get(
+            "test_array_of_enum"
+        )
 
         self._solution = {
             "account_sid": account_sid,
-            "test_integer": test_integer or self._properties["test_integer"],
+            "test_integer": test_integer or self._test_integer,
         }
         self._context: Optional[CallContext] = None
 
@@ -90,116 +102,74 @@ class CallInstance(InstanceResource):
         return self._context
 
     @property
-    def account_sid(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["account_sid"]
+    def account_sid(self) -> Optional[str]:
+        return self._account_sid
 
     @property
-    def sid(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["sid"]
+    def sid(self) -> Optional[str]:
+        return self._sid
 
     @property
-    def test_string(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["test_string"]
+    def test_string(self) -> Optional[str]:
+        return self._test_string
 
     @property
-    def test_integer(self) -> int:
-        """
-        :returns:
-        """
-        return self._properties["test_integer"]
+    def test_integer(self) -> Optional[int]:
+        return self._test_integer
 
     @property
-    def test_object(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["test_object"]
+    def test_object(self) -> Optional[str]:
+        return self._test_object
 
     @property
-    def test_date_time(self) -> datetime:
-        """
-        :returns:
-        """
-        return self._properties["test_date_time"]
+    def test_date_time(self) -> Optional[datetime]:
+        return self._test_date_time
 
     @property
-    def test_number(self) -> float:
-        """
-        :returns:
-        """
-        return self._properties["test_number"]
+    def test_number(self) -> Optional[float]:
+        return self._test_number
 
     @property
-    def price_unit(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["price_unit"]
+    def price_unit(self) -> Optional[str]:
+        return self._price_unit
 
     @property
-    def test_number_float(self) -> float:
-        """
-        :returns:
-        """
-        return self._properties["test_number_float"]
+    def test_number_float(self) -> Optional[float]:
+        return self._test_number_float
 
     @property
-    def test_number_decimal(self) -> Decimal:
-        """
-        :returns:
-        """
-        return self._properties["test_number_decimal"]
+    def test_number_decimal(self) -> Optional[Decimal]:
+        return self._test_number_decimal
 
     @property
-    def test_enum(self) -> "CallInstance.Status":
-        """
-        :returns:
-        """
-        return self._properties["test_enum"]
+    def test_enum(self) -> Optional["CallInstance.Status"]:
+        return self._test_enum
 
     @property
-    def a2p_profile_bundle_sid(self) -> str:
+    def a2p_profile_bundle_sid(self) -> Optional[str]:
         """
         :returns: A2P Messaging Profile Bundle BundleSid
         """
-        return self._properties["a2p_profile_bundle_sid"]
+        return self._a2p_profile_bundle_sid
 
     @property
-    def test_array_of_integers(self) -> List[int]:
-        """
-        :returns:
-        """
-        return self._properties["test_array_of_integers"]
+    def test_array_of_integers(self) -> Optional[List[int]]:
+        return self._test_array_of_integers
 
     @property
-    def test_array_of_array_of_integers(self) -> List[List[int]]:
-        """
-        :returns:
-        """
-        return self._properties["test_array_of_array_of_integers"]
+    def test_array_of_array_of_integers(self) -> Optional[List[List[int]]]:
+        return self._test_array_of_array_of_integers
 
     @property
-    def test_array_of_objects(self) -> List[str]:
-        """
-        :returns:
-        """
-        return self._properties["test_array_of_objects"]
+    def test_array_of_objects(self) -> Optional[List[str]]:
+        return self._test_array_of_objects
 
     @property
-    def test_array_of_enum(self) -> List["CallInstance.Status"]:
+    def test_array_of_enum(self) -> Optional[List["CallInstance.Status"]]:
         """
         :returns: Permissions authorized to the app
         """
-        return self._properties["test_array_of_enum"]
+        return self._test_array_of_enum
 
     def delete(self) -> bool:
         """

--- a/examples/python/twilio/rest/api/v2010/account/call/feedback_call_summary.py
+++ b/examples/python/twilio/rest/api/v2010/account/call/feedback_call_summary.py
@@ -38,32 +38,46 @@ class FeedbackCallSummaryInstance(InstanceResource):
         """
         super().__init__(version)
 
-        self._properties = {
-            "account_sid": payload.get("account_sid"),
-            "sid": payload.get("sid"),
-            "test_string": payload.get("test_string"),
-            "test_integer": deserialize.integer(payload.get("test_integer")),
-            "test_object": payload.get("test_object"),
-            "test_date_time": deserialize.rfc2822_datetime(
-                payload.get("test_date_time")
-            ),
-            "test_number": deserialize.decimal(payload.get("test_number")),
-            "price_unit": payload.get("price_unit"),
-            "test_number_float": payload.get("test_number_float"),
-            "test_number_decimal": payload.get("test_number_decimal"),
-            "test_enum": payload.get("test_enum"),
-            "a2p_profile_bundle_sid": payload.get("a2p_profile_bundle_sid"),
-            "test_array_of_integers": payload.get("test_array_of_integers"),
-            "test_array_of_array_of_integers": payload.get(
-                "test_array_of_array_of_integers"
-            ),
-            "test_array_of_objects": payload.get("test_array_of_objects"),
-            "test_array_of_enum": payload.get("test_array_of_enum"),
-        }
+        self._account_sid: Optional[str] = payload.get("account_sid")
+        self._sid: Optional[str] = payload.get("sid")
+        self._test_string: Optional[str] = payload.get("test_string")
+        self._test_integer: Optional[int] = deserialize.integer(
+            payload.get("test_integer")
+        )
+        self._test_object: Optional[str] = payload.get("test_object")
+        self._test_date_time: Optional[datetime] = deserialize.rfc2822_datetime(
+            payload.get("test_date_time")
+        )
+        self._test_number: Optional[float] = deserialize.decimal(
+            payload.get("test_number")
+        )
+        self._price_unit: Optional[str] = payload.get("price_unit")
+        self._test_number_float: Optional[float] = payload.get("test_number_float")
+        self._test_number_decimal: Optional[Decimal] = payload.get(
+            "test_number_decimal"
+        )
+        self._test_enum: Optional["FeedbackCallSummaryInstance.Status"] = payload.get(
+            "test_enum"
+        )
+        self._a2p_profile_bundle_sid: Optional[str] = payload.get(
+            "a2p_profile_bundle_sid"
+        )
+        self._test_array_of_integers: Optional[List[int]] = payload.get(
+            "test_array_of_integers"
+        )
+        self._test_array_of_array_of_integers: Optional[List[List[int]]] = payload.get(
+            "test_array_of_array_of_integers"
+        )
+        self._test_array_of_objects: Optional[List[str]] = payload.get(
+            "test_array_of_objects"
+        )
+        self._test_array_of_enum: Optional[
+            List["FeedbackCallSummaryInstance.Status"]
+        ] = payload.get("test_array_of_enum")
 
         self._solution = {
             "account_sid": account_sid,
-            "sid": sid or self._properties["sid"],
+            "sid": sid or self._sid,
         }
         self._context: Optional[FeedbackCallSummaryContext] = None
 
@@ -84,116 +98,76 @@ class FeedbackCallSummaryInstance(InstanceResource):
         return self._context
 
     @property
-    def account_sid(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["account_sid"]
+    def account_sid(self) -> Optional[str]:
+        return self._account_sid
 
     @property
-    def sid(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["sid"]
+    def sid(self) -> Optional[str]:
+        return self._sid
 
     @property
-    def test_string(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["test_string"]
+    def test_string(self) -> Optional[str]:
+        return self._test_string
 
     @property
-    def test_integer(self) -> int:
-        """
-        :returns:
-        """
-        return self._properties["test_integer"]
+    def test_integer(self) -> Optional[int]:
+        return self._test_integer
 
     @property
-    def test_object(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["test_object"]
+    def test_object(self) -> Optional[str]:
+        return self._test_object
 
     @property
-    def test_date_time(self) -> datetime:
-        """
-        :returns:
-        """
-        return self._properties["test_date_time"]
+    def test_date_time(self) -> Optional[datetime]:
+        return self._test_date_time
 
     @property
-    def test_number(self) -> float:
-        """
-        :returns:
-        """
-        return self._properties["test_number"]
+    def test_number(self) -> Optional[float]:
+        return self._test_number
 
     @property
-    def price_unit(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["price_unit"]
+    def price_unit(self) -> Optional[str]:
+        return self._price_unit
 
     @property
-    def test_number_float(self) -> float:
-        """
-        :returns:
-        """
-        return self._properties["test_number_float"]
+    def test_number_float(self) -> Optional[float]:
+        return self._test_number_float
 
     @property
-    def test_number_decimal(self) -> Decimal:
-        """
-        :returns:
-        """
-        return self._properties["test_number_decimal"]
+    def test_number_decimal(self) -> Optional[Decimal]:
+        return self._test_number_decimal
 
     @property
-    def test_enum(self) -> "FeedbackCallSummaryInstance.Status":
-        """
-        :returns:
-        """
-        return self._properties["test_enum"]
+    def test_enum(self) -> Optional["FeedbackCallSummaryInstance.Status"]:
+        return self._test_enum
 
     @property
-    def a2p_profile_bundle_sid(self) -> str:
+    def a2p_profile_bundle_sid(self) -> Optional[str]:
         """
         :returns: A2P Messaging Profile Bundle BundleSid
         """
-        return self._properties["a2p_profile_bundle_sid"]
+        return self._a2p_profile_bundle_sid
 
     @property
-    def test_array_of_integers(self) -> List[int]:
-        """
-        :returns:
-        """
-        return self._properties["test_array_of_integers"]
+    def test_array_of_integers(self) -> Optional[List[int]]:
+        return self._test_array_of_integers
 
     @property
-    def test_array_of_array_of_integers(self) -> List[List[int]]:
-        """
-        :returns:
-        """
-        return self._properties["test_array_of_array_of_integers"]
+    def test_array_of_array_of_integers(self) -> Optional[List[List[int]]]:
+        return self._test_array_of_array_of_integers
 
     @property
-    def test_array_of_objects(self) -> List[str]:
-        """
-        :returns:
-        """
-        return self._properties["test_array_of_objects"]
+    def test_array_of_objects(self) -> Optional[List[str]]:
+        return self._test_array_of_objects
 
     @property
-    def test_array_of_enum(self) -> List["FeedbackCallSummaryInstance.Status"]:
+    def test_array_of_enum(
+        self,
+    ) -> Optional[List["FeedbackCallSummaryInstance.Status"]]:
         """
         :returns: Permissions authorized to the app
         """
-        return self._properties["test_array_of_enum"]
+        return self._test_array_of_enum
 
     def update(
         self, end_date, start_date, account_sid=values.unset

--- a/examples/python/twilio/rest/flex_api/v1/call.py
+++ b/examples/python/twilio/rest/flex_api/v1/call.py
@@ -28,12 +28,10 @@ class CallInstance(InstanceResource):
         """
         super().__init__(version)
 
-        self._properties = {
-            "sid": deserialize.integer(payload.get("sid")),
-        }
+        self._sid: Optional[int] = deserialize.integer(payload.get("sid"))
 
         self._solution = {
-            "sid": sid or self._properties["sid"],
+            "sid": sid or self._sid,
         }
         self._context: Optional[CallContext] = None
 
@@ -53,11 +51,11 @@ class CallInstance(InstanceResource):
         return self._context
 
     @property
-    def sid(self) -> int:
+    def sid(self) -> Optional[int]:
         """
         :returns: Non-string path parameter in the response.
         """
-        return self._properties["sid"]
+        return self._sid
 
     def update(self) -> "CallInstance":
         """

--- a/examples/python/twilio/rest/flex_api/v1/credential/aws/__init__.py
+++ b/examples/python/twilio/rest/flex_api/v1/credential/aws/__init__.py
@@ -30,15 +30,15 @@ class AwsInstance(InstanceResource):
         """
         super().__init__(version)
 
-        self._properties = {
-            "account_sid": payload.get("account_sid"),
-            "sid": payload.get("sid"),
-            "test_string": payload.get("test_string"),
-            "test_integer": deserialize.integer(payload.get("test_integer")),
-        }
+        self._account_sid: Optional[str] = payload.get("account_sid")
+        self._sid: Optional[str] = payload.get("sid")
+        self._test_string: Optional[str] = payload.get("test_string")
+        self._test_integer: Optional[int] = deserialize.integer(
+            payload.get("test_integer")
+        )
 
         self._solution = {
-            "sid": sid or self._properties["sid"],
+            "sid": sid or self._sid,
         }
         self._context: Optional[AwsContext] = None
 
@@ -58,32 +58,20 @@ class AwsInstance(InstanceResource):
         return self._context
 
     @property
-    def account_sid(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["account_sid"]
+    def account_sid(self) -> Optional[str]:
+        return self._account_sid
 
     @property
-    def sid(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["sid"]
+    def sid(self) -> Optional[str]:
+        return self._sid
 
     @property
-    def test_string(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["test_string"]
+    def test_string(self) -> Optional[str]:
+        return self._test_string
 
     @property
-    def test_integer(self) -> int:
-        """
-        :returns:
-        """
-        return self._properties["test_integer"]
+    def test_integer(self) -> Optional[int]:
+        return self._test_integer
 
     def delete(self) -> bool:
         """

--- a/examples/python/twilio/rest/flex_api/v1/credential/aws/history.py
+++ b/examples/python/twilio/rest/flex_api/v1/credential/aws/history.py
@@ -28,12 +28,12 @@ class HistoryInstance(InstanceResource):
         """
         super().__init__(version)
 
-        self._properties = {
-            "account_sid": payload.get("account_sid"),
-            "sid": payload.get("sid"),
-            "test_string": payload.get("test_string"),
-            "test_integer": deserialize.integer(payload.get("test_integer")),
-        }
+        self._account_sid: Optional[str] = payload.get("account_sid")
+        self._sid: Optional[str] = payload.get("sid")
+        self._test_string: Optional[str] = payload.get("test_string")
+        self._test_integer: Optional[int] = deserialize.integer(
+            payload.get("test_integer")
+        )
 
         self._solution = {
             "sid": sid,
@@ -56,32 +56,20 @@ class HistoryInstance(InstanceResource):
         return self._context
 
     @property
-    def account_sid(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["account_sid"]
+    def account_sid(self) -> Optional[str]:
+        return self._account_sid
 
     @property
-    def sid(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["sid"]
+    def sid(self) -> Optional[str]:
+        return self._sid
 
     @property
-    def test_string(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["test_string"]
+    def test_string(self) -> Optional[str]:
+        return self._test_string
 
     @property
-    def test_integer(self) -> int:
-        """
-        :returns:
-        """
-        return self._properties["test_integer"]
+    def test_integer(self) -> Optional[int]:
+        return self._test_integer
 
     def fetch(self, add_ons_data=values.unset) -> "HistoryInstance":
         """

--- a/examples/python/twilio/rest/flex_api/v1/credential/new_credentials.py
+++ b/examples/python/twilio/rest/flex_api/v1/credential/new_credentials.py
@@ -13,6 +13,7 @@ r"""
 """
 
 
+from typing import Optional
 from twilio.base import deserialize, serialize, values
 
 from twilio.base.instance_resource import InstanceResource
@@ -27,42 +28,30 @@ class NewCredentialsInstance(InstanceResource):
         """
         super().__init__(version)
 
-        self._properties = {
-            "account_sid": payload.get("account_sid"),
-            "sid": payload.get("sid"),
-            "test_string": payload.get("test_string"),
-            "test_integer": deserialize.integer(payload.get("test_integer")),
-        }
+        self._account_sid: Optional[str] = payload.get("account_sid")
+        self._sid: Optional[str] = payload.get("sid")
+        self._test_string: Optional[str] = payload.get("test_string")
+        self._test_integer: Optional[int] = deserialize.integer(
+            payload.get("test_integer")
+        )
 
         self._solution = {}
 
     @property
-    def account_sid(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["account_sid"]
+    def account_sid(self) -> Optional[str]:
+        return self._account_sid
 
     @property
-    def sid(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["sid"]
+    def sid(self) -> Optional[str]:
+        return self._sid
 
     @property
-    def test_string(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["test_string"]
+    def test_string(self) -> Optional[str]:
+        return self._test_string
 
     @property
-    def test_integer(self) -> int:
-        """
-        :returns:
-        """
-        return self._properties["test_integer"]
+    def test_integer(self) -> Optional[int]:
+        return self._test_integer
 
     def __repr__(self) -> str:
         """

--- a/examples/python/twilio/rest/versionless/deployed_devices/fleet.py
+++ b/examples/python/twilio/rest/versionless/deployed_devices/fleet.py
@@ -28,14 +28,12 @@ class FleetInstance(InstanceResource):
         """
         super().__init__(version)
 
-        self._properties = {
-            "name": payload.get("name"),
-            "sid": payload.get("sid"),
-            "friendly_name": payload.get("friendly_name"),
-        }
+        self._name: Optional[str] = payload.get("name")
+        self._sid: Optional[str] = payload.get("sid")
+        self._friendly_name: Optional[str] = payload.get("friendly_name")
 
         self._solution = {
-            "sid": sid or self._properties["sid"],
+            "sid": sid or self._sid,
         }
         self._context: Optional[FleetContext] = None
 
@@ -55,25 +53,22 @@ class FleetInstance(InstanceResource):
         return self._context
 
     @property
-    def name(self) -> str:
-        """
-        :returns:
-        """
-        return self._properties["name"]
+    def name(self) -> Optional[str]:
+        return self._name
 
     @property
-    def sid(self) -> str:
+    def sid(self) -> Optional[str]:
         """
         :returns: A string that uniquely identifies this Fleet.
         """
-        return self._properties["sid"]
+        return self._sid
 
     @property
-    def friendly_name(self) -> str:
+    def friendly_name(self) -> Optional[str]:
         """
         :returns: A human readable description for this Fleet.
         """
-        return self._properties["friendly_name"]
+        return self._friendly_name
 
     def fetch(self) -> "FleetInstance":
         """

--- a/examples/python/twilio/rest/versionless/understand/assistant.py
+++ b/examples/python/twilio/rest/versionless/understand/assistant.py
@@ -13,7 +13,7 @@ r"""
 """
 
 
-from typing import List
+from typing import List, Optional
 from twilio.base import values
 
 from twilio.base.instance_resource import InstanceResource
@@ -29,26 +29,24 @@ class AssistantInstance(InstanceResource):
         """
         super().__init__(version)
 
-        self._properties = {
-            "sid": payload.get("sid"),
-            "friendly_name": payload.get("friendly_name"),
-        }
+        self._sid: Optional[str] = payload.get("sid")
+        self._friendly_name: Optional[str] = payload.get("friendly_name")
 
         self._solution = {}
 
     @property
-    def sid(self) -> str:
+    def sid(self) -> Optional[str]:
         """
         :returns: A string that uniquely identifies this Fleet.
         """
-        return self._properties["sid"]
+        return self._sid
 
     @property
-    def friendly_name(self) -> str:
+    def friendly_name(self) -> Optional[str]:
         """
         :returns: A human readable description for this Fleet.
         """
-        return self._properties["friendly_name"]
+        return self._friendly_name
 
     def __repr__(self) -> str:
         """

--- a/src/main/resources/twilio-python/instance.handlebars
+++ b/src/main/resources/twilio-python/instance.handlebars
@@ -6,11 +6,10 @@ class {{instanceName}}(InstanceResource):
         """
         super().__init__(version)
 
-        self._properties = { {{#vars}}
-            '{{name}}': {{#if vendorExtensions.x-deserialize}}{{vendorExtensions.x-deserialize}}(payload.get('{{{baseName}}}')){{else}}payload.get('{{{baseName}}}'){{/if}},{{/vars}}
-        }
+        {{#vars}}
+        self._{{name}}: Optional[{{{baseType}}}] = {{#if vendorExtensions.x-deserialize}}{{vendorExtensions.x-deserialize}}(payload.get("{{{baseName}}}")){{else}}payload.get("{{{baseName}}}"){{/if}}{{/vars}}
 
-        self._solution = { {{#instancePathParams}}'{{paramName}}': {{paramName}}{{#if vendorExtensions.x-is-parent-param}}, {{else}} or self._properties['{{paramName}}'], {{/if}}{{/instancePathParams}} }
+        self._solution = { {{#instancePathParams}}"{{paramName}}": {{paramName}}{{#if vendorExtensions.x-is-parent-param}}, {{else}} or self._{{paramName}}, {{/if}}{{/instancePathParams}} }
         {{#instancePath}}self._context: Optional[{{apiName}}Context] = None
 
     @property
@@ -26,11 +25,11 @@ class {{instanceName}}(InstanceResource):
         return self._context{{/instancePath}}
     {{#vars}}
     @property
-    def {{name}}(self) -> {{{baseType}}}:
-        """
-        :returns: {{{description}}}
-        """
-        return self._properties['{{name}}']
+    def {{name}}(self) -> Optional[{{{baseType}}}]:
+        {{#description}}"""
+        :returns: {{{.}}}
+        """{{/description}}
+        return self._{{name}}
     {{/vars}}{{#operations}}{{#vendorExtensions.x-is-context-operation}}
     {{#vendorExtensions.x-is-update-operation}}
     def {{vendorExtensions.x-name-lower}}(self{{#allParams}}, {{paramName}}{{#if required}}{{else}}=values.unset{{/if}}{{/allParams}}) -> "{{instanceName}}":


### PR DESCRIPTION
Moves properties out of ‘self_.properties’ and into individual fields for better type support. This is an implementation detail that should not be depended upon.

https://github.com/twilio/twilio-python/pull/696