### PR TITLE
fix: Content type set

### DIFF
--- a/examples/csharp/src/Twilio/Rest/Api/V2010/Account/Call/FeedbackCallSummaryResource.cs
+++ b/examples/csharp/src/Twilio/Rest/Api/V2010/Account/Call/FeedbackCallSummaryResource.cs
@@ -65,6 +65,7 @@ namespace Twilio.Rest.Api.V2010.Account.Call
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 path,
+                contentType: EnumConstants.ContentTypeEnum.FORM_URLENCODED,
                 postParams: options.GetParams(),
                 headerParams: null
             );

--- a/examples/csharp/src/Twilio/Rest/Api/V2010/Account/CallResource.cs
+++ b/examples/csharp/src/Twilio/Rest/Api/V2010/Account/CallResource.cs
@@ -63,6 +63,7 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 path,
+                contentType: EnumConstants.ContentTypeEnum.FORM_URLENCODED,
                 postParams: options.GetParams(),
                 headerParams: null
             );

--- a/examples/csharp/src/Twilio/Rest/Api/V2010/AccountResource.cs
+++ b/examples/csharp/src/Twilio/Rest/Api/V2010/AccountResource.cs
@@ -73,6 +73,7 @@ namespace Twilio.Rest.Api.V2010
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 path,
+                contentType: EnumConstants.ContentTypeEnum.FORM_URLENCODED,
                 postParams: options.GetParams(),
                 headerParams: options.GetHeaderParams()
             );
@@ -422,6 +423,7 @@ namespace Twilio.Rest.Api.V2010
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 path,
+                contentType: EnumConstants.ContentTypeEnum.FORM_URLENCODED,
                 postParams: options.GetParams(),
                 headerParams: null
             );

--- a/examples/csharp/src/Twilio/Rest/FlexApi/V1/CallResource.cs
+++ b/examples/csharp/src/Twilio/Rest/FlexApi/V1/CallResource.cs
@@ -46,6 +46,7 @@ namespace Twilio.Rest.FlexApi.V1
                 HttpMethod.Post,
                 Rest.Domain.FlexApi,
                 path,
+                contentType: EnumConstants.ContentTypeEnum.FORM_URLENCODED,
                 postParams: options.GetParams(),
                 headerParams: null
             );

--- a/examples/csharp/src/Twilio/Rest/FlexApi/V1/Credential/AwsResource.cs
+++ b/examples/csharp/src/Twilio/Rest/FlexApi/V1/Credential/AwsResource.cs
@@ -299,6 +299,7 @@ namespace Twilio.Rest.FlexApi.V1.Credential
                 HttpMethod.Post,
                 Rest.Domain.FlexApi,
                 path,
+                contentType: EnumConstants.ContentTypeEnum.FORM_URLENCODED,
                 postParams: options.GetParams(),
                 headerParams: null
             );

--- a/examples/csharp/src/Twilio/Rest/FlexApi/V1/Credential/NewCredentialsResource.cs
+++ b/examples/csharp/src/Twilio/Rest/FlexApi/V1/Credential/NewCredentialsResource.cs
@@ -72,6 +72,7 @@ namespace Twilio.Rest.FlexApi.V1.Credential
                 HttpMethod.Post,
                 Rest.Domain.FlexApi,
                 path,
+                contentType: EnumConstants.ContentTypeEnum.FORM_URLENCODED,
                 postParams: options.GetParams(),
                 headerParams: null
             );

--- a/examples/csharp/src/Twilio/Rest/Versionless/DeployedDevices/FleetResource.cs
+++ b/examples/csharp/src/Twilio/Rest/Versionless/DeployedDevices/FleetResource.cs
@@ -44,6 +44,7 @@ namespace Twilio.Rest.Versionless.DeployedDevices
                 HttpMethod.Post,
                 Rest.Domain.Versionless,
                 path,
+                contentType: EnumConstants.ContentTypeEnum.FORM_URLENCODED,
                 postParams: options.GetParams(),
                 headerParams: null
             );

--- a/examples/java/src/main/java/com/twilio/rest/api/v2010/AccountDeleter.java
+++ b/examples/java/src/main/java/com/twilio/rest/api/v2010/AccountDeleter.java
@@ -14,8 +14,10 @@
 
 package com.twilio.rest.api.v2010;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.base.Deleter;
 import com.twilio.converter.Promoter;
+import com.twilio.constant.EnumConstants;
 import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.exception.ApiException;

--- a/examples/java/src/main/java/com/twilio/rest/api/v2010/AccountFetcher.java
+++ b/examples/java/src/main/java/com/twilio/rest/api/v2010/AccountFetcher.java
@@ -14,7 +14,9 @@
 
 package com.twilio.rest.api.v2010;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.base.Fetcher;
+import com.twilio.constant.EnumConstants;
 import com.twilio.converter.Promoter;
 import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;

--- a/examples/java/src/main/java/com/twilio/rest/api/v2010/AccountReader.java
+++ b/examples/java/src/main/java/com/twilio/rest/api/v2010/AccountReader.java
@@ -14,7 +14,9 @@
 
 package com.twilio.rest.api.v2010;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.base.Reader;
+import com.twilio.constant.EnumConstants;
 import com.twilio.base.ResourceSet;
 import com.twilio.converter.Promoter;
 import com.twilio.exception.ApiConnectionException;

--- a/examples/java/src/main/java/com/twilio/rest/api/v2010/AccountUpdater.java
+++ b/examples/java/src/main/java/com/twilio/rest/api/v2010/AccountUpdater.java
@@ -14,6 +14,7 @@
 
 package com.twilio.rest.api.v2010;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.base.Updater;
 import com.twilio.constant.EnumConstants;
 import com.twilio.converter.Promoter;

--- a/examples/java/src/main/java/com/twilio/rest/api/v2010/account/CallDeleter.java
+++ b/examples/java/src/main/java/com/twilio/rest/api/v2010/account/CallDeleter.java
@@ -14,8 +14,10 @@
 
 package com.twilio.rest.api.v2010.account;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.base.Deleter;
 import com.twilio.converter.Promoter;
+import com.twilio.constant.EnumConstants;
 import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.exception.ApiException;

--- a/examples/java/src/main/java/com/twilio/rest/api/v2010/account/CallFetcher.java
+++ b/examples/java/src/main/java/com/twilio/rest/api/v2010/account/CallFetcher.java
@@ -14,7 +14,9 @@
 
 package com.twilio.rest.api.v2010.account;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.base.Fetcher;
+import com.twilio.constant.EnumConstants;
 import com.twilio.converter.Promoter;
 import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;

--- a/examples/java/src/main/java/com/twilio/rest/api/v2010/account/call/FeedbackCallSummaryUpdater.java
+++ b/examples/java/src/main/java/com/twilio/rest/api/v2010/account/call/FeedbackCallSummaryUpdater.java
@@ -14,6 +14,7 @@
 
 package com.twilio.rest.api.v2010.account.call;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.base.Updater;
 import com.twilio.constant.EnumConstants;
 import com.twilio.converter.Promoter;

--- a/examples/java/src/main/java/com/twilio/rest/flexapi/v1/CallUpdater.java
+++ b/examples/java/src/main/java/com/twilio/rest/flexapi/v1/CallUpdater.java
@@ -14,6 +14,7 @@
 
 package com.twilio.rest.flexapi.v1;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.base.Updater;
 import com.twilio.constant.EnumConstants;
 import com.twilio.converter.Promoter;

--- a/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/AwsDeleter.java
+++ b/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/AwsDeleter.java
@@ -14,8 +14,10 @@
 
 package com.twilio.rest.flexapi.v1.credential;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.base.Deleter;
 import com.twilio.converter.Promoter;
+import com.twilio.constant.EnumConstants;
 import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.exception.ApiException;

--- a/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/AwsFetcher.java
+++ b/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/AwsFetcher.java
@@ -14,7 +14,9 @@
 
 package com.twilio.rest.flexapi.v1.credential;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.base.Fetcher;
+import com.twilio.constant.EnumConstants;
 import com.twilio.converter.Promoter;
 import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;

--- a/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/AwsReader.java
+++ b/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/AwsReader.java
@@ -14,7 +14,9 @@
 
 package com.twilio.rest.flexapi.v1.credential;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.base.Reader;
+import com.twilio.constant.EnumConstants;
 import com.twilio.base.ResourceSet;
 import com.twilio.converter.Promoter;
 import com.twilio.exception.ApiConnectionException;

--- a/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/AwsUpdater.java
+++ b/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/AwsUpdater.java
@@ -14,6 +14,7 @@
 
 package com.twilio.rest.flexapi.v1.credential;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.base.Updater;
 import com.twilio.constant.EnumConstants;
 import com.twilio.converter.Promoter;

--- a/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/aws/HistoryFetcher.java
+++ b/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/aws/HistoryFetcher.java
@@ -14,7 +14,9 @@
 
 package com.twilio.rest.flexapi.v1.credential.aws;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.base.Fetcher;
+import com.twilio.constant.EnumConstants;
 import com.twilio.converter.Promoter;
 import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;

--- a/examples/java/src/main/java/com/twilio/rest/versionless/deployedDevices/FleetFetcher.java
+++ b/examples/java/src/main/java/com/twilio/rest/versionless/deployedDevices/FleetFetcher.java
@@ -14,7 +14,9 @@
 
 package com.twilio.rest.versionless.deployedDevices;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.base.Fetcher;
+import com.twilio.constant.EnumConstants;
 import com.twilio.converter.Promoter;
 import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;

--- a/examples/java/src/main/java/com/twilio/rest/versionless/understand/AssistantReader.java
+++ b/examples/java/src/main/java/com/twilio/rest/versionless/understand/AssistantReader.java
@@ -14,7 +14,9 @@
 
 package com.twilio.rest.versionless.understand;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.base.Reader;
+import com.twilio.constant.EnumConstants;
 import com.twilio.base.ResourceSet;
 import com.twilio.converter.Promoter;
 import com.twilio.exception.ApiConnectionException;

--- a/src/main/resources/twilio-csharp/options/UpdateOptions.mustache
+++ b/src/main/resources/twilio-csharp/options/UpdateOptions.mustache
@@ -19,7 +19,12 @@
         }
     {{/vendorExtensions.x-required-param-exists}}
 
+    {{^vendorExtensions.x-is-json}}
         {{>options/GetParams}}
+    {{/vendorExtensions.x-is-json}}
+    {{#vendorExtensions.x-is-json}}
+        {{>options/GetBody}}
+    {{/vendorExtensions.x-is-json}}
         {{>options/HeaderParams}}
     }
 

--- a/src/main/resources/twilio-csharp/resource/CreateResource.mustache
+++ b/src/main/resources/twilio-csharp/resource/CreateResource.mustache
@@ -6,7 +6,9 @@
                 HttpMethod.Post,
                 Rest.Domain.{{domainPackage}},
                 path,
-                {{^vendorExtensions.x-is-json}}postParams: options.GetParams(),{{/vendorExtensions.x-is-json}}
+                {{^vendorExtensions.x-is-json}}
+                contentType: EnumConstants.ContentTypeEnum.FORM_URLENCODED,
+                postParams: options.GetParams(),{{/vendorExtensions.x-is-json}}
                 {{#vendorExtensions.x-is-json}}
                 contentType: EnumConstants.ContentTypeEnum.JSON,
                 body: options.GetBody(),

--- a/src/main/resources/twilio-csharp/resource/UpdateResource.mustache
+++ b/src/main/resources/twilio-csharp/resource/UpdateResource.mustache
@@ -6,7 +6,13 @@
                 HttpMethod.Post,
                 Rest.Domain.{{domainPackage}},
                 path,
-                postParams: options.GetParams(),
+                {{^vendorExtensions.x-is-json}}
+                contentType: EnumConstants.ContentTypeEnum.FORM_URLENCODED,
+                postParams: options.GetParams(),{{/vendorExtensions.x-is-json}}
+                {{#vendorExtensions.x-is-json}}
+                contentType: EnumConstants.ContentTypeEnum.JSON,
+                body: options.GetBody(),
+                {{/vendorExtensions.x-is-json}}
                 headerParams: {{^vendorExtensions.x-header-param-exists}}null{{/vendorExtensions.x-header-param-exists}}{{#vendorExtensions.x-header-param-exists}}options.GetHeaderParams(){{/vendorExtensions.x-header-param-exists}}
             );
         }

--- a/src/main/resources/twilio-java/deleter.mustache
+++ b/src/main/resources/twilio-java/deleter.mustache
@@ -2,8 +2,10 @@
 {{#resources}}
 package com.twilio.rest.{{domainPackage}}.{{apiVersion}}{{namespaceSubPart}};
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.base.Deleter;
 import com.twilio.converter.Promoter;
+import com.twilio.constant.EnumConstants;
 import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.exception.ApiException;

--- a/src/main/resources/twilio-java/deleter.mustache
+++ b/src/main/resources/twilio-java/deleter.mustache
@@ -80,8 +80,13 @@ public class {{apiName}}Deleter extends Deleter<{{apiName}}> {
         addQueryParams(request);
         {{/queryParams.0}}
         {{#formParams.0}}
+        request.setContentType(EnumConstants.ContentType.FORM_URLENCODED);
         addPostParams(request);
         {{/formParams.0}}
+        {{#bodyParams.0}}
+        request.setContentType(EnumConstants.ContentType.JSON);
+        addPostParams(request, client);
+        {{/bodyParams.0}}
         {{#headerParams.0}}
         addHeaderParams(request);
         {{/headerParams.0}}
@@ -101,6 +106,9 @@ public class {{apiName}}Deleter extends Deleter<{{apiName}}> {
 {{#formParams.0}}
 {{>postParams}}
 {{/formParams.0}}
+{{#bodyParams.0}}
+{{>postParams_body}}
+{{/bodyParams.0}}
 {{#headerParams.0}}
 {{>headerParams}}
 {{/headerParams.0}}

--- a/src/main/resources/twilio-java/fetcher.mustache
+++ b/src/main/resources/twilio-java/fetcher.mustache
@@ -2,7 +2,9 @@
 {{#resources}}
 package com.twilio.rest.{{domainPackage}}.{{apiVersion}}{{namespaceSubPart}};
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.base.Fetcher;
+import com.twilio.constant.EnumConstants;
 import com.twilio.converter.Promoter;
 import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;

--- a/src/main/resources/twilio-java/fetcher.mustache
+++ b/src/main/resources/twilio-java/fetcher.mustache
@@ -81,8 +81,13 @@ public class {{apiName}}Fetcher extends Fetcher<{{apiName}}> {
         addQueryParams(request);
         {{/queryParams.0}}
         {{#formParams.0}}
+        request.setContentType(EnumConstants.ContentType.FORM_URLENCODED);
         addPostParams(request);
         {{/formParams.0}}
+        {{#bodyParams.0}}
+        request.setContentType(EnumConstants.ContentType.JSON);
+        addPostParams(request, client);
+        {{/bodyParams.0}}
         {{#headerParams.0}}
         addHeaderParams(request);
         {{/headerParams.0}}
@@ -103,6 +108,9 @@ public class {{apiName}}Fetcher extends Fetcher<{{apiName}}> {
 {{#formParams.0}}
 {{>postParams}}
 {{/formParams.0}}
+{{#bodyParams.0}}
+{{>postParams_body}}
+{{/bodyParams.0}}
 {{#headerParams.0}}
 {{>headerParams}}
 {{/headerParams.0}}

--- a/src/main/resources/twilio-java/reader.mustache
+++ b/src/main/resources/twilio-java/reader.mustache
@@ -97,6 +97,7 @@ public class {{apiName}}Reader extends Reader<{{apiName}}> {
         addQueryParams(request);
         {{/queryParams.0}}
         {{#formParams.0}}
+        request.setContentType(EnumConstants.ContentType.FORM_URLENCODED);
         addPostParams(request);
         {{/formParams.0}}
         {{#headerParams.0}}

--- a/src/main/resources/twilio-java/reader.mustache
+++ b/src/main/resources/twilio-java/reader.mustache
@@ -2,7 +2,9 @@
 {{#resources}}
 package com.twilio.rest.{{domainPackage}}.{{apiVersion}}{{namespaceSubPart}};
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.base.Reader;
+import com.twilio.constant.EnumConstants;
 import com.twilio.base.ResourceSet;
 import com.twilio.converter.Promoter;
 import com.twilio.exception.ApiConnectionException;

--- a/src/main/resources/twilio-java/updater.mustache
+++ b/src/main/resources/twilio-java/updater.mustache
@@ -2,6 +2,7 @@
 {{#resources}}
 package com.twilio.rest.{{domainPackage}}.{{apiVersion}}{{namespaceSubPart}};
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.base.Updater;
 import com.twilio.constant.EnumConstants;
 import com.twilio.converter.Promoter;

--- a/src/main/resources/twilio-java/updater.mustache
+++ b/src/main/resources/twilio-java/updater.mustache
@@ -85,6 +85,10 @@ public class {{apiName}}Updater extends Updater<{{apiName}}>{
         request.setContentType(EnumConstants.ContentType.FORM_URLENCODED);
         addPostParams(request);
         {{/formParams.0}}
+        {{#bodyParams.0}}
+        request.setContentType(EnumConstants.ContentType.JSON);
+        addPostParams(request, client);
+        {{/bodyParams.0}}
         {{#headerParams.0}}
         addHeaderParams(request);
         {{/headerParams.0}}
@@ -104,6 +108,9 @@ public class {{apiName}}Updater extends Updater<{{apiName}}>{
 {{#formParams.0}}
 {{>postParams}}
 {{/formParams.0}}
+{{#bodyParams.0}}
+{{>postParams_body}}
+{{/bodyParams.0}}
 {{#headerParams.0}}
 {{>headerParams}}
 {{/headerParams.0}}


### PR DESCRIPTION

# Fixes #
added json support to c# and java update http method.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] Run `make test-docker`
- [ ] Verify affected language:
    - [ ] Generate [twilio-go](https://github.com/twilio/twilio-go) from our [OpenAPI specification](https://github.com/twilio/twilio-oai) using the [build_twilio_go.py](./examples/build_twilio_go.py) using `python examples/build_twilio_go.py path/to/twilio-oai/spec/yaml path/to/twilio-go` and inspect the diff
    - [ ] Run `make test` in `twilio-go`
    - [ ] Create a pull request in `twilio-go`
    - [ ] Provide a link below to the pull request
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-oai-generator/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please create a GitHub Issue in this repository.
