### PR TITLE
fix: serialize the Java reader page size once, via the parent Reader

### DIFF
--- a/examples/java/src/main/java/com/twilio/rest/api/v2010/AccountReader.java
+++ b/examples/java/src/main/java/com/twilio/rest/api/v2010/AccountReader.java
@@ -43,7 +43,6 @@ public class AccountReader extends Reader<Account> {
     private LocalDate dateTest;
     private ZonedDateTime dateCreatedBefore;
     private ZonedDateTime dateCreatedAfter;
-    private Integer pageSize;
 
         public AccountReader() {
     }
@@ -74,10 +73,11 @@ public AccountReader setDateCreatedAfter(final ZonedDateTime dateCreatedAfter){
 
 
 public AccountReader setPageSize(final Integer pageSize){
-    this.pageSize = pageSize;
+    if (pageSize != null) {
+        super.pageSize(pageSize.intValue());
+    }
     return this;
 }
-
 
     
     public ResourceSetResponse<Account> readWithResponse(final TwilioRestClient client) {
@@ -197,15 +197,6 @@ private Page<Account> pageForRequest(final TwilioRestClient client, final Reques
 
     
     
-    
-
-
-    if (pageSize != null) {
-        Serializer.toString(request, "PageSize", pageSize, ParameterType.QUERY);
-    }
-
-
-
     
     if (getPageSize() != null) {
         request.addQueryParam("PageSize", Integer.toString(getPageSize()));

--- a/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/AwsReader.java
+++ b/examples/java/src/main/java/com/twilio/rest/flexapi/v1/credential/AwsReader.java
@@ -17,8 +17,6 @@ package com.twilio.rest.flexapi.v1.credential;
 import com.twilio.base.Reader;
 import com.twilio.base.ResourceSetResponse;
 import com.twilio.base.TwilioResponse;
-import com.twilio.constant.EnumConstants.ParameterType;
-import com.twilio.converter.Serializer;
 import com.twilio.exception.ApiConnectionException;
 import com.twilio.exception.ApiException;
 import com.twilio.exception.RestException;
@@ -37,17 +35,17 @@ import com.twilio.base.ResourceSet;
 
 public class AwsReader extends Reader<Aws> {
 
-        private Integer pageSize;
-
+    
         public AwsReader() {
     }
 
     
 public AwsReader setPageSize(final Integer pageSize){
-    this.pageSize = pageSize;
+    if (pageSize != null) {
+        super.pageSize(pageSize.intValue());
+    }
     return this;
 }
-
 
     
     public ResourceSetResponse<Aws> readWithResponse(final TwilioRestClient client) {
@@ -150,15 +148,6 @@ private Page<Aws> pageForRequest(final TwilioRestClient client, final Request re
     }
 
     private void addQueryParams(final Request request) {
-
-
-    if (pageSize != null) {
-        Serializer.toString(request, "PageSize", pageSize, ParameterType.QUERY);
-    }
-
-
-
-    
     if (getPageSize() != null) {
         request.addQueryParam("PageSize", Integer.toString(getPageSize()));
     }

--- a/examples/java/src/main/java/com/twilio/rest/intelligence/v3/OperatorResultReader.java
+++ b/examples/java/src/main/java/com/twilio/rest/intelligence/v3/OperatorResultReader.java
@@ -40,24 +40,24 @@ import com.twilio.base.ResourceSet;
 
 public class OperatorResultReader extends Reader<OperatorResult.ListOperatorResultResponse> {
 
-        private Integer pageSize;
-    private UUID uuidKey;
+        private UUID uuidKey;
 
         public OperatorResultReader() {
     }
 
     
-public OperatorResultReader setPageSize(final Integer pageSize){
-    this.pageSize = pageSize;
-    return this;
-}
-
-
 public OperatorResultReader setUuidKey(final UUID uuidKey){
     this.uuidKey = uuidKey;
     return this;
 }
 
+
+public OperatorResultReader setPageSize(final Integer pageSize){
+    if (pageSize != null) {
+        super.pageSize(pageSize.intValue());
+    }
+    return this;
+}
 
     
     public ResourceSetResponse<OperatorResult.ListOperatorResultResponse> readWithResponse(final TwilioRestClient client) {
@@ -188,15 +188,6 @@ private Page<OperatorResult.ListOperatorResultResponse> pageForRequest(final Twi
     }
 
     private void addQueryParams(final Request request) {
-
-
-    if (pageSize != null) {
-        Serializer.toString(request, "PageSize", pageSize, ParameterType.QUERY);
-    }
-
-
-
-    
     if (getPageSize() != null) {
         request.addQueryParam("PageSize", Integer.toString(getPageSize()));
     }

--- a/examples/java/src/main/java/com/twilio/rest/versionless/understand/AssistantReader.java
+++ b/examples/java/src/main/java/com/twilio/rest/versionless/understand/AssistantReader.java
@@ -17,8 +17,6 @@ package com.twilio.rest.versionless.understand;
 import com.twilio.base.Reader;
 import com.twilio.base.ResourceSetResponse;
 import com.twilio.base.TwilioResponse;
-import com.twilio.constant.EnumConstants.ParameterType;
-import com.twilio.converter.Serializer;
 import com.twilio.exception.ApiConnectionException;
 import com.twilio.exception.ApiException;
 import com.twilio.exception.RestException;
@@ -37,17 +35,17 @@ import com.twilio.base.ResourceSet;
 
 public class AssistantReader extends Reader<Assistant> {
 
-        private Integer pageSize;
-
+    
         public AssistantReader() {
     }
 
     
 public AssistantReader setPageSize(final Integer pageSize){
-    this.pageSize = pageSize;
+    if (pageSize != null) {
+        super.pageSize(pageSize.intValue());
+    }
     return this;
 }
-
 
     
     public ResourceSetResponse<Assistant> readWithResponse(final TwilioRestClient client) {
@@ -150,15 +148,6 @@ private Page<Assistant> pageForRequest(final TwilioRestClient client, final Requ
     }
 
     private void addQueryParams(final Request request) {
-
-
-    if (pageSize != null) {
-        Serializer.toString(request, "PageSize", pageSize, ParameterType.QUERY);
-    }
-
-
-
-    
     if (getPageSize() != null) {
         request.addQueryParam("PageSize", Integer.toString(getPageSize()));
     }

--- a/src/main/java/com/twilio/oai/java/feature/PageSizeParameter.java
+++ b/src/main/java/com/twilio/oai/java/feature/PageSizeParameter.java
@@ -1,0 +1,86 @@
+package com.twilio.oai.java.feature;
+
+import com.twilio.oai.common.EnumConstants.SupportedOperation;
+import org.openapitools.codegen.CodegenOperation;
+import org.openapitools.codegen.CodegenParameter;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * The base `Reader` class in twilio-java already owns the page size: `pageSize(int)` and `limit(long)`
+ * store it and `getPageSize()` is what `addQueryParams` puts on the wire. When the spec of a list
+ * operation also declares a page-size query parameter, the generated reader kept a second copy of it and
+ * serialized that one as well, so a reader could send the page size twice (DII-2465).
+ *
+ * This feature makes the parent the only owner of the value. The spec's page-size query parameter is
+ * taken out of `queryParams`, which stops the per-parameter serialization from being generated for it,
+ * and its name is handed to the templates for the single `getPageSize()` query parameter they emit. That
+ * name is used verbatim: classic APIs spell it `PageSize` and API v1 spells it `pageSize`; the two are
+ * distinct query parameters on the wire, so the spelling from the spec has to survive.
+ *
+ * The setter generated for the removed parameter is kept - it now writes through to the parent.
+ */
+public class PageSizeParameter {
+
+    /** The page-size query parameter removed from `queryParams`, for the write-through setter. */
+    public static final String PAGE_SIZE_PARAM = "x-page-size-param";
+    /** Name to serialize `getPageSize()` under. */
+    public static final String PAGE_SIZE_QUERY_NAME = "x-page-size-query-name";
+    /** Whether the reader should call `addQueryParams`, i.e. whether the spec declared any query parameter. */
+    public static final String ADD_QUERY_PARAMS = "x-add-query-params";
+
+    /**
+     * Readers of operations whose spec declares no page-size parameter keep sending `PageSize`: several
+     * classic list endpoints accept it without declaring it.
+     */
+    private static final String DEFAULT_PAGE_SIZE_QUERY_NAME = "PageSize";
+    private static final String PAGE_SIZE_BASE_NAME = "pagesize";
+    /** The write-through setter calls `intValue()`, so only numeric page sizes can be delegated. */
+    private static final List<String> DELEGATABLE_DATA_TYPES = List.of("Integer", "Long");
+
+    public static PageSizeParameter instance;
+
+    private PageSizeParameter() { }
+
+    public static synchronized PageSizeParameter getInstance() {
+        if (instance == null) {
+            instance = new PageSizeParameter();
+        }
+        return instance;
+    }
+
+    public void apply(final CodegenOperation codegenOperation) {
+        if (!Boolean.TRUE.equals(codegenOperation.vendorExtensions.get(SupportedOperation.X_LIST.getValue()))) {
+            return;
+        }
+        // Recorded before the removal below: an operation whose only query parameter is the page size
+        // still has to call addQueryParams, otherwise the page size would not be sent at all.
+        codegenOperation.vendorExtensions.put(ADD_QUERY_PARAMS, !codegenOperation.queryParams.isEmpty());
+
+        Optional<CodegenParameter> pageSizeParam = codegenOperation.queryParams
+                .stream()
+                .filter(PageSizeParameter::isDelegatablePageSize)
+                .findFirst();
+        codegenOperation.vendorExtensions.put(PAGE_SIZE_QUERY_NAME,
+                pageSizeParam.map(param -> param.baseName).orElse(DEFAULT_PAGE_SIZE_QUERY_NAME));
+        pageSizeParam.ifPresent(param -> {
+            codegenOperation.queryParams = codegenOperation.queryParams
+                    .stream()
+                    .filter(queryParam -> queryParam != param)
+                    .collect(Collectors.toList());
+            codegenOperation.vendorExtensions.put(PAGE_SIZE_PARAM, param);
+        });
+    }
+
+    /**
+     * A required page size would be a constructor argument, which the reader has to keep a field for, so
+     * it is left alone. No spec declares one today.
+     */
+    private static boolean isDelegatablePageSize(final CodegenParameter param) {
+        return PAGE_SIZE_BASE_NAME.equalsIgnoreCase(param.baseName)
+                && DELEGATABLE_DATA_TYPES.contains(param.dataType)
+                && !param.required;
+    }
+}

--- a/src/main/java/com/twilio/oai/java/processor/JavaOperationProcessor.java
+++ b/src/main/java/com/twilio/oai/java/processor/JavaOperationProcessor.java
@@ -3,6 +3,7 @@ package com.twilio.oai.java.processor;
 import com.twilio.oai.common.ApplicationConstants;
 import com.twilio.oai.java.cache.ResourceCacheContext;
 import com.twilio.oai.java.feature.Inequality;
+import com.twilio.oai.java.feature.PageSizeParameter;
 import com.twilio.oai.java.feature.SetterMethodGenerator;
 import com.twilio.oai.java.feature.constructor.ConstructorFactory;
 import com.twilio.oai.java.format.Promoter;
@@ -38,6 +39,8 @@ public class JavaOperationProcessor {
 
         // All Features should be applied after processors are completed
         ConstructorFactory.getInstance().applyFeature(codegenOperation);
+        // Must run before the setters are collected: it takes the page-size parameter out of queryParams.
+        PageSizeParameter.getInstance().apply(codegenOperation);
         SetterMethodGenerator.getInstance().apply(codegenOperation);
         Inequality.getInstance().process(codegenOperation);
         Promoter.addPromoter(codegenOperation);

--- a/src/main/resources/twilio-java/common/addQueryParams.mustache
+++ b/src/main/resources/twilio-java/common/addQueryParams.mustache
@@ -32,9 +32,12 @@ private void addQueryParams(final Request request) {
 {{/vendorExtensions.x-has-before-or-after}}
     
 {{/queryParams}}
-{{#vendorExtensions.x-list-operation}}
+{{! -- The page size is owned by the parent Reader, so it is serialized once, here. Set on list
+       operations only, x-page-size-query-name holds the spelling the spec uses: PageSize for classic
+       APIs, pageSize for API v1 - they are not the same query parameter.}}
+{{#vendorExtensions.x-page-size-query-name}}
     if (getPageSize() != null) {
-        request.addQueryParam("PageSize", Integer.toString(getPageSize()));
+        request.addQueryParam("{{{.}}}", Integer.toString(getPageSize()));
     }
-{{/vendorExtensions.x-list-operation}}
+{{/vendorExtensions.x-page-size-query-name}}
 }

--- a/src/main/resources/twilio-java/reader/operationMethod.mustache
+++ b/src/main/resources/twilio-java/reader/operationMethod.mustache
@@ -28,9 +28,9 @@ domainName: example api, video, chat, etc. These can be found in Domains.java in
     {{#vendorExtensions.x-no-auth}}
         request.setAuth(NoAuthStrategy.getInstance());
     {{/vendorExtensions.x-no-auth}}
-    {{#queryParams.0}}
+    {{#vendorExtensions.x-add-query-params}}
         addQueryParams(request);
-    {{/queryParams.0}}
+    {{/vendorExtensions.x-add-query-params}}
     {{#headerParams.0}}
         addHeaderParams(request);
     {{/headerParams.0}}

--- a/src/main/resources/twilio-java/reader/setters.mustache
+++ b/src/main/resources/twilio-java/reader/setters.mustache
@@ -18,3 +18,15 @@ public {{resourceName}}Reader set{{#lambda.titlecase}}{{paramName}}{{/lambda.tit
 }
 {{/vendorExtensions.x-promotion}}
 {{/vendorExtensions.x-setter-methods}}
+{{! The page-size parameter is not held by this reader: the parent Reader owns it (see
+    x-page-size-param). The setter is kept so callers keep compiling, and writes through to the parent,
+    which is also what pageSize()/limit() write to and what addQueryParams serializes. }}
+{{#vendorExtensions.x-page-size-param}}
+
+public {{resourceName}}Reader set{{#lambda.titlecase}}{{paramName}}{{/lambda.titlecase}}(final {{{dataType}}} {{paramName}}){
+    if ({{paramName}} != null) {
+        super.pageSize({{paramName}}.intValue());
+    }
+    return this;
+}
+{{/vendorExtensions.x-page-size-param}}


### PR DESCRIPTION
Stacked on #839 — review that one first; this PR's diff is only the Java change.

JIRA: [DII-2465](https://twilio-engineering.atlassian.net/browse/DII-2465)

## The bug

Every modern-generated reader had two page-size writers in `addQueryParams`: the per-parameter loop, fed by the reader's own field and `setPageSize`, and a hardcoded parent block, fed by `Reader.pageSize(int)` / `Reader.limit(long)`.

```java
if (pageSize != null) {
    Serializer.toString(request, "pageSize", pageSize, ParameterType.QUERY);
}
if (getPageSize() != null) {
    request.addQueryParam("PageSize", Integer.toString(getPageSize()));
}
```

So `setPageSize(5).limit(100)` put `PageSize` on the wire twice on classic APIs, and on API v1 it sent `pageSize=5` **plus** a bogus `PageSize=100` — a query parameter that endpoint never declared.

## The fix

The parent `Reader` becomes the single owner of the value. A new `PageSizeParameter` feature, applied to list operations before the setters are collected, takes the spec's page-size query parameter out of `queryParams` — which stops the per-parameter serialization from being generated for it — and publishes its exact `baseName` as `x-page-size-query-name` for the one `getPageSize()` write the templates emit.

Detection is case-insensitive but the name is emitted verbatim: `pageSize` and `PageSize` are distinct query parameters, so `VersionReader` now sends only `pageSize` and `CallReader` only `PageSize`.

- `common/addQueryParams.mustache`: the parent block uses `x-page-size-query-name` instead of the literal `"PageSize"`.
- `reader/setters.mustache`: `setPageSize` is kept, so callers keep compiling, and writes through to `super.pageSize(...)`.
- `reader/operationMethod.mustache`: `addQueryParams` is now called off `x-add-query-params` rather than `queryParams.0` — readers whose only query parameter was the page size would otherwise stop calling it.

Two cases deliberately left alone: readers whose spec declares no page-size parameter keep sending `PageSize` (several classic list endpoints accept it without declaring it), and a *required* page-size parameter is skipped, since it would be a constructor argument needing a field. No spec declares one today.

## Before / after

`intelligence/v3/VersionReader`:

```diff
-    if (pageSize != null) {
-        Serializer.toString(request, "pageSize", pageSize, ParameterType.QUERY);
-    }
     if (pageToken != null) {
         Serializer.toString(request, "pageToken", pageToken, ParameterType.QUERY);
     }
     if (getPageSize() != null) {
-        request.addQueryParam("PageSize", Integer.toString(getPageSize()));
+        request.addQueryParam("pageSize", Integer.toString(getPageSize()));
     }
```

## Verification

- A/B generated baseline vs patched over `examples/spec` plus the real `intelligence_v3`, `memory_v1`, `numbers_v3` and `api_v2010` specs. Only reader files differ, and only as intended; readers with no page-size parameter in their spec (`ListProfileIdentifiers`) are byte-identical.
- Behaviour checked with a temporary test against the generated readers in twilio-java. Baseline fails it — classic sends `PageSize` twice (`expected:<1> but was:<2>`), v1 sends `pageSize=5` and `PageSize=[100]`; patched sends each exactly once, with twilio-java's full suite green at 930 tests. Happy to land that test as a separate twilio-java PR.
- `examples/java` regenerated (4 readers); generator suite 30/30.

The `java` prism job does not compile at HEAD — the committed `examples/java` output has duplicate classes for intelligence v3 `OperatorResult` against twilio-java main. That reproduces with this branch stashed, so it is pre-existing and unrelated; it is why the behavioural check above was run in twilio-java directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)