### PR TITLE
fix: stop flattened oneOf models emitting sibling-variant zero values in Go

### DIFF
--- a/src/main/java/com/twilio/oai/TwilioGoGenerator.java
+++ b/src/main/java/com/twilio/oai/TwilioGoGenerator.java
@@ -99,7 +99,7 @@ public class TwilioGoGenerator extends AbstractTwilioGoGenerator {
      * fields into pointers -- a breaking change for every caller reading a timestamp, with no
      * serialization benefit, since response models are deserialized rather than sent.
      */
-    private void pointerizeOmittableTimestamps(final Map<String, ModelsMap> allModels) {
+    void pointerizeOmittableTimestamps(final Map<String, ModelsMap> allModels) {
         allModels.values().stream()
             .flatMap(modelsMap -> modelsMap.getModels().stream())
             .map(ModelMap::getModel)
@@ -127,7 +127,7 @@ public class TwilioGoGenerator extends AbstractTwilioGoGenerator {
      * If any variant cannot be resolved the model is left untouched, so an unknown shape can only
      * preserve today's behaviour rather than silently relax a field that really is required.
      */
-    private void relaxOneOfVariantRequired(final Map<String, ModelsMap> allModels) {
+    void relaxOneOfVariantRequired(final Map<String, ModelsMap> allModels) {
         final Map<String, CodegenModel> byClassname = new HashMap<>();
         allModels.values().stream()
             .flatMap(modelsMap -> modelsMap.getModels().stream())

--- a/src/main/java/com/twilio/oai/TwilioGoGenerator.java
+++ b/src/main/java/com/twilio/oai/TwilioGoGenerator.java
@@ -26,6 +26,8 @@ import static com.twilio.oai.common.ApplicationConstants.STRING;
 
 public class TwilioGoGenerator extends AbstractTwilioGoGenerator {
 
+    private static final String TIME_TYPE = "time.Time";
+
     private final Set<String> patchOperationIds = new HashSet<>();
 
     @Override
@@ -70,6 +72,108 @@ public class TwilioGoGenerator extends AbstractTwilioGoGenerator {
             model.allVars.forEach(v -> v.vendorExtensions.put("x-go-omit-empty", omitEmpty(v)));
         }
         return results;
+    }
+
+    @Override
+    public Map<String, ModelsMap> postProcessAllModels(final Map<String, ModelsMap> allModels) {
+        final Map<String, ModelsMap> results = super.postProcessAllModels(allModels);
+        relaxOneOfVariantRequired(results);
+        pointerizeOmittableTimestamps(results);
+        return results;
+    }
+
+    /**
+     * Makes omittable `time.Time` fields pointers so that `omitempty` actually fires.
+     *
+     * <p>`omitempty` has no effect on a struct, and `time.Time` is a struct -- so a field tagged
+     * `json:"uploadExpiration,omitempty"` still serialized the zero value `"0001-01-01T00:00:00Z"`
+     * on every request. The tag promised omission and silently did not deliver it.
+     *
+     * <p>`*time.Time` restores the intended behaviour: nil is omitted, a set value is written.
+     * This mirrors the convention the generator already applies to optional time query parameters.
+     * Required timestamps keep their value type -- they are always transmitted anyway.
+     *
+     * <p>Scoped deliberately to flattened `oneOf` models. That is where a stray zero timestamp
+     * changes behaviour: it makes the body match a sibling variant and the request is rejected.
+     * Elsewhere the same tag is merely inaccurate, and widening the scope would turn ~90 response
+     * fields into pointers -- a breaking change for every caller reading a timestamp, with no
+     * serialization benefit, since response models are deserialized rather than sent.
+     */
+    private void pointerizeOmittableTimestamps(final Map<String, ModelsMap> allModels) {
+        allModels.values().stream()
+            .flatMap(modelsMap -> modelsMap.getModels().stream())
+            .map(ModelMap::getModel)
+            .filter(Objects::nonNull)
+            .filter(model -> model.oneOf != null && !model.oneOf.isEmpty())
+            .forEach(model -> model.allVars.stream()
+                .filter(property -> !property.required)
+                .filter(property -> TIME_TYPE.equals(property.vendorExtensions.get("x-go-base-type")))
+                .filter(property -> !property.isNullable)
+                .forEach(property -> property.isNullable = true));
+    }
+
+    /**
+     * Relaxes `required` on the fields of a flattened `oneOf` model.
+     *
+     * <p>When a `oneOf` is flattened into a single struct, the upstream generator unions every
+     * variant's `required` list onto the merged model. A field required by only one variant is
+     * therefore marked required on the union, loses `omitempty`, and its zero value is serialized
+     * for every other variant -- which breaks discrimination. `KnowledgeSourceTypes` is the clearest
+     * case: creating a Web source also transmitted `content:""`, `fileName:""`, `fileSize:0` and
+     * `mimeType:""`, and Prism rejected the body as matching the Text variant.
+     *
+     * <p>A field is genuinely required on the union only when *every* variant requires it (the
+     * discriminator, typically). Anything else is conditionally required and must be omittable.
+     * If any variant cannot be resolved the model is left untouched, so an unknown shape can only
+     * preserve today's behaviour rather than silently relax a field that really is required.
+     */
+    private void relaxOneOfVariantRequired(final Map<String, ModelsMap> allModels) {
+        final Map<String, CodegenModel> byClassname = new HashMap<>();
+        allModels.values().stream()
+            .flatMap(modelsMap -> modelsMap.getModels().stream())
+            .map(ModelMap::getModel)
+            .filter(Objects::nonNull)
+            .forEach(model -> byClassname.put(model.classname, model));
+
+        for (final CodegenModel model : byClassname.values()) {
+            if (model.oneOf == null || model.oneOf.isEmpty()) {
+                continue;
+            }
+
+            final List<CodegenModel> variants = new ArrayList<>();
+            for (final String variantName : model.oneOf) {
+                final CodegenModel variant = byClassname.get(variantName);
+                if (variant == null) {
+                    variants.clear();
+                    break;
+                }
+                variants.add(variant);
+            }
+            if (variants.isEmpty()) {
+                continue;
+            }
+
+            Set<String> requiredInEveryVariant = null;
+            for (final CodegenModel variant : variants) {
+                final Set<String> variantRequired = variant.allVars.stream()
+                    .filter(property -> property.required)
+                    .map(property -> property.baseName)
+                    .collect(Collectors.toSet());
+                if (requiredInEveryVariant == null) {
+                    requiredInEveryVariant = new HashSet<>(variantRequired);
+                } else {
+                    requiredInEveryVariant.retainAll(variantRequired);
+                }
+            }
+
+            final Set<String> stillRequired = requiredInEveryVariant;
+            model.allVars.stream()
+                .filter(property -> property.required && !stillRequired.contains(property.baseName))
+                .forEach(property -> property.required = false);
+
+            // `required` drives omitEmpty, so recompute it for this model.
+            model.allVars.forEach(v -> v.vendorExtensions.put("x-go-omit-empty", omitEmpty(v)));
+        }
     }
 
     /**

--- a/src/test/java/com/twilio/oai/TwilioGoGeneratorTest.java
+++ b/src/test/java/com/twilio/oai/TwilioGoGeneratorTest.java
@@ -1,0 +1,158 @@
+package com.twilio.oai;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.CodegenProperty;
+import org.openapitools.codegen.model.ModelMap;
+import org.openapitools.codegen.model.ModelsMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Covers the flattened-`oneOf` handling in {@link TwilioGoGenerator}.
+ *
+ * <p>Flattening a `oneOf` unions every variant's `required` list onto the merged struct, so a field
+ * required by a single variant was serialized -- as `""`, `0` or a zero timestamp -- for every other
+ * variant, and the request matched the wrong variant.
+ */
+public class TwilioGoGeneratorTest {
+
+    private TwilioGoGenerator generator;
+
+    @Before
+    public void setUp() {
+        generator = new TwilioGoGenerator();
+    }
+
+    private CodegenProperty property(final String baseName, final boolean required, final String goType) {
+        final CodegenProperty property = new CodegenProperty();
+        property.baseName = baseName;
+        property.name = baseName;
+        property.required = required;
+        property.vendorExtensions.put("x-go-base-type", goType);
+        return property;
+    }
+
+    private CodegenModel model(final String classname, final CodegenProperty... properties) {
+        final CodegenModel model = new CodegenModel();
+        model.classname = classname;
+        model.allVars = Arrays.asList(properties);
+        return model;
+    }
+
+    private Map<String, ModelsMap> asModelsMap(final CodegenModel... models) {
+        final Map<String, ModelsMap> allModels = new HashMap<>();
+        for (final CodegenModel model : models) {
+            final ModelMap modelMap = new ModelMap();
+            modelMap.setModel(model);
+            final ModelsMap modelsMap = new ModelsMap();
+            modelsMap.setModels(java.util.Collections.singletonList(modelMap));
+            allModels.put(model.classname, modelsMap);
+        }
+        return allModels;
+    }
+
+    @Test
+    public void relaxesFieldsRequiredByOnlySomeVariants() {
+        final CodegenModel union = model("KnowledgeSourceTypes",
+            property("type", true, "string"),
+            property("content", true, "string"),
+            property("url", true, "string"));
+        union.oneOf = new java.util.LinkedHashSet<>(Arrays.asList("TextSourceDetails", "WebSourceDetails"));
+
+        final CodegenModel text = model("TextSourceDetails",
+            property("type", true, "string"), property("content", true, "string"));
+        final CodegenModel web = model("WebSourceDetails",
+            property("type", true, "string"), property("url", true, "string"));
+
+        generator.relaxOneOfVariantRequired(asModelsMap(union, text, web));
+
+        final Map<String, CodegenProperty> byName = new HashMap<>();
+        union.allVars.forEach(v -> byName.put(v.baseName, v));
+
+        // `type` is required by every variant -- it is the discriminator and must stay required.
+        assertTrue("discriminator must remain required", byName.get("type").required);
+        assertFalse(Boolean.TRUE.equals(byName.get("type").vendorExtensions.get("x-go-omit-empty")));
+
+        // `content` and `url` are conditionally required, so they must become omittable.
+        assertFalse("content is required by one variant only", byName.get("content").required);
+        assertFalse("url is required by one variant only", byName.get("url").required);
+        assertTrue((Boolean) byName.get("content").vendorExtensions.get("x-go-omit-empty"));
+        assertTrue((Boolean) byName.get("url").vendorExtensions.get("x-go-omit-empty"));
+    }
+
+    @Test
+    public void keepsFieldRequiredWhenEveryVariantRequiresIt() {
+        final CodegenModel union = model("TypingIndicatorRequest",
+            property("channel", true, "string"), property("from", true, "string"));
+        union.oneOf = new java.util.LinkedHashSet<>(Arrays.asList("WhatsApp", "Rcs"));
+
+        final CodegenModel whatsApp = model("WhatsApp",
+            property("channel", true, "string"), property("from", true, "string"));
+        final CodegenModel rcs = model("Rcs",
+            property("channel", true, "string"), property("from", true, "string"));
+
+        generator.relaxOneOfVariantRequired(asModelsMap(union, whatsApp, rcs));
+
+        union.allVars.forEach(v -> assertTrue(v.baseName + " required by all variants", v.required));
+    }
+
+    /** An unresolvable variant must leave the model alone rather than relax a genuinely required field. */
+    @Test
+    public void leavesModelUntouchedWhenAVariantCannotBeResolved() {
+        final CodegenModel union = model("PartiallyKnown",
+            property("type", true, "string"), property("content", true, "string"));
+        union.oneOf = new java.util.LinkedHashSet<>(Arrays.asList("Known", "Missing"));
+
+        final CodegenModel known = model("Known",
+            property("type", true, "string"), property("content", true, "string"));
+
+        generator.relaxOneOfVariantRequired(asModelsMap(union, known));
+
+        union.allVars.forEach(v -> assertTrue("unresolved variant must not relax anything", v.required));
+    }
+
+    @Test
+    public void leavesNonUnionModelsAlone() {
+        final CodegenModel plain = model("DataMappingToTraits",
+            property("type", true, "string"), property("mappings", true, "[]MappingTraitItem"));
+
+        generator.relaxOneOfVariantRequired(asModelsMap(plain));
+
+        plain.allVars.forEach(v -> assertTrue("non-union required fields stay required", v.required));
+    }
+
+    @Test
+    public void pointerizesOmittableTimestampsInUnionModels() {
+        final CodegenProperty uploadExpiration = property("uploadExpiration", false, "time.Time");
+        final CodegenProperty createdAt = property("createdAt", true, "time.Time");
+        final CodegenModel union = model("KnowledgeSourceTypes", uploadExpiration, createdAt);
+        union.oneOf = new java.util.LinkedHashSet<>(Arrays.asList("FileSourceDetails"));
+        final CodegenModel file = model("FileSourceDetails", property("type", true, "string"));
+
+        generator.pointerizeOmittableTimestamps(asModelsMap(union, file));
+
+        // omitempty is inert on a struct, so an omittable time.Time must become *time.Time.
+        assertTrue("omittable timestamp becomes a pointer", uploadExpiration.isNullable);
+        // A required timestamp is always transmitted, so it keeps its value type.
+        assertFalse("required timestamp stays a value", createdAt.isNullable);
+    }
+
+    @Test
+    public void doesNotPointerizeTimestampsOutsideUnionModels() {
+        final CodegenProperty createdAt = property("createdAt", false, "time.Time");
+        final CodegenModel plain = model("Knowledge", createdAt);
+
+        generator.pointerizeOmittableTimestamps(asModelsMap(plain));
+
+        // Widening this to every model would turn ~90 response fields into pointers for no gain.
+        assertFalse("non-union timestamps keep their value type", createdAt.isNullable);
+    }
+}


### PR DESCRIPTION
# Fixes DII-2473 (Go half)

> **Stacked on [`fix/ruby-v1-no-meta-pagination`](https://github.com/twilio/twilio-oai-generator/tree/fix/ruby-v1-no-meta-pagination)** — base that branch, not `main`. Review only the two commits here; the Ruby commit belongs to the parent PR.

Flattening a `oneOf` unions **every variant's `required` list** onto the merged struct. A field required by a single variant therefore loses `omitempty` on the union and its zero value is serialized for *all* the other variants, so the body matches the wrong variant and the API rejects it.

Creating a **Web** knowledge source sent:

```json
{"type":"Web","content":"","url":"https://…","crawlDepth":3,
 "fileName":"","fileSize":0,"mimeType":"","uploadExpiration":"0001-01-01T00:00:00Z"}
```

Prism: `Request body property source must NOT have additional properties; found 'url'` — the empty fields made it match the **Text** variant, which forbids `url`.

Now:

```json
{"type":"Web","url":"https://…","crawlDepth":3}
```

## Changes

**`relaxOneOfVariantRequired`** — a field is required on the union only when **every** variant requires it (typically just the discriminator). Anything else is conditionally required and must be omittable. If any variant can't be resolved the model is left untouched, so an unfamiliar shape can only preserve today's behaviour rather than silently relax a genuinely required field.

**`pointerizeOmittableTimestamps`** — `omitempty` is inert on a struct, and `time.Time` is one, so `uploadExpiration` still emitted `0001-01-01T00:00:00Z` despite carrying the tag. `*time.Time` makes the tag honest. Deliberately **scoped to `oneOf` models**: that's where a stray timestamp flips the variant. Applied globally it converted 99 fields, but only 11 were in request models — the other 88 were breaking changes to response fields that are deserialized, never sent. Scoping cut it to **2** while still fixing the failure.

## Effect on `twilio-go`

Isolated against a baseline regeneration from the **unmodified** generator (so generator drift is excluded): **12 files, 33 insertions, 33 deletions** — 6 flattened-union models plus their docs.

| Model | Stays required | Relaxed |
|---|---|---|
| `knowledge/v2 KnowledgeSourceTypes` | `type` | content, url, fileName, fileSize, mimeType |
| `memory/v1 DataMappingFromTypes` | `type` | columns, datasetId |
| `conversations/v2 start_conversation_action_request` | `payload`, `type` | channel |
| `messaging/v3 TypingIndicatorRequest` | `channel` | from, messageId, to |
| `routes/v3 regional_phone_number_item` | — | isoCountryCode, nationalNumber, numberE164 |
| `voice/v3 CreateV3TranscriptionsRequest` | — | sourceId |

Every relaxation was checked against the spec's per-variant `required` lists. Plus 2 `time.Time` → `*time.Time`.

Verified by marshalling each variant:

```
Web:   {"type":"Web","url":"https://x.com","crawlDepth":3}
Text:  {"type":"Text","content":"hello"}
File:  {"type":"File","fileName":"a.pdf","fileSize":12,"mimeType":"application/pdf","uploadExpiration":"2026-09-11T10:00:00Z"}
```

The File case confirms a *set* timestamp still serializes. `go build`, `go vet`, `go test`, `gofmt` all clean.

Also covers the `DataMappingFromTypes` failure where `"columns":null` pushed the body onto the wrong variant.

## Tests

`TwilioGoGeneratorTest`, 6 cases: conditionally-required fields relax · fields required by every variant stay required · an unresolvable variant leaves the model untouched · non-union models untouched · omittable `time.Time` becomes a pointer inside union models · timestamps outside union models keep their value type.

Confirmed non-vacuous: stubbing both helpers to no-ops fails 2 of the 6 (the rest are guard tests asserting *no* change). Full suite: 36 tests, 0 failures.

## Two pre-existing issues found while verifying (not addressed here)

1. Generating from `spec/yaml` emits unused `gopkg.in/validator.v2` imports that break `go build`. `clean_unused_imports.py` runs for java/php but not go. Reproduced with the **unmodified** generator, so it predates this PR; `goimports` clears it.
2. `build_twilio_library.py` excludes `twilio_monitor_v2.json`, but a yaml-sourced run feeds it `twilio_monitor_v2.yaml`, so `monitor/v2` leaks into the output as new files. The same `.json`-keyed pattern affects `generateForLanguages`.

Both deserve their own issues.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] Run `make test-docker` — not run locally (needs Docker/Prism); relying on CI
- [x] Verify affected language according to the code change:
    - [x] Generate [twilio-go](https://github.com/twilio/twilio-go) from the [OpenAPI specification](https://github.com/twilio/twilio-oai) and inspect the diff
    - [x] Run tests in `twilio-go` — `go build`, `go vet`, `go test ./...` all pass, `gofmt` clean
    - [ ] Create a pull request in `twilio-go` — branch ready, not yet opened
- [x] I have made a material change to the repo
- [x] I have read the Contribution Guidelines and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the base branch
- [x] I have added tests that prove my fix is effective
- [ ] Documentation — no `.md` change needed; behaviour is documented in Javadoc on both methods
- [x] I have added inline documentation to the code I modified
