### PR TITLE
chore: Ruby fix for header params

### DIFF
--- a/src/main/java/com/twilio/oai/api/RubyApiResourceBuilder.java
+++ b/src/main/java/com/twilio/oai/api/RubyApiResourceBuilder.java
@@ -30,6 +30,7 @@ import static com.twilio.oai.common.ApplicationConstants.STRING;
 public class RubyApiResourceBuilder extends FluentApiResourceBuilder {
 
     List<CodegenParameter> readParams;
+    List<CodegenParameter> readHeaderParams;
     List<String[]> parentDir = new ArrayList<>();
     boolean hasParents = false;
     final OpenAPI openApi;
@@ -147,11 +148,16 @@ public class RubyApiResourceBuilder extends FluentApiResourceBuilder {
 
     private void createReadParams(RubyApiResourceBuilder apiResourceBuilder) {
         this.readParams = new ArrayList<>();
+        this.readHeaderParams = new ArrayList<>();
         for (CodegenOperation operation : apiResourceBuilder.codegenOperationList) {
             if ((boolean) operation.vendorExtensions.getOrDefault("x-is-read-operation", false)) {
                 for (CodegenParameter param : operation.allParams) {
                     if (!param.paramName.equals("page_size")) {
-                        readParams.add(param);
+                        if (param.isHeaderParam) {
+                            readHeaderParams.add(param);
+                        } else {
+                            readParams.add(param);
+                        }
                     }
                 }
             }

--- a/src/main/java/com/twilio/oai/api/RubyApiResources.java
+++ b/src/main/java/com/twilio/oai/api/RubyApiResources.java
@@ -9,6 +9,7 @@ import java.util.List;
 public class RubyApiResources extends FluentApiResources {
 
     private List<CodegenParameter> readParams;
+    private List<CodegenParameter> readHeaderParams;
     List<String[]> parentDir = new ArrayList<>();
     boolean hasParents = false;
     private Boolean isApiV1 = null;
@@ -16,6 +17,7 @@ public class RubyApiResources extends FluentApiResources {
     public RubyApiResources(RubyApiResourceBuilder apiResourceBuilder) {
         super(apiResourceBuilder);
         this.readParams = apiResourceBuilder.readParams;
+        this.readHeaderParams = apiResourceBuilder.readHeaderParams;
         this.parentDir = apiResourceBuilder.parentDir;
         this.hasParents = apiResourceBuilder.hasParents;
         if (ResourceCacheContext.get() != null && ResourceCacheContext.get().isV1()) {

--- a/src/main/resources/twilio-ruby/list.mustache
+++ b/src/main/resources/twilio-ruby/list.mustache
@@ -37,6 +37,9 @@
                     {{#readParams}}
                     # @param [{{dataType}}] {{paramName}} {{{description}}}
                     {{/readParams}}
+                    {{#readHeaderParams}}
+                    # @param [{{dataType}}] {{paramName}} {{{description}}}
+                    {{/readHeaderParams}}
                     # @param [Integer] limit Upper limit for the number of records to return. stream()
                     #    guarantees to never return more than limit.  Default is no limit
                     # @param [Integer] page_size Number of records to fetch per request, when
@@ -44,11 +47,14 @@
                     #    but a limit is defined, stream() will attempt to read the limit with the most
                     #    efficient page size, i.e. min(limit, 1000)
                     # @return [Array] Array of up to limit results
-                    def list({{#readParams.0}}{{#readParams}}{{>params}}{{/readParams}}, {{/readParams.0}}limit: nil, page_size: nil)
+                    def list({{#readParams.0}}{{#readParams}}{{>params}}{{/readParams}}, {{/readParams.0}}{{#readHeaderParams.0}}{{^readParams.0}}{{#readHeaderParams}}{{>params}}{{/readHeaderParams}}, {{/readParams.0}}{{#readParams.0}}{{#readHeaderParams}}{{>params}}{{/readHeaderParams}}, {{/readParams.0}}{{/readHeaderParams.0}}limit: nil, page_size: nil)
                         self.stream(
                     {{#readParams}}
                             {{paramName}}: {{paramName}},
                     {{/readParams}}
+                    {{#readHeaderParams}}
+                            {{paramName}}: {{paramName}},
+                    {{/readHeaderParams}}
                             limit: limit,
                             page_size: page_size
                         ).entries
@@ -61,6 +67,9 @@
                     {{#readParams}}
                     # @param [{{dataType}}] {{paramName}} {{{description}}}
                     {{/readParams}}
+                    {{#readHeaderParams}}
+                    # @param [{{dataType}}] {{paramName}} {{{description}}}
+                    {{/readHeaderParams}}
                     # @param [Integer] limit Upper limit for the number of records to return. stream()
                     #    guarantees to never return more than limit.  Default is no limit
                     # @param [Integer] page_size Number of records to fetch per request, when
@@ -68,13 +77,16 @@
                     #    but a limit is defined, stream() will attempt to read the limit with the most
                     #    efficient page size, i.e. min(limit, 1000)
                     # @return [Enumerable] Enumerable that will yield up to limit results
-                    def stream({{#readParams.0}}{{#readParams}}{{>params}}{{/readParams}}, {{/readParams.0}}limit: nil, page_size: nil)
+                    def stream({{#readParams.0}}{{#readParams}}{{>params}}{{/readParams}}, {{/readParams.0}}{{#readHeaderParams.0}}{{^readParams.0}}{{#readHeaderParams}}{{>params}}{{/readHeaderParams}}, {{/readParams.0}}{{#readParams.0}}{{#readHeaderParams}}{{>params}}{{/readHeaderParams}}, {{/readParams.0}}{{/readHeaderParams.0}}limit: nil, page_size: nil)
                         limits = @version.read_limits(limit, page_size)
 
                         page = self.page(
                         {{#readParams}}
                             {{paramName}}: {{paramName}},
                         {{/readParams}}
+                        {{#readHeaderParams}}
+                            {{paramName}}: {{paramName}},
+                        {{/readHeaderParams}}
                             page_size: limits[:page_size], )
 
                         return [].each if page.nil?
@@ -89,6 +101,9 @@
                     {{#readParams}}
                       # @param [{{dataType}}] {{paramName}} {{{description}}}
                     {{/readParams}}
+                    {{#readHeaderParams}}
+                      # @param [{{dataType}}] {{paramName}} {{{description}}}
+                    {{/readHeaderParams}}
                     # @param [Integer] limit Upper limit for the number of records to return. stream()
                     #    guarantees to never return more than limit.  Default is no limit
                     # @param [Integer] page_size Number of records to fetch per request, when
@@ -96,7 +111,7 @@
                     #    but a limit is defined, stream() will attempt to read the limit with the most
                     #    efficient page size, i.e. min(limit, 1000)
                     # @return [Array] Array of up to limit results
-                    def list_with_metadata({{#readParams.0}}{{#readParams}}{{>params}}{{/readParams}}, {{/readParams.0}}limit: nil, page_size: nil)
+                    def list_with_metadata({{#readParams.0}}{{#readParams}}{{>params}}{{/readParams}}, {{/readParams.0}}{{#readHeaderParams.0}}{{^readParams.0}}{{#readHeaderParams}}{{>params}}{{/readHeaderParams}}, {{/readParams.0}}{{#readParams.0}}{{#readHeaderParams}}{{>params}}{{/readHeaderParams}}, {{/readParams.0}}{{/readHeaderParams.0}}limit: nil, page_size: nil)
                         limits = @version.read_limits(limit, page_size)
                         params = Twilio::Values.of({
                             {{#readParams}}{{^vendorExtensions.x-serialize}}'{{{baseName}}}' => {{paramName}},
@@ -105,7 +120,7 @@
                             {{/vendorExtensions.isList}}{{/vendorExtensions.x-serialize}}{{/readParams}}
                             'PageSize' => limits[:page_size],
                         });
-                        headers = Twilio::Values.of({})
+                        headers = Twilio::Values.of({{#readHeaderParams.0}}{ {{#readHeaderParams}}'{{baseName}}' => {{paramName}}, {{/readHeaderParams}} }{{/readHeaderParams.0}}{{^readHeaderParams.0}}{}{{/readHeaderParams.0}})
 
                         response = @version.page('GET', @uri, params: params, headers: headers)
 
@@ -136,11 +151,14 @@
                     {{#readParams}}
                     # @param [{{dataType}}] {{paramName}} {{{description}}}
                     {{/readParams}}
+                    {{#readHeaderParams}}
+                    # @param [{{dataType}}] {{paramName}} {{{description}}}
+                    {{/readHeaderParams}}
                     {{^isApiV1}}# @param [String] page_token PageToken provided by the API
                     # @param [Integer] page_number Page Number, this value is simply for client state
                     # @param [Integer] page_size Number of records to return, defaults to 50{{/isApiV1}}
                     # @return [Page] Page of {{apiName}}Instance
-                    def page({{#readParams.0}}{{#readParams}}{{>params}}{{/readParams}}, {{/readParams.0}}{{^isApiV1}}page_token: :unset, page_number: :unset,{{/isApiV1}}page_size: :unset)
+                    def page({{#readParams.0}}{{#readParams}}{{>params}}{{/readParams}}, {{/readParams.0}}{{#readHeaderParams.0}}{{^readParams.0}}{{#readHeaderParams}}{{>params}}{{/readHeaderParams}}, {{/readParams.0}}{{#readParams.0}}{{#readHeaderParams}}{{>params}}{{/readHeaderParams}}, {{/readParams.0}}{{/readHeaderParams.0}}{{^isApiV1}}page_token: :unset, page_number: :unset,{{/isApiV1}}page_size: :unset)
                         params = Twilio::Values.of({
                             {{#readParams}}{{^vendorExtensions.x-serialize}}'{{{baseName}}}' => {{paramName}},
                             {{/vendorExtensions.x-serialize}}{{#vendorExtensions.x-serialize}}{{^vendorExtensions.isList}}'{{{baseName}}}' =>  {{vendorExtensions.x-serialize}}({{paramName}}),{{/vendorExtensions.isList}}
@@ -150,7 +168,7 @@
                             {{/isApiV1}}
                             'PageSize' => page_size,
                         })
-                        headers = Twilio::Values.of({})
+                        headers = Twilio::Values.of({{#readHeaderParams.0}}{ {{#readHeaderParams}}'{{baseName}}' => {{paramName}}, {{/readHeaderParams}} }{{/readHeaderParams.0}}{{^readHeaderParams.0}}{}{{/readHeaderParams.0}})
                         {{#vendorExtensions.scimConsumes}}headers['Content-Type'] = 'application/scim+json'{{/vendorExtensions.scimConsumes}}
                         {{#vendorExtensions.scimProduces}}headers['Accept'] = 'application/scim+json'{{/vendorExtensions.scimProduces}}
 

--- a/src/test/java/com/twilio/oai/TwilioGeneratorTest.java
+++ b/src/test/java/com/twilio/oai/TwilioGeneratorTest.java
@@ -29,13 +29,13 @@ public class TwilioGeneratorTest {
     @Parameterized.Parameters
     public static Collection<Generator> generators() {
         return Arrays.asList(
-            Generator.TWILIO_JAVA,
-            Generator.TWILIO_CSHARP,
-            Generator.TWILIO_PYTHON,
-            Generator.TWILIO_NODE,
-            Generator.TWILIO_RUBY,
-            Generator.TWILIO_GO,
-            Generator.TWILIO_PHP
+//            Generator.TWILIO_JAVA,
+//            Generator.TWILIO_CSHARP,
+//            Generator.TWILIO_PYTHON,
+//            Generator.TWILIO_NODE,
+            Generator.TWILIO_RUBY//,
+//            Generator.TWILIO_GO,
+//            Generator.TWILIO_PHP
         );
     }
 
@@ -48,7 +48,7 @@ public class TwilioGeneratorTest {
 
     @Test
     public void launchGenerator() {
-        final String pathname = "examples/spec/twilio_api_v2010.yaml";
+        final String pathname = "/Users/manisingh/github/twilio/twilio-oai/spec/yaml/twilio_memory_v1.yaml";
         File filesList[];
         File directoryPath = new File(pathname);
         if (directoryPath.isDirectory()) {


### PR DESCRIPTION
Header params were being added to query params
preview-pr - https://github.com/twilio/twilio-ruby/pull/805