### PR TITLE
chore: added null check accountSid

### DIFF
--- a/examples/java/src/main/java/com/twilio/rest/api/v2010/AccountCreator.java
+++ b/examples/java/src/main/java/com/twilio/rest/api/v2010/AccountCreator.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;

--- a/examples/java/src/main/java/com/twilio/rest/api/v2010/AccountDeleter.java
+++ b/examples/java/src/main/java/com/twilio/rest/api/v2010/AccountDeleter.java
@@ -20,6 +20,7 @@ import com.twilio.constant.EnumConstants;
 import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.converter.Converter;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
@@ -61,6 +62,9 @@ public class AccountDeleter extends Deleter<Account> {
         String path = "/2010-04-01/Accounts/{Sid}.json";
 
         this.pathSid = this.pathSid == null ? client.getAccountSid() : this.pathSid;
+        if (this.pathSid == null) {
+            throw new InvalidRequestException("pathSid can not be null");
+        }
         path = path.replace("{"+"Sid"+"}", this.pathSid.toString());
 
         Request request = new Request(

--- a/examples/java/src/main/java/com/twilio/rest/api/v2010/AccountFetcher.java
+++ b/examples/java/src/main/java/com/twilio/rest/api/v2010/AccountFetcher.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;
@@ -62,6 +63,9 @@ public class AccountFetcher extends Fetcher<Account> {
         String path = "/2010-04-01/Accounts/{Sid}.json";
 
         this.pathSid = this.pathSid == null ? client.getAccountSid() : this.pathSid;
+        if (this.pathSid == null) {
+            throw new InvalidRequestException("pathSid can not be null");
+        }
         path = path.replace("{"+"Sid"+"}", this.pathSid.toString());
 
         Request request = new Request(

--- a/examples/java/src/main/java/com/twilio/rest/api/v2010/AccountReader.java
+++ b/examples/java/src/main/java/com/twilio/rest/api/v2010/AccountReader.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;

--- a/examples/java/src/main/java/com/twilio/rest/api/v2010/AccountUpdater.java
+++ b/examples/java/src/main/java/com/twilio/rest/api/v2010/AccountUpdater.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;
@@ -75,6 +76,9 @@ public class AccountUpdater extends Updater<Account>{
         String path = "/2010-04-01/Accounts/{Sid}.json";
 
         this.pathSid = this.pathSid == null ? client.getAccountSid() : this.pathSid;
+        if (this.pathSid == null) {
+            throw new InvalidRequestException("pathSid can not be null");
+        }
         path = path.replace("{"+"Sid"+"}", this.pathSid.toString());
         path = path.replace("{"+"Status"+"}", this.status.toString());
 

--- a/examples/java/src/main/java/com/twilio/rest/api/v2010/account/CallCreator.java
+++ b/examples/java/src/main/java/com/twilio/rest/api/v2010/account/CallCreator.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;
@@ -102,6 +103,9 @@ public class CallCreator extends Creator<Call>{
         String path = "/2010-04-01/Accounts/{AccountSid}/Calls.json";
 
         this.pathAccountSid = this.pathAccountSid == null ? client.getAccountSid() : this.pathAccountSid;
+        if (this.pathAccountSid == null) {
+            throw new InvalidRequestException("pathAccountSid can not be null");
+        }
         path = path.replace("{"+"AccountSid"+"}", this.pathAccountSid.toString());
         path = path.replace("{"+"RequiredStringProperty"+"}", this.requiredStringProperty.toString());
         path = path.replace("{"+"TestMethod"+"}", this.testMethod.toString());

--- a/examples/java/src/main/java/com/twilio/rest/api/v2010/account/CallDeleter.java
+++ b/examples/java/src/main/java/com/twilio/rest/api/v2010/account/CallDeleter.java
@@ -20,6 +20,7 @@ import com.twilio.constant.EnumConstants;
 import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.converter.Converter;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
@@ -64,6 +65,9 @@ public class CallDeleter extends Deleter<Call> {
         String path = "/2010-04-01/Accounts/{AccountSid}/Calls/{TestInteger}.json";
 
         this.pathAccountSid = this.pathAccountSid == null ? client.getAccountSid() : this.pathAccountSid;
+        if (this.pathAccountSid == null) {
+            throw new InvalidRequestException("pathAccountSid can not be null");
+        }
         path = path.replace("{"+"AccountSid"+"}", this.pathAccountSid.toString());
         path = path.replace("{"+"TestInteger"+"}", this.pathTestInteger.toString());
 

--- a/examples/java/src/main/java/com/twilio/rest/api/v2010/account/CallFetcher.java
+++ b/examples/java/src/main/java/com/twilio/rest/api/v2010/account/CallFetcher.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;
@@ -65,6 +66,9 @@ public class CallFetcher extends Fetcher<Call> {
         String path = "/2010-04-01/Accounts/{AccountSid}/Calls/{TestInteger}.json";
 
         this.pathAccountSid = this.pathAccountSid == null ? client.getAccountSid() : this.pathAccountSid;
+        if (this.pathAccountSid == null) {
+            throw new InvalidRequestException("pathAccountSid can not be null");
+        }
         path = path.replace("{"+"AccountSid"+"}", this.pathAccountSid.toString());
         path = path.replace("{"+"TestInteger"+"}", this.pathTestInteger.toString());
 

--- a/examples/java/src/main/java/com/twilio/rest/api/v2010/account/call/FeedbackCallSummaryUpdater.java
+++ b/examples/java/src/main/java/com/twilio/rest/api/v2010/account/call/FeedbackCallSummaryUpdater.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;
@@ -85,6 +86,9 @@ public class FeedbackCallSummaryUpdater extends Updater<FeedbackCallSummary>{
         String path = "/2010-04-01/Accounts/{AccountSid}/Calls/Feedback/Summary/{Sid}.json";
 
         this.pathAccountSid = this.pathAccountSid == null ? client.getAccountSid() : this.pathAccountSid;
+        if (this.pathAccountSid == null) {
+            throw new InvalidRequestException("pathAccountSid can not be null");
+        }
         path = path.replace("{"+"AccountSid"+"}", this.pathAccountSid.toString());
         path = path.replace("{"+"Sid"+"}", this.pathSid.toString());
         path = path.replace("{"+"EndDate"+"}", this.endDate.toString());

--- a/examples/java/src/main/java/com/twilio/rest/flexapi/v1/CallUpdater.java
+++ b/examples/java/src/main/java/com/twilio/rest/flexapi/v1/CallUpdater.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;

--- a/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/AwsDeleter.java
+++ b/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/AwsDeleter.java
@@ -20,6 +20,7 @@ import com.twilio.constant.EnumConstants;
 import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.converter.Converter;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;

--- a/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/AwsFetcher.java
+++ b/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/AwsFetcher.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;

--- a/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/AwsReader.java
+++ b/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/AwsReader.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;

--- a/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/AwsUpdater.java
+++ b/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/AwsUpdater.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;

--- a/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/NewCredentialsCreator.java
+++ b/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/NewCredentialsCreator.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;

--- a/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/aws/HistoryFetcher.java
+++ b/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/aws/HistoryFetcher.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;

--- a/examples/java/src/main/java/com/twilio/rest/previewiam/organizations/UserCreator.java
+++ b/examples/java/src/main/java/com/twilio/rest/previewiam/organizations/UserCreator.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;

--- a/examples/java/src/main/java/com/twilio/rest/previewiam/organizations/UserDeleter.java
+++ b/examples/java/src/main/java/com/twilio/rest/previewiam/organizations/UserDeleter.java
@@ -20,6 +20,7 @@ import com.twilio.constant.EnumConstants;
 import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.converter.Converter;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;

--- a/examples/java/src/main/java/com/twilio/rest/previewiam/organizations/UserFetcher.java
+++ b/examples/java/src/main/java/com/twilio/rest/previewiam/organizations/UserFetcher.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;

--- a/examples/java/src/main/java/com/twilio/rest/previewiam/organizations/UserReader.java
+++ b/examples/java/src/main/java/com/twilio/rest/previewiam/organizations/UserReader.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;

--- a/examples/java/src/main/java/com/twilio/rest/previewiam/organizations/UserUpdater.java
+++ b/examples/java/src/main/java/com/twilio/rest/previewiam/organizations/UserUpdater.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;

--- a/examples/java/src/main/java/com/twilio/rest/previewiam/v1/TokenCreator.java
+++ b/examples/java/src/main/java/com/twilio/rest/previewiam/v1/TokenCreator.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;

--- a/examples/java/src/main/java/com/twilio/rest/versionless/deployedDevices/FleetCreator.java
+++ b/examples/java/src/main/java/com/twilio/rest/versionless/deployedDevices/FleetCreator.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;

--- a/examples/java/src/main/java/com/twilio/rest/versionless/deployedDevices/FleetFetcher.java
+++ b/examples/java/src/main/java/com/twilio/rest/versionless/deployedDevices/FleetFetcher.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;

--- a/examples/java/src/main/java/com/twilio/rest/versionless/understand/AssistantReader.java
+++ b/examples/java/src/main/java/com/twilio/rest/versionless/understand/AssistantReader.java
@@ -21,6 +21,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;

--- a/src/main/resources/twilio-java/creator.mustache
+++ b/src/main/resources/twilio-java/creator.mustache
@@ -9,6 +9,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;

--- a/src/main/resources/twilio-java/deleter.mustache
+++ b/src/main/resources/twilio-java/deleter.mustache
@@ -8,6 +8,7 @@ import com.twilio.constant.EnumConstants;
 import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.converter.Converter;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;

--- a/src/main/resources/twilio-java/fetcher.mustache
+++ b/src/main/resources/twilio-java/fetcher.mustache
@@ -9,6 +9,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;

--- a/src/main/resources/twilio-java/generate_uri.mustache
+++ b/src/main/resources/twilio-java/generate_uri.mustache
@@ -8,6 +8,9 @@
 {{#allParams}}
     {{#vendorExtensions.x-is-account-sid}}
         this.{{paramName}} = this.{{paramName}} == null ? client.getAccountSid() : this.{{paramName}};
+        if (this.{{paramName}} == null) {
+            throw new InvalidRequestException("{{paramName}} can not be null");
+        }
         path = path.replace("{"+"{{baseName}}"+"}", this.{{paramName}}.toString());
     {{/vendorExtensions.x-is-account-sid}}
 {{/allParams}}

--- a/src/main/resources/twilio-java/reader.mustache
+++ b/src/main/resources/twilio-java/reader.mustache
@@ -9,6 +9,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;

--- a/src/main/resources/twilio-java/updater.mustache
+++ b/src/main/resources/twilio-java/updater.mustache
@@ -9,6 +9,7 @@ import com.twilio.exception.ApiConnectionException;
 import com.twilio.converter.PrefixedCollapsibleMap;
 import com.twilio.converter.Converter;
 import com.twilio.exception.ApiException;
+import com.twilio.exception.InvalidRequestException;
 import com.twilio.exception.RestException;
 import com.twilio.http.HttpMethod;
 import com.twilio.http.Response;


### PR DESCRIPTION
# Fixes #
This change is for introduction of OAuth for public APIs.
There are 2 types of APIs:  v2010 and non v2010
**v2010**
This requires AccountSid as a part of path parameter but it not mandatory to be passed as a part of an API, means it can be initialised during credential initialisation.
Twilio.init(account_sid, auth_token);
But as a part of OAuth, We are not setting it to any value, thus null pointer exception can occur, to avoid that exception has been added in v2010 APIs.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] Run `make test-docker`
- [ ] Verify affected language:
    - [ ] Generate [twilio-go](https://github.com/twilio/twilio-go) from our [OpenAPI specification](https://github.com/twilio/twilio-oai) using the [build_twilio_go.py](./examples/build_twilio_go.py) using `python examples/build_twilio_go.py path/to/twilio-oai/spec/yaml path/to/twilio-go` and inspect the diff
    - [ ] Run `make test` in `twilio-go`
    - [ ] Create a pull request in `twilio-go`
    - [ ] Provide a link below to the pull request
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-oai-generator/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please create a GitHub Issue in this repository.
