### PR TITLE
chore: ignored error response in java and c#

### DIFF
--- a/src/main/java/com/twilio/oai/StringHelper.java
+++ b/src/main/java/com/twilio/oai/StringHelper.java
@@ -48,4 +48,20 @@ public class StringHelper {
             ? inputWord
             : firstCharFunction.apply(inputWord.substring(0, 1)) + inputWord.substring(1);
     }
+
+    public static boolean isSuccess(String responseCode) {
+        // Check if responseCode matches the success pattern for 2xx or 3xx
+        if (responseCode.matches("^[23](\\d{2}|x[0-9]|[0-9]x|xx)$")) {
+            return true;
+        }
+
+        // Check if the response code is an integer between 200 and 399
+        try {
+            int code = Integer.parseInt(responseCode);
+            return (code >= 200 && code <= 399);
+        } catch (NumberFormatException e) {
+            // Handle case where responseCode is not a valid integer
+            return false;
+        }
+    }
 }

--- a/src/main/java/com/twilio/oai/api/CsharpApiResourceBuilder.java
+++ b/src/main/java/com/twilio/oai/api/CsharpApiResourceBuilder.java
@@ -210,18 +210,20 @@ public class CsharpApiResourceBuilder extends ApiResourceBuilder {
     public ApiResourceBuilder updateResponseModel(Resolver<CodegenProperty> codegenPropertyIResolver, Resolver<CodegenModel> codegenModelResolver) {
         List<CodegenModel> responseModels = new ArrayList<>();
         codegenOperationList.forEach(codegenOperation -> {
-            codegenOperation.responses.forEach(response -> {
-                String modelName = response.dataType;
-                if (response.dataType != null && response.dataType.startsWith(EnumConstants.CsharpDataTypes.LIST.getValue())){
-                    modelName = response.baseType;
-                }
-                Optional<CodegenModel> responseModel = Utility.getModel(allModels, modelName, recordKey, codegenOperation);
-                if ((responseModel == null) || responseModel.isEmpty() || (Integer.parseInt(response.code) >= 400)) {
-                    return;
-                }
-                codegenModelResolver.resolve(responseModel.get(), this);
-                responseModels.add(responseModel.get());
-            });
+            codegenOperation.responses.stream()
+                .filter(response -> StringHelper.isSuccess(response.code.trim()))
+                .forEach(response -> {
+                    String modelName = response.dataType;
+                    if (response.dataType != null && response.dataType.startsWith(EnumConstants.CsharpDataTypes.LIST.getValue())){
+                        modelName = response.baseType;
+                    }
+                    Optional<CodegenModel> responseModel = Utility.getModel(allModels, modelName, recordKey, codegenOperation);
+                    if ((responseModel == null) || responseModel.isEmpty() || (Integer.parseInt(response.code) >= 400)) {
+                        return;
+                    }
+                    codegenModelResolver.resolve(responseModel.get(), this);
+                    responseModels.add(responseModel.get());
+                });
         });
         this.apiResponseModels = getDistinctResponseModel(responseModels);
         return this;

--- a/src/main/java/com/twilio/oai/api/JavaApiResourceBuilder.java
+++ b/src/main/java/com/twilio/oai/api/JavaApiResourceBuilder.java
@@ -247,7 +247,7 @@ public class JavaApiResourceBuilder extends ApiResourceBuilder{
             jsonRequestBodyResolver.setResourceName(resourceName);
             co.responses
                     .stream()
-                    .filter(response -> SUCCESS.test(Integer.parseInt(response.code.trim())))
+                    .filter(response -> StringHelper.isSuccess(response.code.trim()))
                     .map(response -> {
                         if (response.dataType != null && response.dataType.startsWith(EnumConstants.JavaDataTypes.LIST.getValue())) {
                             return response.baseType;


### PR DESCRIPTION
# Fixes #
Ignored error response model in Java and C# Autogeneration.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] Run `make test-docker`
- [ ] Verify affected language:
    - [ ] Generate [twilio-go](https://github.com/twilio/twilio-go) from our [OpenAPI specification](https://github.com/twilio/twilio-oai) using the [build_twilio_go.py](./examples/build_twilio_go.py) using `python examples/build_twilio_go.py path/to/twilio-oai/spec/yaml path/to/twilio-go` and inspect the diff
    - [ ] Run `make test` in `twilio-go`
    - [ ] Create a pull request in `twilio-go`
    - [ ] Provide a link below to the pull request
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-oai-generator/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please create a GitHub Issue in this repository.
