### PR TITLE
chore: updated .net8 base image

### DIFF
--- a/examples/csharp/Dockerfile
+++ b/examples/csharp/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ENV PATH="${PATH}:/root/.dotnet/tools"
 
 RUN apt-get update \


### PR DESCRIPTION
twilio-csharp: .net6 support is getting removed, adding support of .net8