### PR TITLE
fixed-content-type for java

### DIFF
--- a/src/main/java/com/twilio/oai/api/ApiResourceBuilder.java
+++ b/src/main/java/com/twilio/oai/api/ApiResourceBuilder.java
@@ -4,6 +4,7 @@ import com.twilio.oai.DirectoryStructureService;
 import com.twilio.oai.PathUtils;
 import com.twilio.oai.StringHelper;
 import com.twilio.oai.common.ApplicationConstants;
+import com.twilio.oai.common.EnumConstants;
 import com.twilio.oai.common.Utility;
 import com.twilio.oai.resolver.Resolver;
 import com.twilio.oai.resource.Resource;
@@ -346,5 +347,23 @@ public abstract class ApiResourceBuilder implements IApiResourceBuilder {
             }
         }
         return hasNestedRequestBody;
+    }
+
+    // Supported content types for this method are application/json and application/x-www-form-urlencoded.
+    protected void updateContentType(CodegenOperation co) {
+        if (co.consumes == null || co.consumes.size() == 0) {
+            co.vendorExtensions.put("x-www-form-urlencoded", true);
+            return;
+        }
+        for (Map<String, String> map : co.consumes) {
+            if (EnumConstants.ContentType.APPLICATION_JSON.getValue().equals(map.get("mediaType"))) {
+                co.vendorExtensions.put(ApplicationConstants.X_JSON, true);
+            } else if (EnumConstants.ContentType.APPLICATION_FORM_URLENCODED.getValue().equals(map.get("mediaType"))) {
+                co.vendorExtensions.put(ApplicationConstants.X_WWW_FORM_URLENCODED, true);
+            } else {
+                // TODO: GET does not have body thus does not have content type
+                co.vendorExtensions.put(ApplicationConstants.X_WWW_FORM_URLENCODED, true);
+            }
+        }
     }
 }

--- a/src/main/java/com/twilio/oai/api/JavaApiResourceBuilder.java
+++ b/src/main/java/com/twilio/oai/api/JavaApiResourceBuilder.java
@@ -102,6 +102,7 @@ public class JavaApiResourceBuilder extends ApiResourceBuilder{
         JsonRequestBodyResolver jsonRequestBodyResolver = new JsonRequestBodyResolver(this, codegenPropertyIResolver);
         this.codegenOperationList.forEach(co -> {
             updateNestedContent(co);
+            updateContentType(co);
             updateHttpMethod(co);
             List<String> filePathArray = new ArrayList<>(Arrays.asList(co.baseName.split(PATH_SEPARATOR_PLACEHOLDER)));
             String resourceName = filePathArray.remove(filePathArray.size()-1);
@@ -667,4 +668,5 @@ public class JavaApiResourceBuilder extends ApiResourceBuilder{
     public JavaApiResources build() {
         return new JavaApiResources(this);
     }
+    
 }

--- a/src/main/java/com/twilio/oai/common/ApplicationConstants.java
+++ b/src/main/java/com/twilio/oai/common/ApplicationConstants.java
@@ -55,4 +55,7 @@ public class ApplicationConstants {
     public static final String PHONE_NUMBER = "phone-number";
 
     public static final Predicate<Integer> SUCCESS = i -> i != null && i >= 200 && i < 400;
+    
+    public static final String X_JSON = "x-is-json";
+    public static final String X_WWW_FORM_URLENCODED = "x-www-form-urlencoded";
 }

--- a/src/main/java/com/twilio/oai/common/EnumConstants.java
+++ b/src/main/java/com/twilio/oai/common/EnumConstants.java
@@ -122,4 +122,13 @@ public class EnumConstants {
 
         private final String value;
     }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum ContentType {
+        APPLICATION_JSON("application/json"),
+        APPLICATION_FORM_URLENCODED("application/x-www-form-urlencoded");
+
+        private final String value;
+    }
 }

--- a/src/test/java/com/twilio/oai/TwilioGeneratorTest.java
+++ b/src/test/java/com/twilio/oai/TwilioGeneratorTest.java
@@ -28,7 +28,14 @@ import static org.junit.Assert.assertFalse;
 public class TwilioGeneratorTest {
     @Parameterized.Parameters
     public static Collection<Generator> generators() {
-        return Arrays.asList(Generator.TWILIO_PYTHON);
+        return Arrays.asList(Generator.TWILIO_CSHARP,
+                Generator.TWILIO_GO,
+                Generator.TWILIO_JAVA,
+                Generator.TWILIO_NODE,
+                Generator.TWILIO_PHP,
+                Generator.TWILIO_PYTHON,
+                Generator.TWILIO_RUBY,
+                Generator.TWILIO_TERRAFORM);
     }
 
     private final Generator generator;
@@ -41,6 +48,7 @@ public class TwilioGeneratorTest {
     @Test
     public void launchGenerator() {
         final String pathname = "examples/spec/twilio_api_v2010.yaml";
+//        final String pathname = "examples/twilio_messaging_bulk_v1.yaml";
         File filesList[] ;
         File directoryPath = new File(pathname);
         if (directoryPath.isDirectory()) {


### PR DESCRIPTION
# Fixes #
Content type for generated java code was not set correctly, This has been fixed.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] Run `make test-docker`
- [ ] Verify affected language:
    - [ ] Generate [twilio-go](https://github.com/twilio/twilio-go) from our [OpenAPI specification](https://github.com/twilio/twilio-oai) using the [build_twilio_go.py](./examples/build_twilio_go.py) using `python examples/build_twilio_go.py path/to/twilio-oai/spec/yaml path/to/twilio-go` and inspect the diff
    - [ ] Run `make test` in `twilio-go`
    - [ ] Create a pull request in `twilio-go`
    - [ ] Provide a link below to the pull request
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-oai-generator/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please create a GitHub Issue in this repository.
