### PR TITLE
fix: Fix a couple issues preventing the Go portion of the pipeline from succeeding

### DIFF
--- a/examples/go/Dockerfile
+++ b/examples/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM golang:1.21
 
 ENV GOPATH /go
 

--- a/src/main/resources/twilio-go/partial_serialization.mustache
+++ b/src/main/resources/twilio-go/partial_serialization.mustache
@@ -30,7 +30,12 @@ if params != nil && params.PathAccountSid != nil {
     if params != nil && params.{{paramName}} != nil {
         b, err := json.Marshal(*params.{{paramName}})
         if err != nil {
-            return nil, err
+{{#returnType}}
+          return nil, err
+{{/returnType}}
+{{^returnType}}
+          return nil
+{{/returnType}}
         }
         body = b
     }


### PR DESCRIPTION
This PR fixes a few issues that are causing the Go portion of the pipeline to fail:
- Update to Go 1.21
  The twilio-go started relying on `github.com/golang-jwt/jwt/v5` as part of twilio/twilio-go#280 back in April. golang-jwt v5 relies on Go 1.21's `slices` package. In order to fix the pipeline, we need to upgrade the Docker image that the Go build runs in.
- Fix compile error introduced by `UpdateAlarmStatus`
  As part of the introduction of `UpdateAlarmStatus` to twilio-oai, there is now an API method that calls an update API endpoint that does not return any content. This seems to be the first instance of an API endpoint that falls into this category, and it has introduced an issue with the partial serialization template: the partial serialization template expected the function that the template is being embedded in always has a return value. In order to fix this, the template has been updated to check to see if there is an expected return type and if not switches to returning only an error.
- Disable terraform tests
  It seems terraform is not actively being maintained and is currently broken. It is relying on a `microvisor` set of REST endpoints that do not exist in OAI.

I am having issues running `make test-docker` on my localhost. Every language passes _except_ Go lang. It seems that the Go tests are trying to authenticate with an actual Twilio server... is that right?

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] Run `make test-docker`
- [x] Verify affected language:
    - [x] Generate [twilio-go](https://github.com/twilio/twilio-go) from our [OpenAPI specification](https://github.com/twilio/twilio-oai) using the [build_twilio_go.py](./examples/build_twilio_go.py) using `python examples/build_twilio_go.py path/to/twilio-oai/spec/yaml path/to/twilio-go` and inspect the diff
    - [x] Run `make test` in `twilio-go`
    - [x] ~Create a pull request in `twilio-go`~ No changes made to `twilio-go`
    - [x] ~Provide a link below to the pull request~ No changes made to `twilio-go`
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-oai-generator/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified
