### PR TITLE
chore: reverting changes for content v1

### DIFF
--- a/scripts/build_twilio_library.py
+++ b/scripts/build_twilio_library.py
@@ -32,8 +32,6 @@ def build(openapi_spec_path: str, output_path: str, language: str) -> None:
     else:
         spec_folder = openapi_spec_path
         spec_files = sorted(os.listdir(spec_folder))
-    if 'twilio_content_v1.json' in spec_files:
-        spec_files.remove('twilio_content_v1.json')
     generate(spec_folder, spec_files, output_path, language)
 
 

--- a/scripts/build_twilio_library.py
+++ b/scripts/build_twilio_library.py
@@ -32,6 +32,8 @@ def build(openapi_spec_path: str, output_path: str, language: str) -> None:
     else:
         spec_folder = openapi_spec_path
         spec_files = sorted(os.listdir(spec_folder))
+    if 'twilio_content_sdk.json' in spec_files:
+        spec_files.remove('twilio_content_sdk.json')
     generate(spec_folder, spec_files, output_path, language)
 
 


### PR DESCRIPTION
Content sdk has been moved to content v1 in open-api specifications, Thus generating content api code via content v1 and not content sdk spec file.

Ignoring content_sdk since it might still be present in twilio-oai, Once deleted from twilio-oai we will remove code for ignoring content_sdk

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] Run `make test-docker`
- [ ] Verify affected language:
    - [ ] Generate [twilio-go](https://github.com/twilio/twilio-go) from our [OpenAPI specification](https://github.com/twilio/twilio-oai) using the [build_twilio_go.py](./examples/build_twilio_go.py) using `python examples/build_twilio_go.py path/to/twilio-oai/spec/yaml path/to/twilio-go` and inspect the diff
    - [ ] Run `make test` in `twilio-go`
    - [ ] Create a pull request in `twilio-go`
    - [ ] Provide a link below to the pull request
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-oai-generator/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please create a GitHub Issue in this repository.
