### PR TITLE
fix: skip meta/pagination generation for Ruby List ops without meta

### DIFF
--- a/examples/ruby/lib/twilio-ruby/rest/api/v2010/account/call.rb
+++ b/examples/ruby/lib/twilio-ruby/rest/api/v2010/account/call.rb
@@ -308,66 +308,6 @@ module Twilio
             end
           end
 
-          class CallPageMetadata < PageMetadata
-            attr_reader :call_page
-
-            def initialize(version, response, solution, limit)
-              super(version, response)
-              @call_page = []
-              @limit = limit
-              key = get_key(response.body)
-              records = 0
-              while (limit != :unset && records < limit)
-                @call_page << CallListResponse.new(version, @payload, key, limit - records)
-                @payload = self.next_page
-                break unless @payload
-
-                records += (@payload.body[key] || []).size
-              end
-              # Path Solution
-              @solution = solution
-            end
-
-            def each
-              @call_page.each do |record|
-                yield record
-              end
-            end
-
-            def to_s
-              '<Twilio::REST::Api::V2010PageMetadata>';
-            end
-          end
-
-          class CallListResponse < InstanceListResource
-            # @param [Array<CallInstance>] instance
-            # @param [Hash{String => Object}] headers
-            # @param [Integer] status_code
-            def initialize(version, payload, key, limit = :unset)
-              data_list = payload.body[key] || []
-              if limit != :unset
-                data_list = data_list[0, limit]
-              end
-              @call = data_list.map do |data|
-                CallInstance.new(version, data)
-              end
-              @headers = payload.headers
-              @status_code = payload.status_code
-            end
-
-            def call
-              @call
-            end
-
-            def headers
-              @headers
-            end
-
-            def status_code
-              @status_code
-            end
-          end
-
           class CallInstance < InstanceResource
             ##
             # Initialize the CallInstance

--- a/examples/ruby/lib/twilio-ruby/rest/api/v2010/account/call/feedback_call_summary.rb
+++ b/examples/ruby/lib/twilio-ruby/rest/api/v2010/account/call/feedback_call_summary.rb
@@ -204,67 +204,6 @@ module Twilio
               end
             end
 
-            class FeedbackCallSummaryPageMetadata < PageMetadata
-              attr_reader :feedback_call_summary_page
-
-              def initialize(version, response, solution, limit)
-                super(version, response)
-                @feedback_call_summary_page = []
-                @limit = limit
-                key = get_key(response.body)
-                records = 0
-                while (limit != :unset && records < limit)
-                  @feedback_call_summary_page << FeedbackCallSummaryListResponse.new(version, @payload, key,
-                                                                                     limit - records)
-                  @payload = self.next_page
-                  break unless @payload
-
-                  records += (@payload.body[key] || []).size
-                end
-                # Path Solution
-                @solution = solution
-              end
-
-              def each
-                @feedback_call_summary_page.each do |record|
-                  yield record
-                end
-              end
-
-              def to_s
-                '<Twilio::REST::Api::V2010PageMetadata>';
-              end
-            end
-
-            class FeedbackCallSummaryListResponse < InstanceListResource
-              # @param [Array<FeedbackCallSummaryInstance>] instance
-              # @param [Hash{String => Object}] headers
-              # @param [Integer] status_code
-              def initialize(version, payload, key, limit = :unset)
-                data_list = payload.body[key] || []
-                if limit != :unset
-                  data_list = data_list[0, limit]
-                end
-                @feedback_call_summary = data_list.map do |data|
-                  FeedbackCallSummaryInstance.new(version, data)
-                end
-                @headers = payload.headers
-                @status_code = payload.status_code
-              end
-
-              def feedback_call_summary
-                @feedback_call_summary
-              end
-
-              def headers
-                @headers
-              end
-
-              def status_code
-                @status_code
-              end
-            end
-
             class FeedbackCallSummaryInstance < InstanceResource
               ##
               # Initialize the FeedbackCallSummaryInstance

--- a/examples/ruby/lib/twilio-ruby/rest/flex_api/v1/call.rb
+++ b/examples/ruby/lib/twilio-ruby/rest/flex_api/v1/call.rb
@@ -173,66 +173,6 @@ module Twilio
           end
         end
 
-        class CallPageMetadata < PageMetadata
-          attr_reader :call_page
-
-          def initialize(version, response, solution, limit)
-            super(version, response)
-            @call_page = []
-            @limit = limit
-            key = get_key(response.body)
-            records = 0
-            while (limit != :unset && records < limit)
-              @call_page << CallListResponse.new(version, @payload, key, limit - records)
-              @payload = self.next_page
-              break unless @payload
-
-              records += (@payload.body[key] || []).size
-            end
-            # Path Solution
-            @solution = solution
-          end
-
-          def each
-            @call_page.each do |record|
-              yield record
-            end
-          end
-
-          def to_s
-            '<Twilio::REST::FlexApi::V1PageMetadata>';
-          end
-        end
-
-        class CallListResponse < InstanceListResource
-          # @param [Array<CallInstance>] instance
-          # @param [Hash{String => Object}] headers
-          # @param [Integer] status_code
-          def initialize(version, payload, key, limit = :unset)
-            data_list = payload.body[key] || []
-            if limit != :unset
-              data_list = data_list[0, limit]
-            end
-            @call = data_list.map do |data|
-              CallInstance.new(version, data)
-            end
-            @headers = payload.headers
-            @status_code = payload.status_code
-          end
-
-          def call
-            @call
-          end
-
-          def headers
-            @headers
-          end
-
-          def status_code
-            @status_code
-          end
-        end
-
         class CallInstance < InstanceResource
           ##
           # Initialize the CallInstance

--- a/examples/ruby/lib/twilio-ruby/rest/flex_api/v1/credential.rb
+++ b/examples/ruby/lib/twilio-ruby/rest/flex_api/v1/credential.rb
@@ -89,66 +89,6 @@ module Twilio
           end
         end
 
-        class CredentialPageMetadata < PageMetadata
-          attr_reader :credential_page
-
-          def initialize(version, response, solution, limit)
-            super(version, response)
-            @credential_page = []
-            @limit = limit
-            key = get_key(response.body)
-            records = 0
-            while (limit != :unset && records < limit)
-              @credential_page << CredentialListResponse.new(version, @payload, key, limit - records)
-              @payload = self.next_page
-              break unless @payload
-
-              records += (@payload.body[key] || []).size
-            end
-            # Path Solution
-            @solution = solution
-          end
-
-          def each
-            @credential_page.each do |record|
-              yield record
-            end
-          end
-
-          def to_s
-            '<Twilio::REST::FlexApi::V1PageMetadata>';
-          end
-        end
-
-        class CredentialListResponse < InstanceListResource
-          # @param [Array<CredentialInstance>] instance
-          # @param [Hash{String => Object}] headers
-          # @param [Integer] status_code
-          def initialize(version, payload, key, limit = :unset)
-            data_list = payload.body[key] || []
-            if limit != :unset
-              data_list = data_list[0, limit]
-            end
-            @credential = data_list.map do |data|
-              CredentialInstance.new(version, data)
-            end
-            @headers = payload.headers
-            @status_code = payload.status_code
-          end
-
-          def credential
-            @credential
-          end
-
-          def headers
-            @headers
-          end
-
-          def status_code
-            @status_code
-          end
-        end
-
         class CredentialInstance < InstanceResource
           ##
           # Initialize the CredentialInstance

--- a/examples/ruby/lib/twilio-ruby/rest/flex_api/v1/credential/aws/history.rb
+++ b/examples/ruby/lib/twilio-ruby/rest/flex_api/v1/credential/aws/history.rb
@@ -185,66 +185,6 @@ module Twilio
               end
             end
 
-            class HistoryPageMetadata < PageMetadata
-              attr_reader :history_page
-
-              def initialize(version, response, solution, limit)
-                super(version, response)
-                @history_page = []
-                @limit = limit
-                key = get_key(response.body)
-                records = 0
-                while (limit != :unset && records < limit)
-                  @history_page << HistoryListResponse.new(version, @payload, key, limit - records)
-                  @payload = self.next_page
-                  break unless @payload
-
-                  records += (@payload.body[key] || []).size
-                end
-                # Path Solution
-                @solution = solution
-              end
-
-              def each
-                @history_page.each do |record|
-                  yield record
-                end
-              end
-
-              def to_s
-                '<Twilio::REST::FlexApi::V1PageMetadata>';
-              end
-            end
-
-            class HistoryListResponse < InstanceListResource
-              # @param [Array<HistoryInstance>] instance
-              # @param [Hash{String => Object}] headers
-              # @param [Integer] status_code
-              def initialize(version, payload, key, limit = :unset)
-                data_list = payload.body[key] || []
-                if limit != :unset
-                  data_list = data_list[0, limit]
-                end
-                @history = data_list.map do |data|
-                  HistoryInstance.new(version, data)
-                end
-                @headers = payload.headers
-                @status_code = payload.status_code
-              end
-
-              def history
-                @history
-              end
-
-              def headers
-                @headers
-              end
-
-              def status_code
-                @status_code
-              end
-            end
-
             class HistoryInstance < InstanceResource
               ##
               # Initialize the HistoryInstance

--- a/examples/ruby/lib/twilio-ruby/rest/flex_api/v1/credential/new_credentials.rb
+++ b/examples/ruby/lib/twilio-ruby/rest/flex_api/v1/credential/new_credentials.rb
@@ -215,67 +215,6 @@ module Twilio
             end
           end
 
-          class NewCredentialsPageMetadata < PageMetadata
-            attr_reader :new_credentials_page
-
-            def initialize(version, response, solution, limit)
-              super(version, response)
-              @new_credentials_page = []
-              @limit = limit
-              key = get_key(response.body)
-              records = 0
-              while (limit != :unset && records < limit)
-                @new_credentials_page << NewCredentialsListResponse.new(version, @payload, key,
-                                                                        limit - records)
-                @payload = self.next_page
-                break unless @payload
-
-                records += (@payload.body[key] || []).size
-              end
-              # Path Solution
-              @solution = solution
-            end
-
-            def each
-              @new_credentials_page.each do |record|
-                yield record
-              end
-            end
-
-            def to_s
-              '<Twilio::REST::FlexApi::V1PageMetadata>';
-            end
-          end
-
-          class NewCredentialsListResponse < InstanceListResource
-            # @param [Array<NewCredentialsInstance>] instance
-            # @param [Hash{String => Object}] headers
-            # @param [Integer] status_code
-            def initialize(version, payload, key, limit = :unset)
-              data_list = payload.body[key] || []
-              if limit != :unset
-                data_list = data_list[0, limit]
-              end
-              @new_credentials = data_list.map do |data|
-                NewCredentialsInstance.new(version, data)
-              end
-              @headers = payload.headers
-              @status_code = payload.status_code
-            end
-
-            def new_credentials
-              @new_credentials
-            end
-
-            def headers
-              @headers
-            end
-
-            def status_code
-              @status_code
-            end
-          end
-
           class NewCredentialsInstance < InstanceResource
             ##
             # Initialize the NewCredentialsInstance

--- a/examples/ruby/lib/twilio-ruby/rest/oauth/v2/token.rb
+++ b/examples/ruby/lib/twilio-ruby/rest/oauth/v2/token.rb
@@ -152,66 +152,6 @@ module Twilio
           end
         end
 
-        class TokenPageMetadata < PageMetadata
-          attr_reader :token_page
-
-          def initialize(version, response, solution, limit)
-            super(version, response)
-            @token_page = []
-            @limit = limit
-            key = get_key(response.body)
-            records = 0
-            while (limit != :unset && records < limit)
-              @token_page << TokenListResponse.new(version, @payload, key, limit - records)
-              @payload = self.next_page
-              break unless @payload
-
-              records += (@payload.body[key] || []).size
-            end
-            # Path Solution
-            @solution = solution
-          end
-
-          def each
-            @token_page.each do |record|
-              yield record
-            end
-          end
-
-          def to_s
-            '<Twilio::REST::Oauth::V2PageMetadata>';
-          end
-        end
-
-        class TokenListResponse < InstanceListResource
-          # @param [Array<TokenInstance>] instance
-          # @param [Hash{String => Object}] headers
-          # @param [Integer] status_code
-          def initialize(version, payload, key, limit = :unset)
-            data_list = payload.body[key] || []
-            if limit != :unset
-              data_list = data_list[0, limit]
-            end
-            @token = data_list.map do |data|
-              TokenInstance.new(version, data)
-            end
-            @headers = payload.headers
-            @status_code = payload.status_code
-          end
-
-          def token
-            @token
-          end
-
-          def headers
-            @headers
-          end
-
-          def status_code
-            @status_code
-          end
-        end
-
         class TokenInstance < InstanceResource
           ##
           # Initialize the TokenInstance

--- a/examples/ruby/lib/twilio-ruby/rest/versionless/deployed_devices/fleet.rb
+++ b/examples/ruby/lib/twilio-ruby/rest/versionless/deployed_devices/fleet.rb
@@ -97,11 +97,17 @@ module Twilio
 
           ##
           # Fetch the FleetInstance
+          # @param [String] page_token The page token. This is provided by the API. On a fetch operation this is a user-supplied query parameter and must be retained (unlike list operations, where paging is handled by the helper library).
           # @return [FleetInstance] Fetched FleetInstance
-          def fetch
+          def fetch(
+            page_token: :unset
+          )
+            params = Twilio::Values.of({
+                                         'PageToken' => page_token,
+                                       })
             headers = Twilio::Values.of({ 'Content-Type' => 'application/x-www-form-urlencoded', })
 
-            payload = @version.fetch('GET', @uri, headers: headers)
+            payload = @version.fetch('GET', @uri, params: params, headers: headers)
             FleetInstance.new(
               @version,
               payload,
@@ -111,11 +117,17 @@ module Twilio
 
           ##
           # Fetch the FleetInstanceMetadata
+          # @param [String] page_token The page token. This is provided by the API. On a fetch operation this is a user-supplied query parameter and must be retained (unlike list operations, where paging is handled by the helper library).
           # @return [FleetInstance] Fetched FleetInstance
-          def fetch_with_metadata
+          def fetch_with_metadata(
+            page_token: :unset
+          )
+            params = Twilio::Values.of({
+                                         'PageToken' => page_token,
+                                       })
             headers = Twilio::Values.of({ 'Content-Type' => 'application/x-www-form-urlencoded', })
 
-            response = @version.fetch_with_metadata('GET', @uri, headers: headers)
+            response = @version.fetch_with_metadata('GET', @uri, params: params, headers: headers)
             fleet_instance = FleetInstance.new(
               @version,
               response.body,
@@ -220,66 +232,6 @@ module Twilio
           end
         end
 
-        class FleetPageMetadata < PageMetadata
-          attr_reader :fleet_page
-
-          def initialize(version, response, solution, limit)
-            super(version, response)
-            @fleet_page = []
-            @limit = limit
-            key = get_key(response.body)
-            records = 0
-            while (limit != :unset && records < limit)
-              @fleet_page << FleetListResponse.new(version, @payload, key, limit - records)
-              @payload = self.next_page
-              break unless @payload
-
-              records += (@payload.body[key] || []).size
-            end
-            # Path Solution
-            @solution = solution
-          end
-
-          def each
-            @fleet_page.each do |record|
-              yield record
-            end
-          end
-
-          def to_s
-            '<Twilio::REST::Versionless::DeployedDevicesPageMetadata>';
-          end
-        end
-
-        class FleetListResponse < InstanceListResource
-          # @param [Array<FleetInstance>] instance
-          # @param [Hash{String => Object}] headers
-          # @param [Integer] status_code
-          def initialize(version, payload, key, limit = :unset)
-            data_list = payload.body[key] || []
-            if limit != :unset
-              data_list = data_list[0, limit]
-            end
-            @fleet = data_list.map do |data|
-              FleetInstance.new(version, data)
-            end
-            @headers = payload.headers
-            @status_code = payload.status_code
-          end
-
-          def fleet
-            @fleet
-          end
-
-          def headers
-            @headers
-          end
-
-          def status_code
-            @status_code
-          end
-        end
-
         class FleetInstance < InstanceResource
           ##
           # Initialize the FleetInstance
@@ -364,9 +316,14 @@ module Twilio
 
           ##
           # Fetch the FleetInstance
+          # @param [String] page_token The page token. This is provided by the API. On a fetch operation this is a user-supplied query parameter and must be retained (unlike list operations, where paging is handled by the helper library).
           # @return [FleetInstance] Fetched FleetInstance
-          def fetch
-            context.fetch
+          def fetch(
+            page_token: :unset
+          )
+            context.fetch(
+              page_token: page_token,
+            )
           end
 
           ##

--- a/src/main/resources/twilio-ruby/api.mustache
+++ b/src/main/resources/twilio-ruby/api.mustache
@@ -14,7 +14,9 @@ module Twilio
 {{>context}}
 {{/metaProperties.hasInstanceOperation}}
 {{>page}}
+{{#hasOperationWithPagination}}
 {{>pageMetadata}}
+{{/hasOperationWithPagination}}
 {{>instance}}
             end
         end

--- a/src/main/resources/twilio-ruby/list.mustache
+++ b/src/main/resources/twilio-ruby/list.mustache
@@ -84,6 +84,7 @@
                         result
                     end
 
+                    {{#vendorExtensions.x-supports-pagination}}
                     ##
                     # Lists {{apiName}}PageMetadata records from the API as a list.
                     {{#readParams}}
@@ -111,6 +112,7 @@
 
                         {{apiName}}PageMetadata.new(@version, response, @solution, limits[:limit])
                     end
+                    {{/vendorExtensions.x-supports-pagination}}
 
                     ##
                     # When passed a block, yields {{apiName}}Instance records from the API.

--- a/src/main/resources/twilio-ruby/parentContext.mustache
+++ b/src/main/resources/twilio-ruby/parentContext.mustache
@@ -7,7 +7,9 @@
 {{>context}}
 {{/metaProperties.hasInstanceOperation}}
 {{>page}}
+{{#hasOperationWithPagination}}
 {{>pageMetadata}}
+{{/hasOperationWithPagination}}
 {{>instance}}
             {{#parentDir}}
              end


### PR DESCRIPTION
Ruby templates always emitted the pagination-metadata scaffolding (list_with_metadata method and the {{apiName}}PageMetadata / {{apiName}}ListResponse classes) for every read operation, even when the List response has no `meta` key and therefore does not support pagination (e.g. ListProfileIdentifiers in Memory v1).

Node and Python already gate this on the x-supports-pagination (per-operation) and hasOperationWithPagination (per-resource) extensions computed in ApiResourceBuilder. Apply the same gating in the Ruby templates:
- list.mustache: wrap list_with_metadata in x-supports-pagination
- api.mustache / parentContext.mustache: wrap the pageMetadata partial in hasOperationWithPagination

Regenerated Ruby examples: this removes orphaned PageMetadata/ ListResponse classes that no list_with_metadata referenced.

Preview PR - https://github.com/twilio/twilio-ruby/pull/806

