### PR TITLE
added primitive datatype support in c#

### DIFF
--- a/src/main/java/com/twilio/oai/api/CsharpApiResourceBuilder.java
+++ b/src/main/java/com/twilio/oai/api/CsharpApiResourceBuilder.java
@@ -35,6 +35,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.twilio.oai.common.ApplicationConstants.HTTP_METHOD;
@@ -45,6 +47,7 @@ public class CsharpApiResourceBuilder extends ApiResourceBuilder {
 
     public String authMethod = "";
     CodegenModelOneOf codegenModelOneOf = CodegenModelOneOf.getInstance();
+    Boolean readHasPrimitive = null;
 
     // Operation-specific response models for V1
     protected List<CodegenProperty> createResponseModels = new ArrayList<>();
@@ -456,12 +459,14 @@ public class CsharpApiResourceBuilder extends ApiResourceBuilder {
                 } else if (operationId.toLowerCase().startsWith("list")) {
                     // For list operations, use only the model inside the List<> property (skip pagination metadata like meta)
                     // since the generated code wraps items in ResourceSet<>
-                    Optional<CodegenModel> listItemModel = getListItemModel(codegenModel);
-                    if (listItemModel.isPresent()) {
+                    boolean metaPresent = doesContainPaginationMeta(codegenModel);
+                    if (!metaPresent) {
                         List<CodegenModel> itemModels = new ArrayList<>();
-                        itemModels.add(listItemModel.get());
+                        itemModels.add(codegenModel);
                         addWithoutDuplicates(this.listResponseModels, getDistinctResponseModel(itemModels));
                     } else {
+                        readHasPrimitive = true;
+                        removeMeta(distinctResponseModel);
                         addWithoutDuplicates(this.listResponseModels, distinctResponseModel);
                     }
                 } else if (operationId.toLowerCase().startsWith("fetch")) {
@@ -469,6 +474,31 @@ public class CsharpApiResourceBuilder extends ApiResourceBuilder {
                 }
             });
         });
+    }
+    
+    private String typeExtractor(String input) {
+        // Regex logic: Find everything between < and >
+        Pattern pattern = Pattern.compile("List<(.*)>");
+        Matcher matcher = pattern.matcher(input);
+        String innerType = "";
+        if (matcher.find()) {
+            innerType = matcher.group(1);
+        }
+        return innerType;
+    }
+    
+    private void removeMeta(Set<CodegenProperty> distinctResponseModel) {
+        Set<CodegenProperty> metaRemoved = new HashSet<>();
+        for (CodegenProperty property : distinctResponseModel) {
+            if (property.baseName.equals(recordKey)) {
+                if (property.dataType.startsWith("List<")) {
+                    property.dataType = typeExtractor(property.dataType);
+                }
+                metaRemoved.add(property);
+            }
+        }
+        distinctResponseModel.clear();
+        distinctResponseModel.addAll(metaRemoved);
     }
     
     private boolean hasDeleteBody(CodegenOperation codegenOperation) {
@@ -491,36 +521,18 @@ public class CsharpApiResourceBuilder extends ApiResourceBuilder {
         return false;
     }
 
-    private Optional<CodegenModel> getListItemModel(CodegenModel responseModel) {
+    // If this is true it means list response have primitive type.
+    // If false: Pagination already removed as a part of getModel.
+    private boolean doesContainPaginationMeta(CodegenModel responseModel) {
         // If recordKey exists, find the array property matching it and extract the inner model
         if (recordKey != null) {
             for (CodegenProperty property: responseModel.vars) {
-                if (property.isArray) {
-                    
+                if ("meta".equals(property.baseName.toLowerCase())) {
+                   return true;
                 }
             }
-            responseModel.getVars().stream()
-                    .collect(Collectors.toList());
-            Optional<CodegenModel> model = responseModel.getVars().stream()
-                    .filter(prop -> prop.baseName.equals(recordKey))
-                    
-                    .map(CodegenProperty::getComplexType)
-                    .filter(Objects::nonNull)
-                    .map(complexType -> Utility.getModelByClassname(allModels, complexType))
-                    .findFirst()
-                    .orElse(Optional.empty());
-            if (model.isPresent()) {
-                return model;
-            }
         }
-        // Fallback: find any array property's inner model
-        return responseModel.getVars().stream()
-                .filter(prop -> prop.isArray)
-                .map(CodegenProperty::getComplexType)
-                .filter(Objects::nonNull)
-                .map(complexType -> Utility.getModelByClassname(allModels, complexType))
-                .findFirst()
-                .orElse(Optional.empty());
+        return false;
     }
 
     private void addWithoutDuplicates(List<CodegenProperty> target, Set<CodegenProperty> source) {
@@ -647,7 +659,8 @@ public class CsharpApiResourceBuilder extends ApiResourceBuilder {
         rearrangeBeforeAfter(co.pathParams);
         rearrangeBeforeAfter(conditionalParameters);
         rearrangeBeforeAfter(optionalParameters);
-        co.optionalParams = co.optionalParams.stream().filter(parameter -> !parameter.paramName.equals("PageSize")).collect(Collectors.toList());
+        if (co.operationId.startsWith("list"))
+            co.optionalParams = co.optionalParams.stream().filter(parameter -> !parameter.paramName.equals("PageSize")).collect(Collectors.toList());
 
         // Add to vendor extension
         LinkedHashMap<String, CodegenParameter> requestBodyArgument = new LinkedHashMap<>();

--- a/src/main/java/com/twilio/oai/api/CsharpApiResourceBuilder.java
+++ b/src/main/java/com/twilio/oai/api/CsharpApiResourceBuilder.java
@@ -659,7 +659,7 @@ public class CsharpApiResourceBuilder extends ApiResourceBuilder {
         rearrangeBeforeAfter(co.pathParams);
         rearrangeBeforeAfter(conditionalParameters);
         rearrangeBeforeAfter(optionalParameters);
-        if (co.operationId.startsWith("list"))
+        if (co.operationId.toLowerCase().startsWith("list"))
             co.optionalParams = co.optionalParams.stream().filter(parameter -> !parameter.paramName.equals("PageSize")).collect(Collectors.toList());
 
         // Add to vendor extension

--- a/src/main/java/com/twilio/oai/api/CsharpApiResources.java
+++ b/src/main/java/com/twilio/oai/api/CsharpApiResources.java
@@ -27,6 +27,7 @@ public class CsharpApiResources extends ApiResources {
     
     Boolean deleteHasBody = null;
     String deleteReturnType = "bool";
+    Boolean readHasPrimitive = null;
 
     public CsharpApiResources(CsharpApiResourceBuilder apiResourceBuilder) {
         super(apiResourceBuilder);
@@ -39,5 +40,6 @@ public class CsharpApiResources extends ApiResources {
         this.deleteResponseModels = apiResourceBuilder.deleteResponseModels;
         deleteHasBody = deleteResponseModels != null && !deleteResponseModels.isEmpty() && deleteResponseModels.size() > 0;
         if (deleteHasBody) deleteReturnType = this.apiName + "DeleteResource";
+        this.readHasPrimitive = apiResourceBuilder.readHasPrimitive;
     }
 }

--- a/src/main/resources/twilio-csharp/standard/ReadResponse.mustache
+++ b/src/main/resources/twilio-csharp/standard/ReadResponse.mustache
@@ -1,31 +1,43 @@
 public class {{apiName}}Read{{resourceConstant}} : {{resourceConstant}}
 {
-{{#listResponseModels}}
-    {{#isEnum}}
-        {{#description}}///<summary> {{{description}}} </summary> {{/description}}
-        [JsonProperty("{{baseName}}")]
-        {{^required}}
-            public {{{dataType}}} {{nameInCamelCase}} { get; private set; }
-        {{/required}}
-        {{#required}}
-            public {{{dataType}}} {{nameInCamelCase}} { get; private set;}
-        {{/required}}
-    {{/isEnum}}
-    {{^isEnum}}
-        {{#description}}///<summary> {{{description}}} </summary> {{/description}}{{^description}}///<summary> The {{baseName}} </summary> {{/description}}
-        [JsonProperty("{{baseName}}")]
-        {{#vendorExtensions.x-jsonConverter}}
-            [JsonConverter(typeof({{vendorExtensions.x-jsonConverter}}))]
-        {{/vendorExtensions.x-jsonConverter}}
-        {{^required}}
-            public {{{dataType}}} {{nameInCamelCase}} { get; private set; }
-        {{/required}}
-        {{#required}}
-            public {{{dataType}}} {{nameInCamelCase}} { get; private set;}
-        {{/required}}
-    {{/isEnum}}
+{{#readHasPrimitive}}
+    {{#listResponseModels}}
+        public {{{dataType}}} {{nameInCamelCase}} { get; private set; }
+        public {{apiName}}Read{{resourceConstant}}({{{dataType}}} {{nameInCamelCase}})
+        {
+        this.{{nameInCamelCase}} = {{nameInCamelCase}};
+        }
+    {{/listResponseModels}}
+{{/readHasPrimitive}}
+{{^readHasPrimitive}}
+    {{#listResponseModels}}
+        {{#isEnum}}
+            {{#description}}///<summary> {{{description}}} </summary> {{/description}}
+            [JsonProperty("{{baseName}}")]
+            {{^required}}
+                public {{{dataType}}} {{nameInCamelCase}} { get; private set; }
+            {{/required}}
+            {{#required}}
+                public {{{dataType}}} {{nameInCamelCase}} { get; private set;}
+            {{/required}}
+        {{/isEnum}}
+        {{^isEnum}}
+            {{#description}}///<summary> {{{description}}} </summary> {{/description}}{{^description}}///<summary> The {{baseName}} </summary> {{/description}}
+            [JsonProperty("{{baseName}}")]
+            {{#vendorExtensions.x-jsonConverter}}
+                [JsonConverter(typeof({{vendorExtensions.x-jsonConverter}}))]
+            {{/vendorExtensions.x-jsonConverter}}
+            {{^required}}
+                public {{{dataType}}} {{nameInCamelCase}} { get; private set; }
+            {{/required}}
+            {{#required}}
+                public {{{dataType}}} {{nameInCamelCase}} { get; private set;}
+            {{/required}}
+        {{/isEnum}}
 
-{{/listResponseModels}}
+    {{/listResponseModels}}
+{{/readHasPrimitive}}
+
     public static {{apiName}}Read{{resourceConstant}} FromJson(string json) {
         try {
             return JsonConvert.DeserializeObject<{{apiName}}Read{{resourceConstant}}>(json);


### PR DESCRIPTION
# Fixes #
- Added primitive datatype support in read operation of c#
- Removed meta for read apis.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] Run `make test-docker`
- [ ] Verify affected language according to the code change:
    - [ ] Generate [twilio-java](https://github.com/twilio/twilio-java) from our [OpenAPI specification](https://github.com/twilio/twilio-oai) using the [scripts/build_twilio_library.py](./scripts/build_twilio_library.py) using `python scripts/build_twilio_library.py path/to/twilio-oai/spec/yaml path/to/twilio-java -l java` and inspect the diff
    - [ ] Run `make test` in `twilio-java`
    - [ ] Create a pull request in `twilio-java`
    - [ ] Provide a link below to the pull request, this ensures that the generated code has been verified
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-oai-generator/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please create a GitHub Issue in this repository.
