### PR TITLE
fix: make C# Guid parameters/properties nullable when optional

### DIFF
--- a/examples/csharp/src/Twilio/Rest/Intelligence/V3/OperatorResultOptions.cs
+++ b/examples/csharp/src/Twilio/Rest/Intelligence/V3/OperatorResultOptions.cs
@@ -57,6 +57,9 @@ namespace Twilio.Rest.Intelligence.V3
     public class ReadOperatorResultOptions : ReadOptions<OperatorResultReadResource>
     {
     
+        ///<summary> Testing for uuid </summary> 
+        public Guid? UuidKey { get; set; }
+
 
 
 
@@ -74,6 +77,16 @@ namespace Twilio.Rest.Intelligence.V3
         }
 
     
+    /// <summary> Generate the necessary header parameters </summary>
+    public List<KeyValuePair<string, string>> GetHeaderParams()
+    {
+        var p = new List<KeyValuePair<string, string>>();
+        if (UuidKey != null)
+        {
+            p.Add(new KeyValuePair<string, string>("uuid-Key", UuidKey.ToString()));
+        }
+        return p;
+    }
 
     }
 

--- a/examples/csharp/src/Twilio/Rest/Intelligence/V3/OperatorResultResource.cs
+++ b/examples/csharp/src/Twilio/Rest/Intelligence/V3/OperatorResultResource.cs
@@ -243,7 +243,7 @@ namespace Twilio.Rest.Intelligence.V3
                 Rest.Domain.Intelligence,
                 path,
                 queryParams: options.GetParams(),
-                headerParams: null
+                headerParams: options.GetHeaderParams()
             );
         }
         /// <summary> read </summary>
@@ -273,31 +273,35 @@ namespace Twilio.Rest.Intelligence.V3
         }
         #endif
         /// <summary> read </summary>
+        /// <param name="uuidKey"> Testing for uuid </param>
         /// <param name="pageSize">  </param>
         /// <param name="limit"> Record limit </param>
         /// <param name="client"> Client to make requests to Twilio </param>
         /// <returns> A single instance of OperatorResult </returns>
         public static ResourceSet<OperatorResultReadResource> Read(
+                                                     Guid? uuidKey = null,
                                                      int? pageSize = null,
                                                      long? limit = null,
                                                     ITwilioRestClient client = null)
         {
-            var options = new ReadOperatorResultOptions(){ PageSize = pageSize, Limit = limit};
+            var options = new ReadOperatorResultOptions(){ UuidKey = uuidKey, PageSize = pageSize, Limit = limit};
             return Read(options, client);
         }
 
         #if !NET35
         /// <summary> read </summary>
+        /// <param name="uuidKey"> Testing for uuid </param>
         /// <param name="pageSize">  </param>
         /// <param name="limit"> Record limit </param>
         /// <param name="client"> Client to make requests to Twilio </param>
         /// <returns> Task that resolves to A single instance of OperatorResult </returns>
         public static async System.Threading.Tasks.Task<ResourceSet<OperatorResultReadResource>> ReadAsync(
+                                                                                             Guid? uuidKey = null,
                                                                                              int? pageSize = null,
                                                                                              long? limit = null,
                                                                                             ITwilioRestClient client = null)
         {
-            var options = new ReadOperatorResultOptions(){ PageSize = pageSize, Limit = limit};
+            var options = new ReadOperatorResultOptions(){ UuidKey = uuidKey, PageSize = pageSize, Limit = limit};
             return await ReadAsync(options, client);
         }
         #endif
@@ -312,11 +316,12 @@ namespace Twilio.Rest.Intelligence.V3
         }
 
         public static ResourceSetResponse<OperatorResultReadResource> ReadWithHeaders(
+            Guid? uuidKey = null,
             int? pageSize = null,
             long? limit = null,
             ITwilioRestClient client = null)
         {
-            var options = new ReadOperatorResultOptions(){ PageSize = pageSize, Limit = limit};
+            var options = new ReadOperatorResultOptions(){ UuidKey = uuidKey, PageSize = pageSize, Limit = limit};
             return ReadWithHeaders(options, client);
         }
 

--- a/examples/go/go-client/helper/rest/intelligence/v3/model_classification_result.go
+++ b/examples/go/go-client/helper/rest/intelligence/v3/model_classification_result.go
@@ -18,5 +18,5 @@ package openapi
 type ClassificationResult struct {
 	OutputFormat     OutputFormat                `json:"output_format"`
 	OperatorResultId string                      `json:"operator_result_id"`
-	Result           *ClassificationResultResult `json:"result"`
+	Result           *ClassificationResultResult `json:"result,omitempty"`
 }

--- a/examples/go/go-client/helper/rest/intelligence/v3/model_extraction_result.go
+++ b/examples/go/go-client/helper/rest/intelligence/v3/model_extraction_result.go
@@ -18,5 +18,5 @@ package openapi
 type ExtractionResult struct {
 	OutputFormat     OutputFormat            `json:"output_format"`
 	OperatorResultId string                  `json:"operator_result_id"`
-	Result           *ExtractionResultResult `json:"result"`
+	Result           *ExtractionResultResult `json:"result,omitempty"`
 }

--- a/examples/go/go-client/helper/rest/intelligence/v3/model_operator_results_response_v1.go
+++ b/examples/go/go-client/helper/rest/intelligence/v3/model_operator_results_response_v1.go
@@ -18,5 +18,5 @@ package openapi
 type OperatorResultsResponseV1 struct {
 	OutputFormat     OutputFormat            `json:"output_format"`
 	OperatorResultId string                  `json:"operator_result_id"`
-	Result           *ExtractionResultResult `json:"result"`
+	Result           *ExtractionResultResult `json:"result,omitempty"`
 }

--- a/examples/go/go-client/helper/rest/intelligence/v3/model_text_result.go
+++ b/examples/go/go-client/helper/rest/intelligence/v3/model_text_result.go
@@ -18,5 +18,5 @@ package openapi
 type TextResult struct {
 	OutputFormat     OutputFormat      `json:"output_format"`
 	OperatorResultId string            `json:"operator_result_id"`
-	Result           *TextResultResult `json:"result"`
+	Result           *TextResultResult `json:"result,omitempty"`
 }

--- a/examples/go/go-client/helper/rest/intelligence/v3/operator_results.go
+++ b/examples/go/go-client/helper/rest/intelligence/v3/operator_results.go
@@ -81,12 +81,18 @@ func (c *ApiService) FetchOperatorResultWithMetadata(OperatorResultId string) (*
 
 // Optional parameters for the method 'ListOperatorResults'
 type ListOperatorResultsParams struct {
+	// Testing for uuid
+	UuidKey *string `json:"uuid-Key,omitempty"`
 	//
 	PageSize *int `json:"PageSize,omitempty"`
 	// Max number of records to return.
 	Limit *int `json:"limit,omitempty"`
 }
 
+func (params *ListOperatorResultsParams) SetUuidKey(UuidKey string) *ListOperatorResultsParams {
+	params.UuidKey = &UuidKey
+	return params
+}
 func (params *ListOperatorResultsParams) SetPageSize(PageSize int) *ListOperatorResultsParams {
 	params.PageSize = &PageSize
 	return params

--- a/examples/java/src/main/java/com/twilio/rest/intelligence/v3/OperatorResultReader.java
+++ b/examples/java/src/main/java/com/twilio/rest/intelligence/v3/OperatorResultReader.java
@@ -31,6 +31,7 @@ import com.twilio.http.TwilioRestClient;
 import com.twilio.rest.Domains;
 
 import java.io.InputStream;
+import java.util.UUID;
 import com.twilio.type.*;
 
 import com.twilio.base.Page;
@@ -40,6 +41,7 @@ import com.twilio.base.ResourceSet;
 public class OperatorResultReader extends Reader<OperatorResult.ListOperatorResultResponse> {
 
         private Integer pageSize;
+    private UUID uuidKey;
 
         public OperatorResultReader() {
     }
@@ -47,6 +49,12 @@ public class OperatorResultReader extends Reader<OperatorResult.ListOperatorResu
     
 public OperatorResultReader setPageSize(final Integer pageSize){
     this.pageSize = pageSize;
+    return this;
+}
+
+
+public OperatorResultReader setUuidKey(final UUID uuidKey){
+    this.uuidKey = uuidKey;
     return this;
 }
 
@@ -76,6 +84,7 @@ public OperatorResultReader setPageSize(final Integer pageSize){
             path
         );
         addQueryParams(request);
+        addHeaderParams(request);
         return request;
     }
     
@@ -194,4 +203,11 @@ private Page<OperatorResult.ListOperatorResultResponse> pageForRequest(final Twi
 }
 
 
+    private void addHeaderParams(final Request request) {
+
+    if (uuidKey != null) {
+        Serializer.toString(request, "uuid-Key", uuidKey, ParameterType.HEADER);
+    }
+
+}
 }

--- a/examples/node/src/rest/intelligence/v3/operatorResult.ts
+++ b/examples/node/src/rest/intelligence/v3/operatorResult.ts
@@ -51,6 +51,8 @@ export type OutputFormat = 'TEXT'|'JSON'|'CLASSIFICATION'|'EXTRACTION';
  * Options to pass to each
  */
 export interface OperatorResultListInstanceEachOptions {
+  /** Testing for uuid */
+  "uuidKey"?: string;
   /**  */
   "pageSize"?: number;
   /** Function to process each record. If this and a positional callback are passed, this one will be used */
@@ -65,6 +67,8 @@ export interface OperatorResultListInstanceEachOptions {
  * Options to pass to list
  */
 export interface OperatorResultListInstanceOptions {
+  /** Testing for uuid */
+  "uuidKey"?: string;
   /**  */
   "pageSize"?: number;
   /** Upper limit for the number of records to return. list() guarantees never to return more than limit. Default is no limit */
@@ -76,6 +80,8 @@ export interface OperatorResultListInstanceOptions {
  * Options to pass to page
  */
 export interface OperatorResultListInstancePageOptions {
+  /** Testing for uuid */
+  "uuidKey"?: string;
   /**  */
   "pageSize"?: number;
 }
@@ -410,6 +416,7 @@ export function OperatorResultListInstance(version: V3): OperatorResultListInsta
     
     const headers: any = {};
     headers["Accept"] = "application/json"
+    if (params["uuidKey"] !== undefined) headers["uuid-Key"] = params["uuidKey"];
 
     let operationVersion = version,
         operationPromise = operationVersion.page({ uri: instance._uri, method: "get", params: data, headers});
@@ -455,6 +462,7 @@ export function OperatorResultListInstance(version: V3): OperatorResultListInsta
     
     const headers: any = {};
     headers["Accept"] = "application/json"
+    if (params["uuidKey"] !== undefined) headers["uuid-Key"] = params["uuidKey"];
 
     let operationVersion = version;
     

--- a/examples/spec/twilio_intelligence_v3.yaml
+++ b/examples/spec/twilio_intelligence_v3.yaml
@@ -152,6 +152,13 @@ paths:
       security:
         - accountSid_authToken: []
       parameters:
+        - in: header
+          name: uuid-Key
+          required: false
+          description: 'Testing for uuid'
+          schema:
+            type: string
+            format: uuid
         - name: PageSize
           in: query
           schema:

--- a/src/main/resources/config/csharp.json
+++ b/src/main/resources/config/csharp.json
@@ -48,6 +48,7 @@
         "http-method": "Twilio.Http.HttpMethod",
         "int": "int?",
         "long": "long?",
+        "uuid": "Guid?",
         "uri": "Uri",
         "uri-map": "Dictionary<string, string>",
         "string-map": "Dictionary<string, string>",

--- a/src/test/java/com/twilio/oai/TwilioGeneratorTest.java
+++ b/src/test/java/com/twilio/oai/TwilioGeneratorTest.java
@@ -29,13 +29,13 @@ public class TwilioGeneratorTest {
     @Parameterized.Parameters
     public static Collection<Generator> generators() {
         return Arrays.asList(
-//            Generator.TWILIO_JAVA,
-            Generator.TWILIO_CSHARP
-//            Generator.TWILIO_PYTHON,
-//            Generator.TWILIO_NODE,
- //           Generator.TWILIO_RUBY,
-//            Generator.TWILIO_GO,
-//            Generator.TWILIO_PHP
+                Generator.TWILIO_JAVA,
+                Generator.TWILIO_CSHARP,
+                Generator.TWILIO_PYTHON,
+                Generator.TWILIO_NODE,
+                Generator.TWILIO_RUBY,
+                Generator.TWILIO_GO,
+                Generator.TWILIO_PHP
         );
     }
 
@@ -48,7 +48,7 @@ public class TwilioGeneratorTest {
 
     @Test
     public void launchGenerator() {
-        final String pathname = "/Users/sbansla/Documents/code/twilio-oai/spec/json/twilio_insights_v3.yaml";
+        final String pathname = "examples/spec/twilio_api_v2010.yaml";
         File filesList[];
         File directoryPath = new File(pathname);
         if (directoryPath.isDirectory()) {

--- a/src/test/java/com/twilio/oai/TwilioGeneratorTest.java
+++ b/src/test/java/com/twilio/oai/TwilioGeneratorTest.java
@@ -30,10 +30,10 @@ public class TwilioGeneratorTest {
     public static Collection<Generator> generators() {
         return Arrays.asList(
 //            Generator.TWILIO_JAVA,
-//            Generator.TWILIO_CSHARP,
+            Generator.TWILIO_CSHARP
 //            Generator.TWILIO_PYTHON,
 //            Generator.TWILIO_NODE,
-            Generator.TWILIO_RUBY//,
+ //           Generator.TWILIO_RUBY,
 //            Generator.TWILIO_GO,
 //            Generator.TWILIO_PHP
         );
@@ -48,7 +48,7 @@ public class TwilioGeneratorTest {
 
     @Test
     public void launchGenerator() {
-        final String pathname = "/Users/manisingh/github/twilio/twilio-oai/spec/yaml/twilio_memory_v1.yaml";
+        final String pathname = "/Users/sbansla/Documents/code/twilio-oai/spec/json/twilio_insights_v3.yaml";
         File filesList[];
         File directoryPath = new File(pathname);
         if (directoryPath.isDirectory()) {


### PR DESCRIPTION
- Adds a "uuid": "Guid?" entry to the properties type map in src/main/resources/config/csharp.json, following the same pattern already used for other C# value types (int, bool, decimal, float, double, date, etc.).

C# Before Fix
Guid idempotencyKey = null

C# After Fix
Guid? idempotencyKey = null