### PR TITLE
chore: added a temporary fix to unblock python orgs release [DO-NOT-MERGE Before Release]

### DIFF
--- a/scripts/build_twilio_library.py
+++ b/scripts/build_twilio_library.py
@@ -117,25 +117,23 @@ def get_domain_info(oai_spec_location: str, domain: str, is_file: bool = False) 
     return full_path, domain_name, api_version
 
 def merge_orgs_schema(from_spec, to_spec):
-    # Load file.json
+
     with open(to_spec, 'r') as f1:
         spec1 = json.load(f1)
 
-    # Load file2.json
+
     with open(from_spec, 'r') as f2:
         spec2 = json.load(f2)
 
-    # Assuming both files follow OpenAPI structure, we merge the 'paths' section
     if 'paths' in spec1 and 'paths' in spec2:
         spec1['paths'].update(spec2['paths'])
     else:
         print("One of the files doesn't contain 'paths'.")
 
-    # Save the merged result into a new file
     with open(to_spec, 'w') as outfile:
         json.dump(spec1, outfile, indent=2)
 
-    print("Files merged successfully into to_spec.")
+    print(f"Files merged successfully into {to_spec}.")
 
 
 if __name__ == '__main__':

--- a/scripts/build_twilio_library.py
+++ b/scripts/build_twilio_library.py
@@ -5,7 +5,6 @@ import re
 import shutil
 from pathlib import Path
 from typing import List, Tuple
-
 from clean_unused_imports import remove_unused_imports, remove_duplicate_imports
 
 '''
@@ -31,6 +30,10 @@ def build(openapi_spec_path: str, output_path: str, language: str) -> None:
         spec_files = [domain]
     else:
         spec_folder = openapi_spec_path
+        # It will be removed once orgs team add the path(/Organizations/{OrganizationSid}) to twilio_iam_organizations spec
+        if language == 'python':
+            iam_orgs_spec_path = spec_folder + 'twilio_iam_organizations.json'
+            merge_orgs_schema('twilio_am_temporary.json', iam_orgs_spec_path)
         spec_files = sorted(os.listdir(spec_folder))
     generate(spec_folder, spec_files, output_path, language)
 
@@ -112,6 +115,27 @@ def get_domain_info(oai_spec_location: str, domain: str, is_file: bool = False) 
             domain_name = domain_parts[1]
             api_version = domain_parts[2]
     return full_path, domain_name, api_version
+
+def merge_orgs_schema(from_spec, to_spec):
+    # Load file.json
+    with open(to_spec, 'r') as f1:
+        spec1 = json.load(f1)
+
+    # Load file2.json
+    with open(from_spec, 'r') as f2:
+        spec2 = json.load(f2)
+
+    # Assuming both files follow OpenAPI structure, we merge the 'paths' section
+    if 'paths' in spec1 and 'paths' in spec2:
+        spec1['paths'].update(spec2['paths'])
+    else:
+        print("One of the files doesn't contain 'paths'.")
+
+    # Save the merged result into a new file
+    with open(to_spec, 'w') as outfile:
+        json.dump(spec1, outfile, indent=2)
+
+    print("Files merged successfully into to_spec.")
 
 
 if __name__ == '__main__':

--- a/twilio_am_temporary.json
+++ b/twilio_am_temporary.json
@@ -1,0 +1,116 @@
+{
+  "openapi": "3.0.1",
+  "security": [
+    {
+      "oAuth2ClientCredentials": []
+    }
+  ],
+  "info": {
+    "title": "Organization Public API",
+    "contact": {
+      "name": "Twilio Support",
+      "url": "https://support.twilio.com",
+      "email": "support@twilio.com"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/Organizations/{OrganizationSid}": {
+      "servers": [
+        {
+          "url": "https://preview-iam.twilio.com"
+        }
+      ],
+      "get": {
+        "summary": "List SCIM Users",
+        "operationId": "FetchOrganization",
+        "parameters": [
+          {
+            "name": "OrganizationSid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "pattern": "OR[0-9a-f]{32}",
+              "type": "string",
+              "format": "OrganizationSid",
+              "example": "OR33f4f3aa6fffe840d000f8ef22e883db"
+            }
+          }
+        ],
+        "responses": {
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/scim+json": {
+                "schema": {
+                  
+                }
+              }
+            },
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "description": "Specify the origin(s) allowed to access the resource",
+                "schema": {
+                  "type": "string"
+                },
+                "example": "*"
+              },
+              "Access-Control-Allow-Methods": {
+                "description": "Specify the HTTP methods allowed when accessing the resource",
+                "schema": {
+                  "type": "string"
+                },
+                "example": "POST, OPTIONS"
+              },
+              "Access-Control-Allow-Headers": {
+                "description": "Specify the headers allowed when accessing the resource",
+                "schema": {
+                  "type": "string"
+                },
+                "example": "Content-Type, Authorization"
+              },
+              "Access-Control-Allow-Credentials": {
+                "description": "Indicates whether the browser should include credentials",
+                "schema": {
+                  "type": "boolean"
+                }
+              },
+              "Access-Control-Expose-Headers": {
+                "description": "Headers exposed to the client",
+                "schema": {
+                  "type": "string",
+                  "example": "X-Custom-Header1, X-Custom-Header2"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "oAuth2ClientCredentials": {
+        "type": "oauth2",
+        "flows": {
+          "clientCredentials": {
+            "tokenUrl": "https://preview-iam.twilio.com/v1/token",
+            "scopes": {}
+          }
+        }
+      }
+    },
+    "schemas": {
+      
+    }
+  },
+  "servers": [
+    {
+      "url": "https://preview-iam.twilio.com"
+    }
+  ]
+}


### PR DESCRIPTION
# Fixes #
Orgs API does not have path '/Organizations/{OrganizationSid}' in the spec file, which is needed for python orgs.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] Run `make test-docker`
- [ ] Verify affected language:
    - [ ] Generate [twilio-go](https://github.com/twilio/twilio-go) from our [OpenAPI specification](https://github.com/twilio/twilio-oai) using the [build_twilio_go.py](./examples/build_twilio_go.py) using `python examples/build_twilio_go.py path/to/twilio-oai/spec/yaml path/to/twilio-go` and inspect the diff
    - [ ] Run `make test` in `twilio-go`
    - [ ] Create a pull request in `twilio-go`
    - [ ] Provide a link below to the pull request
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-oai-generator/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please create a GitHub Issue in this repository.
