### PR TITLE
fix: correct Go return for void JSON-body operations

### DIFF
--- a/src/main/resources/twilio-go/api.mustache
+++ b/src/main/resources/twilio-go/api.mustache
@@ -82,7 +82,7 @@ func (c *ApiService) {{{nickname}}}({{#allParams}}{{#required}}{{paramName}} {{{
 // {{{nickname}}}WithMetadata returns response with metadata like status code and response headers
 func (c *ApiService) {{{nickname}}}WithMetadata({{#allParams}}{{#required}}{{paramName}} {{{dataType}}}{{^-last}}, {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}}params *{{{nickname}}}Params{{/hasOptionalParams}}) (*metadata.ResourceMetadata[{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}bool{{/returnType}}], error) {
     path := "{{{path}}}"
-    {{>partial_serialization}}
+    {{>partial_serialization_metadata}}
 
 {{#hasHeaderParams}}
 {{#headerParams}}
@@ -122,7 +122,7 @@ func (c *ApiService) {{{nickname}}}WithMetadata({{#allParams}}{{#required}}{{par
 func (c *ApiService) Page{{{vendorExtensions.x-domain-name}}}({{#allParams}}{{#required}}{{paramName}} {{{dataType}}}{{^last}}, {{/last}}{{/required}}{{/allParams}}params *{{{nickname}}}Params{{#vendorExtensions.isApiV1}}, pageToken string{{/vendorExtensions.isApiV1}}{{^vendorExtensions.isApiV1}}, pageToken, pageNumber string{{/vendorExtensions.isApiV1}}) (*{{{returnContainer}}}, error) {
     path := "{{{path}}}"
 
-    {{>partial_serialization}}
+    {{>partial_serialization_metadata}}
     if pageToken != "" {
         data.Set("PageToken", pageToken)
     }
@@ -150,7 +150,7 @@ func (c *ApiService) Page{{{vendorExtensions.x-domain-name}}}({{#allParams}}{{#r
 func (c *ApiService) Page{{{vendorExtensions.x-domain-name}}}WithMetadata({{#allParams}}{{#required}}{{paramName}} {{{dataType}}}{{^last}}, {{/last}}{{/required}}{{/allParams}}params *{{{nickname}}}Params{{#vendorExtensions.isApiV1}}, pageToken string{{/vendorExtensions.isApiV1}}{{^vendorExtensions.isApiV1}}, pageToken, pageNumber string{{/vendorExtensions.isApiV1}}) (*metadata.ResourceMetadata[{{{returnContainer}}}], error) {
     path := "{{{path}}}"
 
-    {{>partial_serialization}}
+    {{>partial_serialization_metadata}}
     if pageToken != "" {
         data.Set("PageToken", pageToken)
     }

--- a/src/main/resources/twilio-go/partial_serialization_metadata.mustache
+++ b/src/main/resources/twilio-go/partial_serialization_metadata.mustache
@@ -30,7 +30,7 @@ if params != nil && params.PathAccountSid != nil {
     if params != nil && params.{{paramName}} != nil {
         b, err := json.Marshal(*params.{{paramName}})
         if err != nil {
-            {{#returnType}}return nil, err{{/returnType}}{{^returnType}}return err{{/returnType}}
+            return nil, err
         }
         body = b
     }
@@ -46,7 +46,7 @@ if params != nil && params.PathAccountSid != nil {
             v, err := json.Marshal(item)
 
             if err != nil {
-            {{#returnType}}return nil, err{{/returnType}}{{^returnType}}return err{{/returnType}}
+            return nil, err
             }
 
             data.Add("{{{baseName}}}", string(v))
@@ -61,7 +61,7 @@ if params != nil && params.PathAccountSid != nil {
         v, err := json.Marshal(params.{{paramName}})
 
         if err != nil {
-        {{#returnType}}return nil, err{{/returnType}}{{^returnType}}return err{{/returnType}}
+        return nil, err
         }
 
         data.Set("{{{baseName}}}", string(v))
@@ -91,7 +91,7 @@ if params != nil && params.PathAccountSid != nil {
             v, err := json.Marshal(item)
 
             if err != nil {
-                {{#returnType}}return nil, err{{/returnType}}{{^returnType}}return err{{/returnType}}
+                return nil, err
             }
 
             data.Add("{{{baseName}}}", string(v))
@@ -106,7 +106,7 @@ if params != nil && params.PathAccountSid != nil {
         v, err := json.Marshal(params.{{paramName}})
 
         if err != nil {
-            {{#returnType}}return nil, err{{/returnType}}{{^returnType}}return err{{/returnType}}
+            return nil, err
         }
 
         data.Set("{{{baseName}}}", string(v))


### PR DESCRIPTION
## Summary
- Fixes a Go compile error (`too many return values`) hit on the `enable-go-sdk` pipeline: [twilio-librarian-status-checks build #65332](https://buildkite.com/twilio/twilio-librarian-status-checks/builds/65332)
- `src/main/resources/twilio-go/partial_serialization.mustache` hardcoded `return nil, err` for JSON-marshal error handling, but that partial is shared across 4 call sites in `api.mustache`: the main operation function (return arity depends on `returnType`) and the `WithMetadata`/`Page`/`PageWithMetadata` functions (always 2-value return)
- For a write operation with a JSON request body and **no response payload**, the main function's signature is `(error)` — but the partial's unconditional `return nil, err` produced `too many return values`
- Confirmed exact failing operations from the build:
  - `POST /v3/RuleExecutions` (`CreateRuleExecution`, `twilio_intelligence_v3.yaml`, `202` no-schema response) → `rest/intelligence/v3/rule_executions.go:48`
  - `POST /v2/Configurations/{Type}/Default` (`CreateOrUpdateDefaultConfiguration`, `twilio_voice_v2.yaml`, `204 No Content`) → `rest/voice/v2/configurations_default.go:49`

## Fix
Split the shared partial in two:
- `partial_serialization.mustache` (main function only) — return now follows `{{#returnType}}return nil, err{{/returnType}}{{^returnType}}return err{{/returnType}}`
- `partial_serialization_metadata.mustache` (new) — used by `WithMetadata`/`Page`/`PageWithMetadata`, which always need the unconditional 2-value `return nil, err`

## Test plan
- [x] `make install` builds the generator jar successfully
- [x] Regenerated `twilio_intelligence_v3.yaml` and `twilio_voice_v2.yaml` locally and confirmed `rule_executions.go` / `configurations_default.go` now emit `return err` (matching the single-value `(error)` signature) instead of `return nil, err`
- [x] Confirmed `WithMetadata`/`Page`/`PageWithMetadata` variants still correctly emit `return nil, err` (unaffected)
- [x] Ran `go build` against a local `twilio-go` checkout with the regenerated `rest/` tree swapped in — the "too many return values" errors are gone for both packages
- [x] Verified (by comparing against the unfixed baseline) that this is the only functional diff introduced; pre-existing unrelated "imported and not used" errors in a raw full-module build are present in the baseline too (expected — the real CI pipeline runs an import-cleanup/goimports step this local repro doesn't)

Fixes DII-2553.