### PR TITLE
fix: stop serializing null values for required fields in Go and PHP

### DIFF
--- a/examples/go/go-client/helper/rest/intelligence/v3/model_json_result.go
+++ b/examples/go/go-client/helper/rest/intelligence/v3/model_json_result.go
@@ -18,5 +18,5 @@ package openapi
 type JSONResult struct {
 	OutputFormat     OutputFormat           `json:"output_format"`
 	OperatorResultId string                 `json:"operator_result_id"`
-	Result           map[string]interface{} `json:"result"`
+	Result           map[string]interface{} `json:"result,omitempty"`
 }

--- a/src/main/java/com/twilio/oai/TwilioGoGenerator.java
+++ b/src/main/java/com/twilio/oai/TwilioGoGenerator.java
@@ -67,8 +67,25 @@ public class TwilioGoGenerator extends AbstractTwilioGoGenerator {
             model.allVars.forEach(v -> v.setIsNumber(v.isNumber || v.isFloat));
             model.vendorExtensions.put("x-has-numbers-vars", model.allVars.stream().anyMatch(v -> v.isNumber));
 
+            model.allVars.forEach(v -> v.vendorExtensions.put("x-go-omit-empty", omitEmpty(v)));
         }
         return results;
+    }
+
+    /**
+     * Decides whether a struct field gets the `omitempty` JSON tag.
+     *
+     * <p>Optional fields have always carried it. Required fields did not, which meant a required
+     * field the caller never populated was still serialized -- and for the nil-able Go types
+     * (slices, maps, pointers) that emits an explicit `null` into the request body rather than
+     * leaving the field out. Required nil-able fields therefore get `omitempty` as well.
+     *
+     * <p>Required scalars are deliberately left alone: their zero values (`""`, `0`, `false`)
+     * marshal as real JSON values rather than `null`, and omitting them would silently drop
+     * legitimate payload values such as a required `false`.
+     */
+    private boolean omitEmpty(final CodegenProperty property) {
+        return !property.required || property.isContainer || property.isNullable;
     }
 
     boolean containsAllOf(String modelName) {

--- a/src/main/resources/twilio-go/model_simple.mustache
+++ b/src/main/resources/twilio-go/model_simple.mustache
@@ -4,7 +4,7 @@ type {{classname}} struct {
 	{{#description}}
 		// {{{description}}}
 	{{/description}}
-	{{name}} {{#isNullable}}*{{/isNullable}}{{{vendorExtensions.x-go-base-type}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+	{{name}} {{#isNullable}}*{{/isNullable}}{{{vendorExtensions.x-go-base-type}}} `json:"{{baseName}}{{#vendorExtensions.x-go-omit-empty}},omitempty{{/vendorExtensions.x-go-omit-empty}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
 {{/allVars}}
 }
 

--- a/src/main/resources/twilio-php/models/modelClass.mustache
+++ b/src/main/resources/twilio-php/models/modelClass.mustache
@@ -22,10 +22,12 @@ class {{classname}} implements \JsonSerializable
     public function jsonSerialize(): array
     {
         $jsonString = [
-            {{#requiredVars}}
-            '{{baseName}}' => $this->{{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}}{{^-last}},{{/-last}}
-            {{/requiredVars}}
         ];
+        {{#requiredVars}}
+        if (isset($this->{{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}})) {
+            $jsonString['{{baseName}}'] = $this->{{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}};
+        }
+        {{/requiredVars}}
         {{#optionalVars}}
         if (isset($this->{{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}})) {
             $jsonString['{{baseName}}'] = $this->{{#lambda.camelcase}}{{baseName}}{{/lambda.camelcase}};


### PR DESCRIPTION
# Fixes [DII-2473](https://twilio-engineering.atlassian.net/browse/DII-2473)

Required model fields bypassed the null/omit guard in both the Go and PHP generators, so a required field the caller never populated was still written into the request body. For `PatchDataMapping` (Memory v1) that produced:

```json
{"displayName": "crm-contacts", "mappingTo": {"type": "", "mappings": null}}
```

even though the spec marks `mappings` as `required` and does **not** mark it `nullable`.

## What changed

**Go** — [`model_simple.mustache`](src/main/resources/twilio-go/model_simple.mustache) derived `omitempty` from `{{^required}}`, so required fields never got the tag and a nil slice/map/pointer marshalled as an explicit `null`. The decision now comes from an `x-go-omit-empty` vendor extension computed in `TwilioGoGenerator#omitEmpty`:

```java
return !property.required || property.isContainer || property.isNullable;
```

Required **nil-able** types (slices, maps, pointers) now get `omitempty` — those are exactly the ones whose zero value marshals to `null`. Required **scalars** are deliberately excluded: `""`/`0`/`false` marshal as real JSON values, and adding `omitempty` there would silently drop a legitimate required `false`.

**PHP** — [`modelClass.mustache`](src/main/resources/twilio-php/models/modelClass.mustache) wrote `requiredVars` into `$jsonString` unconditionally while only `optionalVars` got an `isset()` guard. Required vars now use the same guard.

## Verification

Generated `twilio_memory_v1` from twilio-oai and marshalled `DataMappingCore` exactly the way `PatchDataMapping` does (`json.Marshal(*params.DataMappingCore)` / `$dataMappingCore->toArray()`):

| Case | Before | After |
|---|---|---|
| Go, `mappingTo` zero value | `{"displayName":"crm-contacts","mappingTo":{"type":"","mappings":null}}` | `{"displayName":"crm-contacts","mappingTo":{"type":""}}` |
| Go, type set / mappings unset | `…{"type":"TRAITS","mappings":null}}` | `…{"type":"TRAITS"}}` |
| Go, fully populated | `…"mappings":[{…}]}` | unchanged ✓ |
| PHP, `mappingTo` empty | `{"…","mappingTo":{"type":null,"mappings":null}}` | `{"…","mappingTo":[]}` |
| PHP, type set | `…{"type":"TRAITS","mappings":null}}` | `…{"type":"TRAITS"}}` |

Audited the entire regenerated Memory output for remaining offenders — nil-able Go fields without `omitempty`, unguarded PHP `$jsonString` assignments — and found none. `make test` passes (30/30).

The `examples/` diff is a single line: `JSONResult.Result` is a required `map` that had the same defect. Required scalars beside it correctly keep their tags.

## Reviewer notes

Three things I found but deliberately did **not** change here:

1. **Go still emits an empty nested object.** `MappingTo DataMappingToTraits \`json:"mappingTo,omitempty"\`` — `omitempty` is a no-op on a struct *value* in `encoding/json`, so `{"mappingTo":{"type":""}}` is still sent for a field the caller never touched. Fixing it means generating optional model fields as `*DataMappingToTraits`, which is a **breaking change** to the twilio-go public API (`MappingTo: X{}` → `MappingTo: &X{}`). Worth a separate decision. PHP has no equivalent problem.
2. **PHP emits `[]` rather than `{}`** when every field is filtered out (see the `mappingTo` empty row). Pre-existing — all-optional models like `DataMappingCore` already behaved this way, confirmed against unpatched code — but this change widens which models can hit it. Arguably worse than nulls for an object-typed field; happy to fix in a follow-up.
3. **`twilio-go/rest/memory/v1` does not compile as committed** on `main` — unused imports (`fmt`, `bytes`, `client`) across many generated files. Reproduces from a fresh generation, so the `goimports` step in `scripts/generate.sh` isn't reaching that package in the twilio-go pipeline. Unrelated to this fix, but that package is currently unusable.

Also note: `mvn` needs `JAVA_HOME` pointed at JDK 17 — on JDK 26 Lombok 1.18.30 silently fails annotation processing and the build dies with phantom "cannot find symbol" errors.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] Run `make test-docker`
- [x] Verify affected language according to the code change:
    - [x] Generated Go and PHP from the [OpenAPI specification](https://github.com/twilio/twilio-oai) with `scripts/build_twilio_library.py` and inspected the diff
    - [x] Reproduced the bug and confirmed the fix against `twilio_memory_v1`
    - [ ] Create a pull request in the affected SDK repos
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-oai-generator/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added inline documentation to the code I modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
