### PR TITLE
fix: skip Ruby pagination for v1 list operations without response meta

### DIFF
--- a/src/main/resources/twilio-ruby/api.mustache
+++ b/src/main/resources/twilio-ruby/api.mustache
@@ -13,7 +13,14 @@ module Twilio
 {{#metaProperties.hasInstanceOperation}}
 {{>context}}
 {{/metaProperties.hasInstanceOperation}}
+{{^isApiV1}}
 {{>page}}
+{{/isApiV1}}
+{{#isApiV1}}
+{{#hasOperationWithPagination}}
+{{>page}}
+{{/hasOperationWithPagination}}
+{{/isApiV1}}
 {{#hasOperationWithPagination}}
 {{>pageMetadata}}
 {{/hasOperationWithPagination}}

--- a/src/main/resources/twilio-ruby/list.mustache
+++ b/src/main/resources/twilio-ruby/list.mustache
@@ -30,6 +30,37 @@
                 {{/vendorExtensions.listOperation}}
                 {{/apiOperations}}
                 {{#operations}}{{#vendorExtensions.x-is-read-operation}}
+                    {{^vendorExtensions.x-supports-pagination}}
+                    ##
+                    # Lists {{apiName}}Instance records from the API as a list.
+                    # This endpoint does not paginate; every record is returned by a single request.
+                    {{#readParams}}
+                    # @param [{{dataType}}] {{paramName}} {{{description}}}
+                    {{/readParams}}
+                    {{#readHeaderParams}}
+                    # @param [{{dataType}}] {{paramName}} {{{description}}}
+                    {{/readHeaderParams}}
+                    # @return [Array] Array of {{apiName}}Instance
+                    def list{{#readParams.0}}({{#readParams}}{{>params}}{{/readParams}}{{#readHeaderParams.0}}, {{#readHeaderParams}}{{>params}}{{/readHeaderParams}}{{/readHeaderParams.0}}){{/readParams.0}}{{^readParams.0}}{{#readHeaderParams.0}}({{#readHeaderParams}}{{>params}}{{/readHeaderParams}}){{/readHeaderParams.0}}{{/readParams.0}}
+                        params = Twilio::Values.of({
+                            {{#readParams}}{{^vendorExtensions.x-serialize}}'{{{baseName}}}' => {{paramName}},
+                            {{/vendorExtensions.x-serialize}}{{#vendorExtensions.x-serialize}}{{^vendorExtensions.isList}}'{{{baseName}}}' =>  {{vendorExtensions.x-serialize}}({{paramName}}),{{/vendorExtensions.isList}}
+                            {{#vendorExtensions.isList}}'{{{baseName}}}' =>  {{vendorExtensions.x-serialize}}({{paramName}}) { |e| e },
+                            {{/vendorExtensions.isList}}{{/vendorExtensions.x-serialize}}{{/readParams}}
+                        })
+                        headers = Twilio::Values.of({{#readHeaderParams.0}}{ {{#readHeaderParams}}'{{baseName}}' => {{paramName}}, {{/readHeaderParams}} }{{/readHeaderParams.0}}{{^readHeaderParams.0}}{}{{/readHeaderParams.0}})
+                        {{#vendorExtensions.scimConsumes}}headers['Content-Type'] = 'application/scim+json'{{/vendorExtensions.scimConsumes}}
+                        {{#vendorExtensions.scimProduces}}headers['Accept'] = 'application/scim+json'{{/vendorExtensions.scimProduces}}
+
+                        payload = @version.fetch('{{httpMethod}}', @uri, params: params, headers: headers)
+
+                        records = payload['{{recordKey}}'] || []
+                        records.map do |record|
+                            {{apiName}}Instance.new(@version, record{{#listPathParams}}, {{paramName}}: @solution[:{{paramName}}]{{/listPathParams}})
+                        end
+                    end
+                    {{/vendorExtensions.x-supports-pagination}}
+                    {{#vendorExtensions.x-supports-pagination}}
                     ##
                     # Lists {{apiName}}Instance records from the API as a list.
                     # Unlike stream(), this operation is eager and will load `limit` records into
@@ -96,7 +127,6 @@
                         result
                     end
 
-                    {{#vendorExtensions.x-supports-pagination}}
                     ##
                     # Lists {{apiName}}PageMetadata records from the API as a list.
                     {{#readParams}}
@@ -127,7 +157,6 @@
 
                         {{apiName}}PageMetadata.new(@version, response, @solution, limits[:limit])
                     end
-                    {{/vendorExtensions.x-supports-pagination}}
 
                     ##
                     # When passed a block, yields {{apiName}}Instance records from the API.
@@ -191,6 +220,7 @@
                         )
                     {{apiName}}Page.new(@version, response, @solution)
                     end
+                    {{/vendorExtensions.x-supports-pagination}}
                     {{/vendorExtensions.x-is-read-operation}}{{/operations}}
 
                 {{#metaProperties.listImportProperties}}

--- a/src/main/resources/twilio-ruby/parentContext.mustache
+++ b/src/main/resources/twilio-ruby/parentContext.mustache
@@ -6,7 +6,14 @@
 {{#metaProperties.hasInstanceOperation}}
 {{>context}}
 {{/metaProperties.hasInstanceOperation}}
+{{^isApiV1}}
 {{>page}}
+{{/isApiV1}}
+{{#isApiV1}}
+{{#hasOperationWithPagination}}
+{{>page}}
+{{/hasOperationWithPagination}}
+{{/isApiV1}}
 {{#hasOperationWithPagination}}
 {{>pageMetadata}}
 {{/hasOperationWithPagination}}


### PR DESCRIPTION
## Problem

API v1 standard specs (`x-twilio.apiStandards: v1.0`) use token-based pagination. The generated `XPage` subclasses `TokenPage`, and `TokenPage` is strictly token-based:

- `load_page` reads `payload['meta']['key']` and **raises `'Page Records can not be deserialized'`** when `meta` is absent
- `next_page_url` requires `meta.nextToken`

So a v1 list endpoint whose response has no `meta` was generating `list` / `stream` / `each` / `page` / `get_page` that all funnel into `TokenPage` and **raise on the first call**.

`ListProfileIdentifiers` in `twilio_memory_v1.yaml` is exactly such an endpoint — it returns a bare `{identifiers: [...]}` capped at `maxItems: 50`, with no `meta`.

For contrast, non-v1 specs subclass plain `Page`, whose `load_page` falls back to "the one payload key that isn't a meta key" and whose next/prev come from `next_page_uri` / `meta.next_page_url`. Pagination always works there, which is why this only bites v1.

## Fix

The generator **already** computes this signal: `ApiResourceBuilder.mapOperation` sets

```java
boolean supportsPagination = !isApiV1 || hasMetaInResponse(operation);
operationMap.put("x-supports-pagination", supportsPagination);
```

It was added for the Node generator; the Ruby templates simply weren't consuming it. **No Java changes were needed.**

- **`list.mustache`** — split the read operation on `x-supports-pagination`. The paginated branch is unchanged (and now also encloses `list_with_metadata`, which previously had its own redundant inner guard). The new branch emits a single non-paginating `list`:

  ```ruby
  def list
      params = Twilio::Values.of({})
      headers = Twilio::Values.of({})
      payload = @version.fetch('GET', @uri, params: params, headers: headers)
      records = payload['identifiers'] || []
      records.map do |record|
          IdentifierInstance.new(@version, record, store_id: @solution[:store_id], profile_id: @solution[:profile_id])
      end
  end
  ```

  No `stream`, `each`, `page`, or `get_page`.

- **`parentContext.mustache` / `api.mustache`** — skip the `XPage` class entirely for v1 resources with no paginating operation. Non-v1 keeps emitting it unconditionally.

This mirrors what twilio-node already does for the same case: `operation.mustache` calls `fetch` and maps `payload[recordKey]` when `x-supports-pagination` is false.

## Verification

A/B generated baseline vs. patched Ruby across **all eight** v1-standard specs (`intelligence_v3`, `insights_v3`, `numbers_v3`, `voice_v3`, `knowledge_v2`, `memory_v1`, `conversations_v2`, `routes_v3` — 47 files) plus `examples/spec`:

| Scope | Result |
| --- | --- |
| `examples/spec` and all non-v1 output | **byte-identical** |
| The 9 memory resources that *do* have `meta` | **byte-identical** — `TokenPage` and `list_with_metadata` retained |
| `memory/v1/identifier.rb` | pagination replaced by the single-request `list` |
| 15 other v1 files | only lost a dead `XPage < TokenPage` class — those resources have no list operation, so nothing referenced them |

Across every v1 file, the *only* added lines are `identifier.rb`'s new `list`. All 47 generated files pass `ruby -c`, and `mvn clean package` is green (30 tests).

## Notes for the reviewer

- The `def list` signature uses the same nested `{{#readParams.0}}` / `{{#readHeaderParams.0}}` dance as the existing paginated `list` in the same file, so that a no-argument case emits `def list` rather than `def list()`.
- Separate, pre-existing, **not** addressed here: generated v1 instance classes read response fields with snake_case keys (`payload['id_type']`) while v1 APIs return camelCase (`idType`), and nothing in twilio-ruby converts keys — so those properties look like they're always `nil`. twilio-php handles this with an `isApiV1` → `baseName` conditional that the Ruby instance template lacks. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
