### PR TITLE
Handle empty authMethods as no auth

### DIFF
--- a/src/main/java/com/twilio/oai/TwilioCsharpGenerator.java
+++ b/src/main/java/com/twilio/oai/TwilioCsharpGenerator.java
@@ -160,7 +160,7 @@ public class TwilioCsharpGenerator extends CSharpClientCodegen {
 
         if(opList != null){
             List<CodegenSecurity> authMethods = opList.get(0).authMethods;
-            if(authMethods != null){
+            if(authMethods != null && !authMethods.isEmpty()){
                 for(CodegenSecurity c : authMethods){
                     if(c.isOAuth == true){
                         isTokenAuthPresent = true;

--- a/src/main/java/com/twilio/oai/api/CsharpApiResourceBuilder.java
+++ b/src/main/java/com/twilio/oai/api/CsharpApiResourceBuilder.java
@@ -132,7 +132,7 @@ public class CsharpApiResourceBuilder extends ApiResourceBuilder {
         boolean isTokenAuthPresent = false;
         if(opList != null){
             List<CodegenSecurity> authMethods = opList.get(0).authMethods;
-            if(authMethods != null){
+            if(authMethods != null && !authMethods.isEmpty()){
                 for(CodegenSecurity c : authMethods){
                     if(c.isOAuth == true){
                         isTokenAuthPresent = true;

--- a/src/main/java/com/twilio/oai/api/JavaApiResourceBuilder.java
+++ b/src/main/java/com/twilio/oai/api/JavaApiResourceBuilder.java
@@ -204,7 +204,7 @@ public class JavaApiResourceBuilder extends ApiResourceBuilder{
     public void processAuthMethods(List<CodegenOperation> opList) {
         if(opList != null){
             List<CodegenSecurity> authMethods = opList.get(0).authMethods;
-            if(authMethods != null){
+            if(authMethods != null && !authMethods.isEmpty()){
                 for(CodegenSecurity c : authMethods){
                     if(c.isOAuth == true){
                         this.authMethodPackage = ".bearertoken";

--- a/src/main/java/com/twilio/oai/resolver/java/JavaConventionResolver.java
+++ b/src/main/java/com/twilio/oai/resolver/java/JavaConventionResolver.java
@@ -130,7 +130,7 @@ public class JavaConventionResolver {
     public Map<String, Object> populateSecurityAttributes(CodegenOperation co) {
         ArrayList<CodegenSecurity> authMethods = (ArrayList) co.authMethods;
         HashMap<String,String> authAttributes = new HashMap<>();
-        if(authMethods == null){
+        if(authMethods == null || authMethods.isEmpty()){
             authAttributes.put(AUTH_IMPORT_CLASS, NOAUTH_IMPORT_CLASS);
             authAttributes.put(HTTP_CLASS_PREFIX, NOAUTH_HTTP_CLASS_PREFIX);
         }else{

--- a/src/test/java/com/twilio/oai/SecurityAuthTest.java
+++ b/src/test/java/com/twilio/oai/SecurityAuthTest.java
@@ -1,0 +1,59 @@
+package com.twilio.oai;
+
+import com.twilio.oai.api.CsharpApiResourceBuilder;
+import com.twilio.oai.api.JavaApiResourceBuilder;
+import com.twilio.oai.common.EnumConstants;
+import com.twilio.oai.resolver.java.JavaConventionResolver;
+import org.junit.Test;
+import org.openapitools.codegen.CodegenOperation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.twilio.oai.resolver.java.JavaConventionResolver.AUTH_IMPORT_CLASS;
+import static com.twilio.oai.resolver.java.JavaConventionResolver.HTTP_CLASS_PREFIX;
+import static com.twilio.oai.resolver.java.JavaConventionResolver.NOAUTH_HTTP_CLASS_PREFIX;
+import static com.twilio.oai.resolver.java.JavaConventionResolver.NOAUTH_IMPORT_CLASS;
+import static org.junit.Assert.assertEquals;
+
+public class SecurityAuthTest {
+
+    @Test
+    public void testJavaResolverTreatsEmptyAuthMethodsAsNoAuth() {
+        CodegenOperation operation = operationWithEmptyAuthMethods();
+        Map<String, Object> vendorExtensions = new JavaConventionResolver().populateSecurityAttributes(operation);
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> authAttributes = (Map<String, String>) vendorExtensions.get("x-auth-attributes");
+
+        assertEquals(NOAUTH_IMPORT_CLASS, authAttributes.get(AUTH_IMPORT_CLASS));
+        assertEquals(NOAUTH_HTTP_CLASS_PREFIX, authAttributes.get(HTTP_CLASS_PREFIX));
+    }
+
+    @Test
+    public void testJavaResourceBuilderTreatsEmptyAuthMethodsAsNoAuth() {
+        CodegenOperation operation = operationWithEmptyAuthMethods();
+        JavaApiResourceBuilder builder = new JavaApiResourceBuilder(null, List.of(operation), List.of());
+
+        builder.processAuthMethods(List.of(operation));
+
+        assertEquals(NOAUTH_IMPORT_CLASS, builder.authMethodPackage);
+    }
+
+    @Test
+    public void testCsharpResourceBuilderTreatsEmptyAuthMethodsAsNoAuth() {
+        CodegenOperation operation = operationWithEmptyAuthMethods();
+        CsharpApiResourceBuilder builder = new CsharpApiResourceBuilder(null, List.of(operation), List.of());
+
+        builder.processAuthMethods(List.of(operation));
+
+        assertEquals(EnumConstants.AuthType.NOAUTH.getValue(), builder.authMethod);
+    }
+
+    private CodegenOperation operationWithEmptyAuthMethods() {
+        CodegenOperation operation = new CodegenOperation();
+        operation.authMethods = new ArrayList<>();
+        return operation;
+    }
+}


### PR DESCRIPTION
Summary
- Treat an empty authMethods list like null authMethods in Java and C# auth path selection.
- Add unit coverage for empty authMethods in the Java resolver and resource builders.

Validation
- git diff --check
- Not run: mvn -Dtest=SecurityAuthTest test. Maven and a Java runtime are not installed in this environment.
