### PR TITLE
fix: harden PHP instance solution rendering

### DIFF
--- a/src/main/resources/twilio-php/context.mustache
+++ b/src/main/resources/twilio-php/context.mustache
@@ -101,6 +101,10 @@ class {{apiName}}Context extends InstanceContext
     {
         $context = [];
         foreach ($this->solution as $key => $value) {
+            if ($value instanceof \DateTimeInterface) {
+                $value = $value->format('Y-m-d');
+            }
+
             $context[] = "$key=$value";
         }
         return '[Twilio.{{domainName}}.{{apiVersionClass}}.{{apiName}}Context ' . \implode(' ', $context) . ']';

--- a/src/main/resources/twilio-php/instance.mustache
+++ b/src/main/resources/twilio-php/instance.mustache
@@ -50,7 +50,7 @@ class {{apiName}}Instance extends InstanceResource
         ];
 
     {{/responseModels.0}}
-        $this->solution = [{{#requiredPathParams}}{{#vendorExtensions.x-is-parent-param}}'{{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}}' => ${{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}}, {{/vendorExtensions.x-is-parent-param}}{{^vendorExtensions.x-is-parent-param}}'{{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}}' => ${{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}} ?: $this->properties['{{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}}'], {{/vendorExtensions.x-is-parent-param}}{{/requiredPathParams}}];
+        $this->solution = [{{#requiredPathParams}}{{#vendorExtensions.x-is-parent-param}}'{{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}}' => ${{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}}, {{/vendorExtensions.x-is-parent-param}}{{^vendorExtensions.x-is-parent-param}}'{{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}}' => ${{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}} ?: ($this->properties['{{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}}'] ?? null), {{/vendorExtensions.x-is-parent-param}}{{/requiredPathParams}}];
     }
 
 {{#metaProperties.x-is-context-operation}}
@@ -123,6 +123,10 @@ class {{apiName}}Instance extends InstanceResource
         {{#metaProperties.x-is-context-operation}}
         $context = [];
         foreach ($this->solution as $key => $value) {
+            if ($value instanceof \DateTimeInterface) {
+                $value = $value->format('Y-m-d');
+            }
+
             $context[] = "$key=$value";
         }
         {{/metaProperties.x-is-context-operation}}

--- a/src/main/resources/twilio-php/instanceClass.mustache
+++ b/src/main/resources/twilio-php/instanceClass.mustache
@@ -119,6 +119,10 @@ class {{classname}}Instance extends InstanceResource
         {{#metaProperties.x-is-context-operation}}
         $context = [];
         foreach ($this->solution as $key => $value) {
+            if ($value instanceof \DateTimeInterface) {
+                $value = $value->format('Y-m-d');
+            }
+
             $context[] = "$key=$value";
         }
         {{/metaProperties.x-is-context-operation}}

--- a/src/main/resources/twilio-php/instanceClasses.mustache
+++ b/src/main/resources/twilio-php/instanceClasses.mustache
@@ -37,7 +37,7 @@ class {{classname}}Instance extends InstanceResource
             {{/vars}}
         ];
 
-        $this->solution = [{{#requiredPathParams}}{{#vendorExtensions.x-is-parent-param}}'{{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}}' => ${{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}}, {{/vendorExtensions.x-is-parent-param}}{{^vendorExtensions.x-is-parent-param}}'{{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}}' => ${{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}} ?: $this->properties['{{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}}'], {{/vendorExtensions.x-is-parent-param}}{{/requiredPathParams}}];
+        $this->solution = [{{#requiredPathParams}}{{#vendorExtensions.x-is-parent-param}}'{{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}}' => ${{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}}, {{/vendorExtensions.x-is-parent-param}}{{^vendorExtensions.x-is-parent-param}}'{{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}}' => ${{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}} ?: ($this->properties['{{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}}'] ?? null), {{/vendorExtensions.x-is-parent-param}}{{/requiredPathParams}}];
     }
 
 {{#metaProperties.x-is-context-operation}}
@@ -110,6 +110,10 @@ class {{classname}}Instance extends InstanceResource
         {{#metaProperties.x-is-context-operation}}
         $context = [];
         foreach ($this->solution as $key => $value) {
+            if ($value instanceof \DateTimeInterface) {
+                $value = $value->format('Y-m-d');
+            }
+
             $context[] = "$key=$value";
         }
         {{/metaProperties.x-is-context-operation}}

--- a/src/test/java/com/twilio/oai/PhpInstanceSolutionTemplateTest.java
+++ b/src/test/java/com/twilio/oai/PhpInstanceSolutionTemplateTest.java
@@ -1,0 +1,38 @@
+package com.twilio.oai;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PhpInstanceSolutionTemplateTest {
+    private static final Path INSTANCE_TEMPLATE = Paths.get("src/main/resources/twilio-php/instance.mustache");
+    private static final Path INSTANCE_CLASSES_TEMPLATE = Paths.get("src/main/resources/twilio-php/instanceClasses.mustache");
+    private static final List<Path> STRING_OUTPUT_TEMPLATES = Arrays.asList(
+        INSTANCE_TEMPLATE,
+        INSTANCE_CLASSES_TEMPLATE,
+        Paths.get("src/main/resources/twilio-php/instanceClass.mustache"),
+        Paths.get("src/main/resources/twilio-php/context.mustache")
+    );
+
+    @Test
+    public void phpInstanceSolutionFallbacksAreNullSafe() throws IOException {
+        assertFalse(Files.readString(INSTANCE_TEMPLATE).contains(" ?: $this->properties['"));
+        assertFalse(Files.readString(INSTANCE_CLASSES_TEMPLATE).contains(" ?: $this->properties['"));
+    }
+
+    @Test
+    public void phpStringOutputFormatsDateTimeSolutionValues() throws IOException {
+        for (Path template : STRING_OUTPUT_TEMPLATES) {
+            String content = Files.readString(template);
+            assertTrue(template.toString(), content.contains("if ($value instanceof \\DateTimeInterface)"));
+        }
+    }
+}


### PR DESCRIPTION
This makes path-parameter fallbacks null-safe, so generated code no longer reads missing `$this->properties[...]` keys and emits Undefined index / Undefined array key warnings, and generated `__toString()` methods handle `DateTimeInterface` solution values by formatting them as `Y-m-d` before interpolation, avoiding object-to-string errors.